### PR TITLE
fix: normalize exported package versions

### DIFF
--- a/src/tidas_tools/export.py
+++ b/src/tidas_tools/export.py
@@ -11,6 +11,7 @@ import xmltodict
 from dotenv import load_dotenv
 from tqdm import tqdm
 
+from .package_versions import normalize_package_versions
 from .tidas_log import setup_logging
 
 
@@ -293,6 +294,9 @@ def main():
         # Close database connection
         conn.close()
         logging.info("Database connection closed")
+
+        if args.to_tidas:
+            normalize_package_versions(args.output_dir)
 
         # Download external documents if needed
         if not args.skip_external_docs:

--- a/src/tidas_tools/package_versions.py
+++ b/src/tidas_tools/package_versions.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+SUPPORTED_VERSIONED_CATEGORIES = (
+    "contacts",
+    "flowproperties",
+    "flows",
+    "lciamethods",
+    "lifecyclemodels",
+    "processes",
+    "sources",
+    "unitgroups",
+)
+
+PRECEDING_REFERENCE_KEYS = frozenset(
+    {
+        "common:referenceToPrecedingDataSetVersion",
+        "referenceToPrecedingDataSetVersion",
+    }
+)
+
+TYPE_TO_CATEGORY = {
+    "contact data set": "contacts",
+    "flow property data set": "flowproperties",
+    "flow data set": "flows",
+    "lcia method data set": "lciamethods",
+    "life cycle model data set": "lifecyclemodels",
+    "lifecycle model data set": "lifecyclemodels",
+    "process data set": "processes",
+    "source data set": "sources",
+    "unit group data set": "unitgroups",
+    "compliance system": "sources",
+    "ilcddataformatreference": "sources",
+    "datasetformat": "sources",
+    "ilcdformatglobalreference": "sources",
+}
+
+VERSIONED_FILE_RE = re.compile(
+    r"^(?P<uuid>[0-9a-fA-F-]{36})_(?P<version>\d{2}\.\d{2}\.\d{3})\.json$"
+)
+VERSIONED_URI_RE = re.compile(
+    r"(?P<uuid>[0-9a-fA-F-]{36})_(?P<version>\d{2}\.\d{2}\.\d{3})(?P<suffix>\.(?:xml|json))$"
+)
+UNVERSIONED_URI_RE = re.compile(
+    r"(?P<uuid>[0-9a-fA-F-]{36})(?P<suffix>\.(?:xml|json))$"
+)
+
+
+@dataclass
+class VersionedRecord:
+    category: str
+    uuid: str
+    version: str
+    path: Path
+    payload: dict
+
+
+def _normalize_reference_type(reference_type: str | None) -> str | None:
+    if not reference_type:
+        return None
+    return TYPE_TO_CATEGORY.get(reference_type.strip().lower())
+
+
+def _infer_reference_category(reference: dict) -> str | None:
+    uri = reference.get("@uri") or ""
+    for category in SUPPORTED_VERSIONED_CATEGORIES:
+        if f"/{category}/" in uri or f"../{category}/" in uri:
+            return category
+    return _normalize_reference_type(reference.get("@type"))
+
+
+def _infer_reference_target(reference: dict) -> tuple[str, str, str | None] | None:
+    category = _infer_reference_category(reference)
+    ref_uuid = reference.get("@refObjectId")
+    version = reference.get("@version")
+    uri = reference.get("@uri") or ""
+
+    versioned_match = VERSIONED_URI_RE.search(uri)
+    if versioned_match:
+        ref_uuid = ref_uuid or versioned_match.group("uuid")
+        version = version or versioned_match.group("version")
+    else:
+        unversioned_match = UNVERSIONED_URI_RE.search(uri)
+        if unversioned_match:
+            ref_uuid = ref_uuid or unversioned_match.group("uuid")
+
+    if not category or not ref_uuid:
+        return None
+
+    return category, ref_uuid, version
+
+
+def _rewrite_reference_uri(
+    uri: str | None,
+    *,
+    ref_uuid: str,
+    latest_version: str,
+) -> str | None:
+    if not uri:
+        return uri
+
+    versioned_match = VERSIONED_URI_RE.search(uri)
+    if versioned_match and versioned_match.group("uuid") == ref_uuid:
+        return VERSIONED_URI_RE.sub(
+            f"{ref_uuid}_{latest_version}\\g<suffix>",
+            uri,
+            count=1,
+        )
+
+    return uri
+
+
+def _load_versioned_records(package_dir: Path) -> list[VersionedRecord]:
+    records: list[VersionedRecord] = []
+
+    for category in SUPPORTED_VERSIONED_CATEGORIES:
+        category_dir = package_dir / category
+        if not category_dir.is_dir():
+            continue
+
+        for path in sorted(category_dir.glob("*.json")):
+            match = VERSIONED_FILE_RE.match(path.name)
+            if not match:
+                continue
+
+            with path.open(encoding="utf-8") as handle:
+                payload = json.load(handle)
+
+            records.append(
+                VersionedRecord(
+                    category=category,
+                    uuid=match.group("uuid"),
+                    version=match.group("version"),
+                    path=path,
+                    payload=payload,
+                )
+            )
+
+    return records
+
+
+def _build_versions_by_dataset(
+    records: list[VersionedRecord],
+) -> dict[tuple[str, str], list[str]]:
+    versions_by_dataset: dict[tuple[str, str], list[str]] = {}
+
+    for record in records:
+        key = (record.category, record.uuid)
+        versions_by_dataset.setdefault(key, []).append(record.version)
+
+    for versions in versions_by_dataset.values():
+        versions.sort()
+
+    return versions_by_dataset
+
+
+def _normalize_payload_references(
+    node,
+    *,
+    latest_versions: dict[tuple[str, str], str],
+    versions_by_dataset: dict[tuple[str, str], list[str]],
+    summary: dict[str, int],
+) -> bool:
+    changed = False
+
+    if isinstance(node, dict):
+        for key in list(node.keys()):
+            value = node[key]
+
+            if isinstance(value, dict) and "@refObjectId" in value:
+                target = _infer_reference_target(value)
+                if target is not None:
+                    category, ref_uuid, version = target
+                    dataset_key = (category, ref_uuid)
+                    latest_version = latest_versions.get(dataset_key)
+                    versions = versions_by_dataset.get(dataset_key, [])
+
+                    if key in PRECEDING_REFERENCE_KEYS and len(versions) > 1:
+                        del node[key]
+                        summary["removed_preceding_references"] += 1
+                        changed = True
+                        continue
+
+                    if (
+                        latest_version is not None
+                        and version is not None
+                        and version != latest_version
+                    ):
+                        value["@version"] = latest_version
+                        rewritten_uri = _rewrite_reference_uri(
+                            value.get("@uri"),
+                            ref_uuid=ref_uuid,
+                            latest_version=latest_version,
+                        )
+                        if rewritten_uri is not None:
+                            value["@uri"] = rewritten_uri
+                        summary["updated_references"] += 1
+                        changed = True
+
+            if key in node:
+                changed = _normalize_payload_references(
+                    node[key],
+                    latest_versions=latest_versions,
+                    versions_by_dataset=versions_by_dataset,
+                    summary=summary,
+                ) or changed
+
+    elif isinstance(node, list):
+        for item in node:
+            changed = _normalize_payload_references(
+                item,
+                latest_versions=latest_versions,
+                versions_by_dataset=versions_by_dataset,
+                summary=summary,
+            ) or changed
+
+    return changed
+
+
+def normalize_package_versions(package_dir: str | Path) -> dict[str, int | str]:
+    package_path = Path(package_dir)
+    records = _load_versioned_records(package_path)
+    versions_by_dataset = _build_versions_by_dataset(records)
+    latest_versions = {
+        dataset_key: versions[-1]
+        for dataset_key, versions in versions_by_dataset.items()
+    }
+
+    summary: dict[str, int | str] = {
+        "package_dir": str(package_path),
+        "scanned_records": len(records),
+        "dataset_count": len(versions_by_dataset),
+        "duplicate_dataset_count": sum(
+            1 for versions in versions_by_dataset.values() if len(versions) > 1
+        ),
+        "kept_records": 0,
+        "removed_records": 0,
+        "rewritten_files": 0,
+        "updated_references": 0,
+        "removed_preceding_references": 0,
+    }
+
+    kept_records: list[VersionedRecord] = []
+    removed_records: list[VersionedRecord] = []
+
+    for record in records:
+        if record.version == latest_versions[(record.category, record.uuid)]:
+            kept_records.append(record)
+        else:
+            removed_records.append(record)
+
+    for record in kept_records:
+        changed = _normalize_payload_references(
+            record.payload,
+            latest_versions=latest_versions,
+            versions_by_dataset=versions_by_dataset,
+            summary=summary,
+        )
+        if changed:
+            with record.path.open("w", encoding="utf-8") as handle:
+                json.dump(record.payload, handle, indent=2, ensure_ascii=False)
+                handle.write("\n")
+            summary["rewritten_files"] += 1
+
+    for record in removed_records:
+        record.path.unlink()
+
+    summary["kept_records"] = len(kept_records)
+    summary["removed_records"] = len(removed_records)
+
+    logging.info(
+        "Normalized package versions in %s: kept=%s removed=%s updated_refs=%s removed_preceding_refs=%s rewritten_files=%s",
+        package_path,
+        summary["kept_records"],
+        summary["removed_records"],
+        summary["updated_references"],
+        summary["removed_preceding_references"],
+        summary["rewritten_files"],
+    )
+
+    return summary

--- a/src/tidas_tools/tidas/schemas/tidas_contacts.json
+++ b/src/tidas_tools/tidas/schemas/tidas_contacts.json
@@ -46,7 +46,7 @@
                 },
                 "classificationInformation": {
                   "type": "object",
-                  "description": "Hierachical classification of the contact foreseen to be used to structure the contact content of the database. (Note: This entry is NOT required for the identification of the contact data set. It should nevertheless be avoided to use identical names for contacts in the same class.",
+                  "description": "Hierarchical classification of the contact foreseen to be used to structure the contact content of the database. (Note: This entry is NOT required for the identification of the contact data set. It should nevertheless be avoided to use identical names for contacts in the same class.",
                   "properties": {
                     "common:classification": {
                       "type": "object",

--- a/tests/test_package_versions.py
+++ b/tests/test_package_versions.py
@@ -1,0 +1,109 @@
+import json
+
+from tidas_tools.package_versions import normalize_package_versions
+
+
+def _write_json(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+
+
+def test_normalize_package_versions_updates_references_and_removes_old_versions(
+    tmp_path,
+):
+    package_dir = tmp_path / "package"
+
+    contact_uuid = "11111111-1111-1111-1111-111111111111"
+    flow_uuid = "22222222-2222-2222-2222-222222222222"
+    process_uuid = "33333333-3333-3333-3333-333333333333"
+
+    _write_json(
+        package_dir / "contacts" / f"{contact_uuid}_01.00.005.json",
+        {"contactDataSet": {"common:UUID": contact_uuid}},
+    )
+    _write_json(
+        package_dir / "contacts" / f"{contact_uuid}_01.00.006.json",
+        {"contactDataSet": {"common:UUID": contact_uuid}},
+    )
+    _write_json(
+        package_dir / "flows" / f"{flow_uuid}_01.01.000.json",
+        {"flowDataSet": {"common:UUID": flow_uuid}},
+    )
+    _write_json(
+        package_dir / "flows" / f"{flow_uuid}_01.01.001.json",
+        {
+            "flowDataSet": {
+                "administrativeInformation": {
+                    "publicationAndOwnership": {
+                        "common:referenceToOwnershipOfDataSet": {
+                            "@refObjectId": contact_uuid,
+                            "@type": "contact data set",
+                            "@version": "01.00.005",
+                            "@uri": f"../contacts/{contact_uuid}_01.00.005.xml",
+                        },
+                        "common:referenceToPrecedingDataSetVersion": {
+                            "@refObjectId": flow_uuid,
+                            "@type": "flow data set",
+                            "@version": "01.01.000",
+                            "@uri": f"../flows/{flow_uuid}_01.01.000.xml",
+                        },
+                    }
+                }
+            }
+        },
+    )
+    _write_json(
+        package_dir / "processes" / f"{process_uuid}_01.01.000.json",
+        {
+            "processDataSet": {
+                "exchanges": {
+                    "exchange": [
+                        {
+                            "referenceToFlowDataSet": {
+                                "@refObjectId": flow_uuid,
+                                "@type": "flow data set",
+                                "@version": "01.01.000",
+                                "@uri": f"../flows/{flow_uuid}_01.01.000.xml",
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+    )
+
+    summary = normalize_package_versions(package_dir)
+
+    assert summary["duplicate_dataset_count"] == 2
+    assert summary["removed_records"] == 2
+    assert summary["updated_references"] == 2
+    assert summary["removed_preceding_references"] == 1
+
+    assert not (package_dir / "contacts" / f"{contact_uuid}_01.00.005.json").exists()
+    assert not (package_dir / "flows" / f"{flow_uuid}_01.01.000.json").exists()
+    assert (package_dir / "contacts" / f"{contact_uuid}_01.00.006.json").exists()
+    assert (package_dir / "flows" / f"{flow_uuid}_01.01.001.json").exists()
+
+    latest_flow = json.loads(
+        (package_dir / "flows" / f"{flow_uuid}_01.01.001.json").read_text()
+    )
+    ownership_ref = latest_flow["flowDataSet"]["administrativeInformation"][
+        "publicationAndOwnership"
+    ]["common:referenceToOwnershipOfDataSet"]
+    assert ownership_ref["@version"] == "01.00.006"
+    assert ownership_ref["@uri"] == f"../contacts/{contact_uuid}_01.00.006.xml"
+    assert (
+        "common:referenceToPrecedingDataSetVersion"
+        not in latest_flow["flowDataSet"]["administrativeInformation"][
+            "publicationAndOwnership"
+        ]
+    )
+
+    kept_process = json.loads(
+        (package_dir / "processes" / f"{process_uuid}_01.01.000.json").read_text()
+    )
+    flow_ref = kept_process["processDataSet"]["exchanges"]["exchange"][0][
+        "referenceToFlowDataSet"
+    ]
+    assert flow_ref["@version"] == "01.01.001"
+    assert flow_ref["@uri"] == f"../flows/{flow_uuid}_01.01.001.xml"


### PR DESCRIPTION
## Summary
- add package-level version normalization to keep only the latest dataset file per UUID during TIDAS export
- rewrite ordinary references to the latest kept version and drop preceding-version links before removing older files
- cover the normalization behavior with regression tests and include a non-functional contact schema description typo fix to trigger the downstream SDK sync workflow

## Validation
- `uv run pytest`
- ran `normalize_package_versions()` against a temporary copy of `test_data/tidas-package-open_data-1775045666560` and confirmed the fixture currently has `duplicate_dataset_count = 0`

Closes #27
