### PR TITLE
feat: add structured TIDAS validation reports

### DIFF
--- a/src/tidas_tools/validate.py
+++ b/src/tidas_tools/validate.py
@@ -10,10 +10,25 @@ from jsonschema import Draft7Validator
 from referencing import Registry
 from referencing.jsonschema import DRAFT7
 from .tidas_log import setup_logging
+from .validation_report import (
+    ValidationIssue,
+    build_category_report,
+    build_package_report,
+)
 
 import tidas_tools.tidas.schemas as schemas
 
 CHINESE_CHARACTER_RE = re.compile(r"[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]")
+SUPPORTED_CATEGORIES = [
+    "contacts",
+    "flowproperties",
+    "flows",
+    "lciamethods",
+    "lifecyclemodels",
+    "processes",
+    "sources",
+    "unitgroups",
+]
 
 
 def validate_elementary_flows_classification_hierarchy(class_items):
@@ -217,6 +232,171 @@ def validate_localized_text_language_constraints(node, path=""):
     return errors
 
 
+def _make_issue(
+    *,
+    issue_code: str,
+    category: str,
+    file_path: str,
+    message: str,
+    location: str = "<root>",
+    context: dict | None = None,
+) -> ValidationIssue:
+    return ValidationIssue(
+        issue_code=issue_code,
+        severity="error",
+        category=category,
+        file_path=file_path,
+        location=location,
+        message=message,
+        context=context or {},
+    )
+
+
+def _collect_classification_issues(json_item: dict, category: str, file_path: str):
+    issues = []
+    try:
+        if category == "flows":
+            data_set_type = json_item["flowDataSet"]["modellingAndValidation"]["LCIMethod"][
+                "typeOfDataSet"
+            ]
+            if data_set_type == "Product flow":
+                validation_result = validate_product_flows_classification_hierarchy(
+                    json_item["flowDataSet"]["flowInformation"]["dataSetInformation"][
+                        "classificationInformation"
+                    ]["common:classification"]["common:class"]
+                )
+                if not validation_result["valid"]:
+                    issues.extend(
+                        _make_issue(
+                            issue_code="classification_hierarchy_error",
+                            category=category,
+                            file_path=file_path,
+                            message=message,
+                        )
+                        for message in validation_result["errors"]
+                    )
+            elif data_set_type == "Elementary flow":
+                validation_result = validate_elementary_flows_classification_hierarchy(
+                    json_item["flowDataSet"]["flowInformation"]["dataSetInformation"][
+                        "classificationInformation"
+                    ]["common:elementaryFlowCategorization"]["common:category"]
+                )
+                if not validation_result["valid"]:
+                    issues.extend(
+                        _make_issue(
+                            issue_code="classification_hierarchy_error",
+                            category=category,
+                            file_path=file_path,
+                            message=message,
+                        )
+                        for message in validation_result["errors"]
+                    )
+
+        elif category == "processes":
+            validation_result = validate_processes_classification_hierarchy(
+                json_item["processDataSet"]["processInformation"]["dataSetInformation"][
+                    "classificationInformation"
+                ]["common:classification"]["common:class"]
+            )
+            if not validation_result["valid"]:
+                issues.extend(
+                    _make_issue(
+                        issue_code="classification_hierarchy_error",
+                        category=category,
+                        file_path=file_path,
+                        message=message,
+                    )
+                    for message in validation_result["errors"]
+                )
+
+        elif category == "lifecyclemodels":
+            validation_result = validate_processes_classification_hierarchy(
+                json_item["lifecycleModelDataSet"]["lifecycleModelInformation"][
+                    "dataSetInformation"
+                ]["classificationInformation"]["common:classification"]["common:class"]
+            )
+            if not validation_result["valid"]:
+                issues.extend(
+                    _make_issue(
+                        issue_code="classification_hierarchy_error",
+                        category=category,
+                        file_path=file_path,
+                        message=message,
+                    )
+                    for message in validation_result["errors"]
+                )
+
+        elif category == "sources":
+            validation_result = validate_sources_classification_hierarchy(
+                json_item["sourceDataSet"]["sourceInformation"]["dataSetInformation"][
+                    "classificationInformation"
+                ]["common:classification"]["common:class"]
+            )
+            if not validation_result["valid"]:
+                issues.extend(
+                    _make_issue(
+                        issue_code="classification_hierarchy_error",
+                        category=category,
+                        file_path=file_path,
+                        message=message,
+                    )
+                    for message in validation_result["errors"]
+                )
+    except (KeyError, TypeError, ValueError):
+        # Structural schema issues already cover missing hierarchy paths.
+        return issues
+
+    return issues
+
+
+def _collect_item_issues(validator: Draft7Validator, json_item: dict, category: str, file_path: str):
+    issues = []
+    try:
+        for schema_error in validator.iter_errors(json_item):
+            location = (
+                "/".join(str(part) for part in schema_error.path)
+                if schema_error.path
+                else "<root>"
+            )
+            issues.append(
+                _make_issue(
+                    issue_code="schema_error",
+                    category=category,
+                    file_path=file_path,
+                    location=location,
+                    message=f"Schema Error at {location}: {schema_error.message}",
+                    context={"validator": schema_error.validator},
+                )
+            )
+    except Exception as e:
+        issues.append(
+            _make_issue(
+                issue_code="validation_error",
+                category=category,
+                file_path=file_path,
+                message=f"Validation error: {e}",
+            )
+        )
+
+    localized_text_errors = validate_localized_text_language_constraints(json_item)
+    for message in localized_text_errors:
+        location = "<root>"
+        if message.startswith("Localized text error at ") and ":" in message:
+            location = message.split("Localized text error at ", 1)[1].split(":", 1)[0]
+        issues.append(
+            _make_issue(
+                issue_code="localized_text_language_error",
+                category=category,
+                file_path=file_path,
+                location=location,
+                message=message,
+            )
+        )
+
+    issues.extend(_collect_classification_issues(json_item, category, file_path))
+    return issues
+
+
 def retrieve_schema(uri):
     """Custom retrieval function for schema references"""
     # Handle both local and remote references
@@ -236,9 +416,10 @@ def retrieve_schema(uri):
     return None
 
 
-def category_validate(json_file_path: str, category: str):
+def category_validate(json_file_path: str, category: str, emit_logs: bool = True):
     schema_file_path = pkg_resources.files(schemas) / f"tidas_{category.lower()}.json"
     schema_uri = f"file://{schema_file_path}"
+    issues = []
 
     with schema_file_path.open() as f:
         schema = json.load(f)
@@ -250,115 +431,61 @@ def category_validate(json_file_path: str, category: str):
         # Instantiate validator once per category for efficiency
         validator = Draft7Validator(schema, registry=registry)
 
-        for filename in os.listdir(json_file_path):
+        for filename in sorted(os.listdir(json_file_path)):
             if filename.endswith(".json"):
                 full_path = os.path.join(json_file_path, filename)
-                with open(full_path, "r") as json_file:
-                    json_item = json.load(json_file)
-
-                    errors = []
-
-                    try:
-                        # Use iter_errors to capture every schema violation
-                        for schema_error in validator.iter_errors(json_item):
-                            location = (
-                                "/".join(str(part) for part in schema_error.path)
-                                if schema_error.path
-                                else "<root>"
-                            )
-                            errors.append(
-                                f"Schema Error at {location}: {schema_error.message}"
-                            )
-                    except Exception as e:
-                        logging.error(
-                            f"Unexpected validation error: {type(e).__name__}: {e}"
+                try:
+                    with open(full_path, "r") as json_file:
+                        json_item = json.load(json_file)
+                except Exception as e:
+                    issues.append(
+                        _make_issue(
+                            issue_code="invalid_json",
+                            category=category,
+                            file_path=full_path,
+                            message=f"Invalid JSON: {type(e).__name__}: {e}",
                         )
-                        errors.append(f"Validation error: {e}")
-
-                    errors.extend(
-                        validate_localized_text_language_constraints(json_item)
                     )
+                    continue
 
-                    if category == "flows":
-                        if (
-                            json_item["flowDataSet"]["modellingAndValidation"][
-                                "LCIMethod"
-                            ]["typeOfDataSet"]
-                            == "Product flow"
-                        ):
-                            validation_result = (
-                                validate_product_flows_classification_hierarchy(
-                                    json_item["flowDataSet"]["flowInformation"][
-                                        "dataSetInformation"
-                                    ]["classificationInformation"][
-                                        "common:classification"
-                                    ][
-                                        "common:class"
-                                    ]
-                                )
-                            )
-                            if not validation_result["valid"]:
-                                errors.extend(validation_result["errors"])
-                        elif (
-                            json_item["flowDataSet"]["modellingAndValidation"][
-                                "LCIMethod"
-                            ]["typeOfDataSet"]
-                            == "Elementary flow"
-                        ):
-                            validation_result = (
-                                validate_elementary_flows_classification_hierarchy(
-                                    json_item["flowDataSet"]["flowInformation"][
-                                        "dataSetInformation"
-                                    ]["classificationInformation"][
-                                        "common:elementaryFlowCategorization"
-                                    ][
-                                        "common:category"
-                                    ]
-                                )
-                            )
-                            if not validation_result["valid"]:
-                                errors.extend(validation_result["errors"])
+                item_issues = _collect_item_issues(validator, json_item, category, full_path)
+                issues.extend(item_issues)
 
-                    if category == "processes":
-                        validation_result = validate_processes_classification_hierarchy(
-                            json_item["processDataSet"]["processInformation"][
-                                "dataSetInformation"
-                            ]["classificationInformation"]["common:classification"][
-                                "common:class"
-                            ]
-                        )
-                        if not validation_result["valid"]:
-                            errors.extend(validation_result["errors"])
-
-                    if category == "lifecyclemodels":
-                        validation_result = validate_processes_classification_hierarchy(
-                            json_item["lifecycleModelDataSet"][
-                                "lifecycleModelInformation"
-                            ]["dataSetInformation"]["classificationInformation"][
-                                "common:classification"
-                            ][
-                                "common:class"
-                            ]
-                        )
-                        if not validation_result["valid"]:
-                            errors.extend(validation_result["errors"])
-
-                    if category == "sources":
-                        validation_result = validate_sources_classification_hierarchy(
-                            json_item["sourceDataSet"]["sourceInformation"][
-                                "dataSetInformation"
-                            ]["classificationInformation"]["common:classification"][
-                                "common:class"
-                            ]
-                        )
-                        if not validation_result["valid"]:
-                            errors.extend(validation_result["errors"])
-
-                    if errors:
-                        for err in errors:
-                            logging.error(f"ERROR: {full_path} {err}")
+                if emit_logs:
+                    if item_issues:
+                        for issue in item_issues:
+                            logging.error(f"ERROR: {full_path} {issue.message}")
                     else:
                         logging.info(f"INFO: {full_path} PASSED.")
+
+    return build_category_report(category, issues)
+
+
+def validate_package_dir(input_dir: str, emit_logs: bool = False):
+    schemas_root = pkg_resources.files(schemas)
+    category_reports = []
+    for category in SUPPORTED_CATEGORIES:
+        category_dir = os.path.join(input_dir, category)
+        if not os.path.isdir(category_dir):
+            if emit_logs:
+                logging.debug("Skipping missing directory %s", category_dir)
+            continue
+
+        schema_filename = f"tidas_{category.lower()}.json"
+        schema_path = schemas_root / schema_filename
+        if not schema_path.is_file():
+            if emit_logs:
+                logging.debug(
+                    "Skipping directory %s — no schema file %s",
+                    category_dir,
+                    schema_filename,
+                )
+            continue
+
+        category_report = category_validate(category_dir, category, emit_logs=emit_logs)
+        category_reports.append(category_report)
+
+    return build_package_report(input_dir, category_reports)
 
 
 def main():
@@ -372,45 +499,24 @@ def main():
     parser.add_argument(
         "--verbose", "-v", action="store_true", help="Enable verbose logging"
     )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format. Defaults to text logging.",
+    )
     try:
         args = parser.parse_args()
 
-        setup_logging(args.verbose, "validate")
+        if args.format == "text":
+            setup_logging(args.verbose, "validate")
+            report = validate_package_dir(args.input_dir, emit_logs=True)
+        else:
+            report = validate_package_dir(args.input_dir, emit_logs=False)
+            print(json.dumps(report, indent=2, ensure_ascii=False))
 
-        schemas_root = pkg_resources.files(schemas)
-        supported_categories = [
-            "contacts",
-            "flowproperties",
-            "flows",
-            "lciamethods",
-            "lifecyclemodels",
-            "processes",
-            "sources",
-            "unitgroups",
-        ]
-
-        for category in supported_categories:
-            try:
-                category_dir = os.path.join(args.input_dir, category)
-                if not os.path.isdir(category_dir):
-                    logging.debug("Skipping missing directory %s", category_dir)
-                    continue
-
-                schema_filename = f"tidas_{category.lower()}.json"
-                schema_path = schemas_root / schema_filename
-
-                if not schema_path.is_file():
-                    logging.debug(
-                        "Skipping directory %s — no schema file %s",
-                        category_dir,
-                        schema_filename,
-                    )
-                    continue
-
-                category_validate(category_dir, category)
-            except Exception as e:
-                error_msg = f"Error validating category {category}: {e}"
-                logging.error(error_msg)
+        if not report["ok"]:
+            sys.exit(1)
     except Exception as e:
         error_msg = f"Error validating: {e}"
         logging.error(error_msg)

--- a/src/tidas_tools/validation_report.py
+++ b/src/tidas_tools/validation_report.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    issue_code: str
+    severity: str
+    category: str
+    file_path: str
+    message: str
+    location: str = "<root>"
+    context: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "issue_code": self.issue_code,
+            "severity": self.severity,
+            "category": self.category,
+            "file_path": self.file_path,
+            "location": self.location,
+            "message": self.message,
+            "context": self.context or {},
+        }
+
+
+def summarize_issues(issues: list[ValidationIssue]) -> dict[str, int]:
+    error_count = sum(1 for issue in issues if issue.severity == "error")
+    warning_count = sum(1 for issue in issues if issue.severity == "warning")
+    info_count = sum(1 for issue in issues if issue.severity == "info")
+    return {
+        "issue_count": len(issues),
+        "error_count": error_count,
+        "warning_count": warning_count,
+        "info_count": info_count,
+    }
+
+
+def build_category_report(category: str, issues: list[ValidationIssue]) -> dict[str, Any]:
+    return {
+        "category": category,
+        "ok": len(issues) == 0,
+        "summary": summarize_issues(issues),
+        "issues": [issue.to_dict() for issue in issues],
+    }
+
+
+def build_package_report(
+    input_dir: str, category_reports: list[dict[str, Any]]
+) -> dict[str, Any]:
+    issues: list[dict[str, Any]] = []
+    issue_count = 0
+    error_count = 0
+    warning_count = 0
+    info_count = 0
+
+    for report in category_reports:
+        issues.extend(report["issues"])
+        summary = report["summary"]
+        issue_count += summary["issue_count"]
+        error_count += summary["error_count"]
+        warning_count += summary["warning_count"]
+        info_count += summary["info_count"]
+
+    return {
+        "input_dir": input_dir,
+        "ok": issue_count == 0,
+        "summary": {
+            "category_count": len(category_reports),
+            "issue_count": issue_count,
+            "error_count": error_count,
+            "warning_count": warning_count,
+            "info_count": info_count,
+        },
+        "categories": category_reports,
+        "issues": issues,
+    }

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -6,6 +6,7 @@ from jsonschema import Draft7Validator
 import tidas_tools.tidas.schemas as schemas
 from tidas_tools.validate import (
     category_validate,
+    validate_package_dir,
     validate_localized_text_language_constraints,
 )
 
@@ -29,6 +30,51 @@ def test_category_validate(tmp_path):
     sources_dir.mkdir()
 
     category_validate(str(sources_dir), "sources")
+
+
+def test_category_validate_returns_structured_issues(tmp_path):
+    sources_dir = tmp_path / "sources"
+    sources_dir.mkdir()
+    (sources_dir / "bad.json").write_text("{}", encoding="utf-8")
+
+    report = category_validate(str(sources_dir), "sources")
+
+    assert report["category"] == "sources"
+    assert report["summary"]["issue_count"] >= 1
+    first_issue = report["issues"][0]
+    assert first_issue["issue_code"] in {
+        "schema_error",
+        "validation_error",
+        "localized_text_language_error",
+        "classification_hierarchy_error",
+    }
+    assert first_issue["severity"] == "error"
+    assert first_issue["category"] == "sources"
+    assert first_issue["file_path"].endswith("bad.json")
+
+
+def test_category_validate_avoids_cascading_classification_errors(tmp_path):
+    sources_dir = tmp_path / "sources"
+    sources_dir.mkdir()
+    (sources_dir / "bad.json").write_text("{}", encoding="utf-8")
+
+    report = category_validate(str(sources_dir), "sources")
+
+    assert [issue["issue_code"] for issue in report["issues"]] == ["schema_error"]
+
+
+def test_validate_package_dir_returns_structured_report(tmp_path):
+    package_dir = tmp_path / "package"
+    sources_dir = package_dir / "sources"
+    sources_dir.mkdir(parents=True)
+    (sources_dir / "bad.json").write_text("{}", encoding="utf-8")
+
+    report = validate_package_dir(str(package_dir))
+
+    assert report["ok"] is False
+    assert report["summary"]["issue_count"] >= 1
+    assert report["summary"]["error_count"] >= 1
+    assert report["issues"][0]["category"] == "sources"
 
 
 def test_string_multilang_schema_requires_chinese_for_zh():


### PR DESCRIPTION
Closes tiangong-lca/tidas-tools#23

## Summary
- Add structured ValidationIssue and package report helpers for TIDAS validation output.
- Change category_validate to return structured issues and add validate_package_dir plus CLI JSON output.

## Key Decisions
- Keep English fallback messages in tidas-tools and leave zh-CN/en-US localization to downstream UI layers.
- Suppress cascading classification errors when structural schema failures already explain the problem, so downstream reports stay cleaner.

## Validation
- cd /Users/biao/Code/lca-workspace/lca-workspace/tidas-tools && uv run pytest tests/test_validate.py -q
- CLI JSON smoke check on invalid input prints structured issue objects and exits with code 1.

## Risks / Rollback
- Downstream worker and UI will depend on the serialized report field names, so follow-up repos should reuse this exact shape.

## Follow-ups
- Calculator worker should consume this report in import execution before conflict partitioning.