### PR TITLE
Make lifecycle model connections optional

### DIFF
--- a/src/tidas_tools/tidas/schemas/tidas_lifecyclemodels.json
+++ b/src/tidas_tools/tidas/schemas/tidas_lifecyclemodels.json
@@ -623,8 +623,7 @@
                             "required": [
                             "@dataSetInternalID",
                             "@multiplicationFactor",
-                            "referenceToProcess",
-                            "connections"
+                            "referenceToProcess"
                             ]
                           }
                         },
@@ -924,8 +923,7 @@
                           "required": [
                           "@dataSetInternalID",
                           "@multiplicationFactor",
-                          "referenceToProcess",
-                          "connections"
+                          "referenceToProcess"
                           ]
                         }
                       ]


### PR DESCRIPTION
## Summary
- @linancn Removed `connections` from the required fields for lifecycle model process instances.
- Kept the existing `connections` structure validation when the field is provided.

## Tests
- `python3 -m json.tool src/tidas_tools/tidas/schemas/tidas_lifecyclemodels.json`
- Recursive JSON check confirmed no `required` arrays contain `connections`.