### PR TITLE
Add localized text language constraints

### DIFF
--- a/src/tidas_tools/tidas/schemas/tidas_data_types.json
+++ b/src/tidas_tools/tidas/schemas/tidas_data_types.json
@@ -10,44 +10,106 @@
       "type": "string",
       "description": "Free text with an unlimited length."
     },
+    "LocalizedTextItem": {
+      "description": "Language-tagged text with optional script checks for selected languages.",
+      "type": "object",
+      "properties": {
+        "@xml:lang": {
+          "type": "string"
+        },
+        "#text": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "@xml:lang",
+        "#text"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "@xml:lang": {
+                "pattern": "^[zZ][hH](?:-|$)"
+              }
+            },
+            "required": [
+              "@xml:lang"
+            ]
+          },
+          "then": {
+            "properties": {
+              "#text": {
+                "pattern": "[\\u3400-\\u4DBF\\u4E00-\\u9FFF\\uF900-\\uFAFF]"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "@xml:lang": {
+                "pattern": "^[eE][nN](?:-|$)"
+              }
+            },
+            "required": [
+              "@xml:lang"
+            ]
+          },
+          "then": {
+            "properties": {
+              "#text": {
+                "not": {
+                  "pattern": "[\\u3400-\\u4DBF\\u4E00-\\u9FFF\\uF900-\\uFAFF]"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "LocalizedText500Item": {
+      "description": "Language-tagged text with a maximum length of 500 characters.",
+      "allOf": [
+        {
+          "$ref": "#/$defs/LocalizedTextItem"
+        },
+        {
+          "properties": {
+            "#text": {
+              "maxLength": 500
+            }
+          }
+        }
+      ]
+    },
+    "LocalizedText1000Item": {
+      "description": "Language-tagged text with a maximum length of 1000 characters.",
+      "allOf": [
+        {
+          "$ref": "#/$defs/LocalizedTextItem"
+        },
+        {
+          "properties": {
+            "#text": {
+              "maxLength": 1000
+            }
+          }
+        }
+      ]
+    },
     "StringMultiLang": {
       "description": "Multi-language string with a maximum length of 500 characters",
       "anyOf": [
         {
           "type": "array",
           "items": {
-            "type": "object",
-            "properties": {
-              "@xml:lang": {
-                "type": "string"
-              },
-              "#text": {
-                "type": "string",
-                "maxLength": 500
-              }
-            },
-            "required": [
-              "@xml:lang",
-              "#text"
-            ]
+            "$ref": "#/$defs/LocalizedText500Item"
           },
           "uniqueItems": true
         },
         {
-          "type": "object",
-          "properties": {
-            "@xml:lang": {
-              "type": "string"
-            },
-            "#text": {
-              "type": "string",
-              "maxLength": 500
-            }
-          },
-          "required": [
-            "@xml:lang",
-            "#text"
-          ]
+          "$ref": "#/$defs/LocalizedText500Item"
         }
       ]
     },
@@ -105,38 +167,12 @@
         {
           "type": "array",
           "items": {
-            "type": "object",
-            "properties": {
-              "@xml:lang": {
-                "type": "string"
-              },
-              "#text": {
-                "type": "string",
-                "maxLength": 1000
-              }
-            },
-            "required": [
-              "@xml:lang",
-              "#text"
-            ]
+            "$ref": "#/$defs/LocalizedText1000Item"
           },
           "uniqueItems": true
         },
         {
-          "type": "object",
-          "properties": {
-            "@xml:lang": {
-              "type": "string"
-            },
-            "#text": {
-              "type": "string",
-              "maxLength": 1000
-            }
-          },
-          "required": [
-            "@xml:lang",
-            "#text"
-          ]
+          "$ref": "#/$defs/LocalizedText1000Item"
         }
       ]
     },
@@ -146,36 +182,12 @@
         {
           "type": "array",
           "items": {
-            "type": "object",
-            "properties": {
-              "@xml:lang": {
-                "type": "string"
-              },
-              "#text": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "@xml:lang",
-              "#text"
-            ]
+            "$ref": "#/$defs/LocalizedTextItem"
           },
           "uniqueItems": true
         },
         {
-          "type": "object",
-          "properties": {
-            "@xml:lang": {
-              "type": "string"
-            },
-            "#text": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "@xml:lang",
-            "#text"
-          ]
+          "$ref": "#/$defs/LocalizedTextItem"
         }
       ]
     },

--- a/src/tidas_tools/validate.py
+++ b/src/tidas_tools/validate.py
@@ -3,6 +3,7 @@ import importlib.resources as pkg_resources
 import json
 import logging
 import os
+import re
 import sys
 
 from jsonschema import Draft7Validator
@@ -11,6 +12,8 @@ from referencing.jsonschema import DRAFT7
 from .tidas_log import setup_logging
 
 import tidas_tools.tidas.schemas as schemas
+
+CHINESE_CHARACTER_RE = re.compile(r"[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]")
 
 
 def validate_elementary_flows_classification_hierarchy(class_items):
@@ -175,6 +178,45 @@ def validate_sources_classification_hierarchy(class_items):
         return {"valid": True}
 
 
+def validate_localized_text_language_constraints(node, path=""):
+    errors = []
+
+    if isinstance(node, dict):
+        language = node.get("@xml:lang")
+        text = node.get("#text")
+        location = path or "<root>"
+
+        if isinstance(language, str) and isinstance(text, str):
+            normalized_language = language.lower()
+            has_chinese = bool(CHINESE_CHARACTER_RE.search(text))
+
+            if normalized_language == "zh" or normalized_language.startswith("zh-"):
+                if not has_chinese:
+                    errors.append(
+                        f"Localized text error at {location}: @xml:lang '{language}' must include at least one Chinese character"
+                    )
+            elif normalized_language == "en" or normalized_language.startswith("en-"):
+                if has_chinese:
+                    errors.append(
+                        f"Localized text error at {location}: @xml:lang '{language}' must not contain Chinese characters"
+                    )
+
+        for key, value in node.items():
+            child_path = f"{path}/{key}" if path else key
+            errors.extend(
+                validate_localized_text_language_constraints(value, child_path)
+            )
+
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            child_path = f"{path}/{index}" if path else str(index)
+            errors.extend(
+                validate_localized_text_language_constraints(value, child_path)
+            )
+
+    return errors
+
+
 def retrieve_schema(uri):
     """Custom retrieval function for schema references"""
     # Handle both local and remote references
@@ -232,6 +274,10 @@ def category_validate(json_file_path: str, category: str):
                             f"Unexpected validation error: {type(e).__name__}: {e}"
                         )
                         errors.append(f"Validation error: {e}")
+
+                    errors.extend(
+                        validate_localized_text_language_constraints(json_item)
+                    )
 
                     if category == "flows":
                         if (

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,4 +1,27 @@
-from tidas_tools.validate import category_validate
+import importlib.resources as pkg_resources
+import json
+
+from jsonschema import Draft7Validator
+
+import tidas_tools.tidas.schemas as schemas
+from tidas_tools.validate import (
+    category_validate,
+    validate_localized_text_language_constraints,
+)
+
+
+def build_data_type_validator(definition_name):
+    schema_file_path = pkg_resources.files(schemas) / "tidas_data_types.json"
+    with schema_file_path.open() as schema_file:
+        root_schema = json.load(schema_file)
+
+    return Draft7Validator(
+        {
+            "$schema": root_schema["$schema"],
+            "$defs": root_schema["$defs"],
+            **root_schema["$defs"][definition_name],
+        }
+    )
 
 
 def test_category_validate(tmp_path):
@@ -6,3 +29,61 @@ def test_category_validate(tmp_path):
     sources_dir.mkdir()
 
     category_validate(str(sources_dir), "sources")
+
+
+def test_string_multilang_schema_requires_chinese_for_zh():
+    validator = build_data_type_validator("StringMultiLang")
+
+    errors = list(
+        validator.iter_errors({"@xml:lang": "zh-CN", "#text": "english only"})
+    )
+
+    assert errors
+
+
+def test_string_multilang_schema_rejects_chinese_for_en():
+    validator = build_data_type_validator("StringMultiLang")
+
+    errors = list(validator.iter_errors({"@xml:lang": "en", "#text": "English 中文"}))
+
+    assert errors
+
+
+def test_string_multilang_schema_accepts_valid_localized_text():
+    validator = build_data_type_validator("StringMultiLang")
+
+    errors = list(
+        validator.iter_errors(
+            [
+                {"@xml:lang": "zh", "#text": "中文名称"},
+                {"@xml:lang": "en-US", "#text": "English title"},
+                {"@xml:lang": "fr", "#text": "Bonjour 中文"},
+            ]
+        )
+    )
+
+    assert errors == []
+
+
+def test_validate_localized_text_language_constraints_reports_nested_paths():
+    payload = {
+        "processDataSet": {
+            "processInformation": {
+                "dataSetInformation": {
+                    "name": {
+                        "baseName": [
+                            {"@xml:lang": "zh-CN", "#text": "english only"},
+                            {"@xml:lang": "en", "#text": "English 中文"},
+                        ]
+                    }
+                }
+            }
+        }
+    }
+
+    errors = validate_localized_text_language_constraints(payload)
+
+    assert errors == [
+        "Localized text error at processDataSet/processInformation/dataSetInformation/name/baseName/0: @xml:lang 'zh-CN' must include at least one Chinese character",
+        "Localized text error at processDataSet/processInformation/dataSetInformation/name/baseName/1: @xml:lang 'en' must not contain Chinese characters",
+    ]


### PR DESCRIPTION
## Summary
- add language-aware localized text schema definitions for multilingual text fields
- enforce Chinese character presence for `zh*` entries and absence for `en*` entries during validation
- cover the new schema and validator behavior with tests

## Validation
- uv run pytest

## Notes
- prepared from the Neo9281 fork on top of the current upstream `main`