### PR TITLE
Remove redundant '@dominant' field from lifecycle models schema

### DIFF
--- a/src/tidas_tools/tidas/schemas/tidas_lifecyclemodels.json
+++ b/src/tidas_tools/tidas/schemas/tidas_lifecyclemodels.json
@@ -516,7 +516,6 @@
                                           }
                                         },
                                         "required": [
-                                          "@dominant",
                                           "@flowUUID",
                                           "downstreamProcess"
                                         ]
@@ -608,7 +607,6 @@
                                             }
                                           },
                                           "required": [
-                                            "@dominant",
                                             "@flowUUID",
                                             "downstreamProcess"
                                           ]
@@ -816,7 +814,6 @@
                                         }
                                       },
                                       "required": [
-                                        "@dominant",
                                         "@flowUUID",
                                         "downstreamProcess"
                                       ]
@@ -908,7 +905,6 @@
                                           }
                                         },
                                         "required": [
-                                          "@dominant",
                                           "@flowUUID",
                                           "downstreamProcess"
                                         ]


### PR DESCRIPTION
@linancn 
Eliminate the unnecessary '@dominant' field from the required properties in the lifecycle models schema to streamline the validation process.