### PR TITLE
Reorder properties in tidas_processes.json for clarity

### DIFF
--- a/src/tidas_tools/tidas/schemas/tidas_processes.json
+++ b/src/tidas_tools/tidas/schemas/tidas_processes.json
@@ -684,15 +684,15 @@
                         "Topic not relevant",
                         "No statement"
                       ]
-                    },
-                    "completenessOtherProblemField": {
-                      "$ref": "tidas_data_types.json#/$defs/FTMultiLang",
-                      "description": "Completeness of coverage of elementary flows that contribute to other problem fields that are named here as free text, preferably using the same terminology as for the specified environmental problems."
-                    },
-                    "common:other": {
-                      "type": "string"
                     }
                   }
+                },
+                "completenessOtherProblemField": {
+                  "$ref": "tidas_data_types.json#/$defs/FTMultiLang",
+                  "description": "Completeness of coverage of elementary flows that contribute to other problem fields that are named here as free text, preferably using the same terminology as for the specified environmental problems."
+                },
+                "common:other": {
+                  "type": "string"
                 }
               }
             },


### PR DESCRIPTION
In the file  src/tidas_tools/tidas/schemas/tidas_processes.json,  the “completenessOtherProblemField”  should be under “completeness”, not under “completenessElementaryFlows”.
@linancn 