### PR TITLE
docs: add AI doc contracts for issue #34

### DIFF
--- a/.github/scripts/ai-doc-lint.mjs
+++ b/.github/scripts/ai-doc-lint.mjs
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const MARKDOWN_METADATA_KEYS = [
+  'docType',
+  'scope',
+  'status',
+  'authoritative',
+  'owner',
+  'language',
+  'whenToUse',
+  'whenToUpdate',
+  'checkPaths',
+  'lastReviewedAt',
+  'lastReviewedCommit',
+];
+
+const YAML_METADATA_KEYS = ['lastReviewedAt', 'lastReviewedCommit'];
+
+export function normalizePath(value) {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/');
+}
+
+export function escapeRegex(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+export function globToRegExp(pattern) {
+  const normalized = normalizePath(pattern);
+  let output = '^';
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    const next = normalized[index + 1];
+
+    if (char === '*') {
+      if (next === '*') {
+        output += '.*';
+        index += 1;
+      } else {
+        output += '[^/]*';
+      }
+      continue;
+    }
+
+    if (char === '?') {
+      output += '[^/]';
+      continue;
+    }
+
+    output += escapeRegex(char);
+  }
+
+  output += '$';
+  return new RegExp(output);
+}
+
+export function matchesPattern(filePath, pattern) {
+  return globToRegExp(pattern).test(normalizePath(filePath));
+}
+
+export function parseJsonCompatibleYaml(text, sourceLabel) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `${sourceLabel} is not valid JSON-compatible YAML. Phase 1 contract files must use JSON-compatible YAML syntax. ${error.message}`,
+    );
+  }
+}
+
+export function loadJsonCompatibleYaml(absPath, sourceLabel = absPath) {
+  return parseJsonCompatibleYaml(readFileSync(absPath, 'utf8'), sourceLabel);
+}
+
+export function parseFrontmatterKeys(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    return new Set();
+  }
+
+  return new Set(
+    Array.from(match[1].matchAll(/^([A-Za-z][A-Za-z0-9]*)\s*:/gm), (result) => result[1]),
+  );
+}
+
+export function missingMarkdownMetadata(text) {
+  const keys = parseFrontmatterKeys(text);
+  return MARKDOWN_METADATA_KEYS.filter((key) => !keys.has(key));
+}
+
+export function missingYamlMetadata(text, sourceLabel) {
+  const parsed = parseJsonCompatibleYaml(text, sourceLabel);
+  return YAML_METADATA_KEYS.filter((key) => !(key in parsed));
+}
+
+export function isKeyMarkdownDoc(relPath) {
+  const normalized = normalizePath(relPath);
+  return (
+    path.posix.basename(normalized) === 'AGENTS.md' ||
+    ((normalized.startsWith('ai/') || normalized.includes('/ai/')) && normalized.endsWith('.md'))
+  );
+}
+
+export function isKeyYamlContract(relPath) {
+  const normalized = normalizePath(relPath);
+  return normalized.endsWith('.yaml') && (normalized.startsWith('ai/') || normalized.includes('/ai/'));
+}
+
+export function detectImpactLayout(rootDir) {
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact-map.yaml'))) {
+    return 'workspace';
+  }
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact.yaml'))) {
+    return 'repo';
+  }
+  return 'none';
+}
+
+export function listImpactFiles(rootDir) {
+  const layout = detectImpactLayout(rootDir);
+
+  if (layout === 'repo') {
+    return [
+      {
+        absPath: path.join(rootDir, 'ai', 'doc-impact.yaml'),
+        relPath: 'ai/doc-impact.yaml',
+        baseDir: '',
+      },
+    ];
+  }
+
+  if (layout !== 'workspace') {
+    return [];
+  }
+
+  const rootImpact = path.join(rootDir, 'ai', 'doc-impact-map.yaml');
+  const results = [
+    {
+      absPath: rootImpact,
+      relPath: 'ai/doc-impact-map.yaml',
+      baseDir: '',
+    },
+  ];
+
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const repoImpact = path.join(rootDir, entry.name, 'ai', 'doc-impact.yaml');
+    if (!existsSync(repoImpact)) {
+      continue;
+    }
+
+    results.push({
+      absPath: repoImpact,
+      relPath: normalizePath(path.join(entry.name, 'ai', 'doc-impact.yaml')),
+      baseDir: entry.name,
+    });
+  }
+
+  return results;
+}
+
+export function loadImpactFiles(rootDir) {
+  return listImpactFiles(rootDir).flatMap(({ absPath, relPath, baseDir }) => {
+    const parsed = loadJsonCompatibleYaml(absPath, relPath);
+    const rules = Array.isArray(parsed.rules) ? parsed.rules : [];
+
+    return rules.map((rule) => ({
+      source: relPath,
+      baseDir,
+      rule,
+    }));
+  });
+}
+
+export function resolveRulePath(baseDir, relPattern) {
+  if (!baseDir) {
+    return normalizePath(relPattern);
+  }
+  return normalizePath(path.posix.join(baseDir, relPattern));
+}
+
+export function matchRules(changedPaths, loadedRules) {
+  const matches = [];
+
+  for (const changedPath of changedPaths) {
+    for (const loaded of loadedRules) {
+      const triggers = Array.isArray(loaded.rule.triggers) ? loaded.rule.triggers : [];
+      if (
+        triggers.some((trigger) =>
+          matchesPattern(changedPath, resolveRulePath(loaded.baseDir, trigger.path)),
+        )
+      ) {
+        matches.push({
+          changedPath,
+          source: loaded.source,
+          rule: loaded.rule,
+          baseDir: loaded.baseDir,
+        });
+      }
+    }
+  }
+
+  return matches;
+}
+
+export function collectExpectedDocs(matches) {
+  const expected = new Map();
+
+  for (const match of matches) {
+    const requiredDocs = Array.isArray(match.rule.requiredDocs) ? match.rule.requiredDocs : [];
+    for (const doc of requiredDocs) {
+      const fullPath = resolveRulePath(match.baseDir, doc.path);
+      if (!expected.has(fullPath)) {
+        expected.set(fullPath, {
+          path: fullPath,
+          rules: new Set(),
+          changedPaths: new Set(),
+          modes: new Set(),
+        });
+      }
+
+      const entry = expected.get(fullPath);
+      entry.rules.add(match.rule.id);
+      entry.changedPaths.add(match.changedPath);
+      entry.modes.add(doc.mode);
+    }
+  }
+
+  return expected;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    rootDir: process.cwd(),
+    mode: 'warn',
+    files: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--root') {
+      options.rootDir = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--mode') {
+      options.mode = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--base') {
+      options.base = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--head') {
+      options.head = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--files') {
+      options.files = argv[index + 1]
+        .split(',')
+        .map((value) => normalizePath(value.trim()))
+        .filter(Boolean);
+      index += 1;
+      continue;
+    }
+    if (arg === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+export function getChangedPaths({ rootDir, base, head, files }) {
+  if (files.length > 0) {
+    return [...new Set(files)];
+  }
+
+  if (!base || !head) {
+    throw new Error('Pass either --files or both --base and --head.');
+  }
+
+  const output = execFileSync('git', ['diff', '--name-only', `${base}...${head}`], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+
+  return [...new Set(output.split(/\r?\n/).map((value) => normalizePath(value.trim())).filter(Boolean))];
+}
+
+export function buildDocProblems({ rootDir, changedPaths }) {
+  const problems = [];
+
+  for (const relPath of changedPaths) {
+    const absPath = path.join(rootDir, relPath);
+    if (!existsSync(absPath)) {
+      continue;
+    }
+
+    if (isKeyMarkdownDoc(relPath)) {
+      const missing = missingMarkdownMetadata(readFileSync(absPath, 'utf8'));
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing Markdown metadata keys: ${missing.join(', ')}`,
+        });
+      }
+      continue;
+    }
+
+    if (isKeyYamlContract(relPath)) {
+      const missing = missingYamlMetadata(readFileSync(absPath, 'utf8'), relPath);
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing YAML metadata keys: ${missing.join(', ')}`,
+        });
+      }
+    }
+  }
+
+  return problems;
+}
+
+export function buildMissingDocProblems({ changedPaths, expectedDocs }) {
+  const changed = new Set(changedPaths);
+  const problems = [];
+
+  for (const entry of expectedDocs.values()) {
+    if (changed.has(entry.path)) {
+      continue;
+    }
+
+    problems.push({
+      type: 'missing-review',
+      path: entry.path,
+      message: `Expected reviewed doc was not touched. Triggered by ${Array.from(entry.changedPaths).join(', ')} via rule(s): ${Array.from(entry.rules).join(', ')}`,
+    });
+  }
+
+  return problems;
+}
+
+export function formatProblem(problem) {
+  return `- [${problem.type}] ${problem.path}: ${problem.message}`;
+}
+
+export function emitProblems(problems, mode) {
+  if (problems.length === 0) {
+    console.log('AI doc lint: no problems found.');
+    return;
+  }
+
+  const heading =
+    mode === 'enforce' ? 'AI doc lint found blocking problems:' : 'AI doc lint found warnings:';
+  const annotationLevel = mode === 'enforce' ? 'error' : 'warning';
+  console.log(heading);
+  for (const problem of problems) {
+    console.log(formatProblem(problem));
+    if (process.env.GITHUB_ACTIONS) {
+      console.log(`::${annotationLevel} file=${problem.path}::${problem.message}`);
+    }
+  }
+}
+
+export function run(options) {
+  const changedPaths = getChangedPaths(options);
+  if (changedPaths.length === 0) {
+    console.log('AI doc lint: no changed paths to inspect.');
+    return { problems: [], changedPaths, matchedRules: [] };
+  }
+
+  const loadedRules = loadImpactFiles(options.rootDir);
+  const matchedRules = matchRules(changedPaths, loadedRules);
+  const expectedDocs = collectExpectedDocs(matchedRules);
+  const problems = [
+    ...buildMissingDocProblems({ changedPaths, expectedDocs }),
+    ...buildDocProblems({ rootDir: options.rootDir, changedPaths }),
+  ];
+
+  emitProblems(problems, options.mode);
+
+  if (options.mode === 'enforce' && problems.length > 0) {
+    process.exitCode = 1;
+  }
+
+  return { problems, changedPaths, matchedRules };
+}
+
+function printHelp() {
+  console.log(`Usage: node .github/scripts/ai-doc-lint.mjs [--mode warn|enforce] [--base <sha> --head <sha> | --files <csv>] [--root <dir>]`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      printHelp();
+      process.exit(0);
+    }
+    run(options);
+  } catch (error) {
+    console.error(`AI doc lint error: ${error.message}`);
+    process.exit(2);
+  }
+}

--- a/.github/scripts/ai-doc-lint.test.mjs
+++ b/.github/scripts/ai-doc-lint.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  collectExpectedDocs,
+  detectImpactLayout,
+  globToRegExp,
+  isKeyMarkdownDoc,
+  loadImpactFiles,
+  matchRules,
+  missingMarkdownMetadata,
+  missingYamlMetadata,
+  normalizePath,
+} from './ai-doc-lint.mjs';
+
+test('normalizePath and globToRegExp support repo-relative matching', () => {
+  assert.equal(normalizePath('.\\tiangong-lca-next\\config\\routes.ts'), 'tiangong-lca-next/config/routes.ts');
+  assert.equal(globToRegExp('tiangong-lca-next/**').test('tiangong-lca-next/config/routes.ts'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/quality-rubric.md'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/nested/file.md'), false);
+});
+
+test('detectImpactLayout distinguishes workspace and repo roots', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-layout-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  assert.equal(detectImpactLayout(tempDir), 'none');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'repo');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact-map.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'workspace');
+});
+
+test('isKeyMarkdownDoc excludes YAML contract files', () => {
+  assert.equal(isKeyMarkdownDoc('ai/quality-rubric.md'), true);
+  assert.equal(isKeyMarkdownDoc('AGENTS.md'), true);
+  assert.equal(isKeyMarkdownDoc('ai/workspace.yaml'), false);
+});
+
+test('missingMarkdownMetadata detects absent frontmatter keys', () => {
+  const text = `---
+title: Example
+docType: contract
+scope: workspace
+status: draft
+authoritative: false
+owner: lca-workspace
+language: en
+whenToUse:
+  - x
+whenToUpdate:
+  - y
+checkPaths:
+  - ai/**
+lastReviewedAt: 2026-04-18
+---
+
+# Example
+`;
+
+  assert.deepEqual(missingMarkdownMetadata(text), ['lastReviewedCommit']);
+});
+
+test('missingYamlMetadata detects absent top-level review fields', () => {
+  const text = JSON.stringify({ version: 1, lastReviewedAt: '2026-04-18' });
+  assert.deepEqual(missingYamlMetadata(text, 'ai/example.yaml'), ['lastReviewedCommit']);
+});
+
+test('loadImpactFiles, matchRules, and collectExpectedDocs resolve repo-local paths', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+  mkdirSync(path.join(tempDir, 'subrepo', 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact-map.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'root-rule',
+            scope: 'workspace',
+            repo: 'lca-workspace',
+            triggers: [{ path: 'AGENTS.md', kind: 'doc-contract' }],
+            requiredDocs: [{ path: 'ai/workspace.yaml', mode: 'review_or_update' }],
+            reason: 'root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  writeFileSync(
+    path.join(tempDir, 'subrepo', 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'subrepo',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/task-router.md', mode: 'review_or_update' }],
+            reason: 'repo',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['AGENTS.md', 'subrepo/src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 2);
+  assert.equal(matches.length, 2);
+  assert.deepEqual([...expectedDocs.keys()].sort(), ['ai/workspace.yaml', 'subrepo/ai/task-router.md']);
+});
+
+test('loadImpactFiles supports repo-root mode', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-repo-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'example',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/validation.md', mode: 'review_or_update' }],
+            reason: 'repo-root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 1);
+  assert.equal(matches.length, 1);
+  assert.deepEqual([...expectedDocs.keys()], ['ai/validation.md']);
+});

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,0 +1,32 @@
+name: ai-doc-lint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ai-doc-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Run ai-doc-lint unit tests
+        run: node --test .github/scripts/ai-doc-lint.test.mjs
+
+      - name: Run ai-doc-lint
+        run: |
+          node .github/scripts/ai-doc-lint.mjs \
+            --mode enforce \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ Route those tasks to:
 
 ## Runtime Facts
 
+- Repo-local AI-doc maintenance is enforced by `.github/workflows/ai-doc-lint.yml` using the vendored `.github/scripts/ai-doc-lint.*` files.
 - Python package manager and runner: `uv`
 - Canonical local setup: `uv sync --dev`
 - Canonical local test command: `uv run pytest`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,102 @@
+---
+title: tidas-tools AI Working Guide
+docType: contract
+scope: repo
+status: active
+authoritative: true
+owner: tidas-tools
+language: en
+whenToUse:
+  - when a task may change standalone TIDAS conversion, validation, export behavior, or the packaged schema and methodology assets
+  - when routing work from the workspace root into tidas-tools
+  - when deciding whether a change belongs here, in tidas-sdk, in tidas, or in lca-workspace
+whenToUpdate:
+  - when tool ownership, runtime prerequisites, or release automation change
+  - when the SDK dispatch contract changes
+  - when the repo-local AI bootstrap docs under ai/ change
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - README_CN.md
+  - ai/**/*.md
+  - ai/**/*.yaml
+  - pyproject.toml
+  - src/tidas_tools/**
+  - tests/**
+  - test_data/**
+  - .github/workflows/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 19d0d16cb047a533c9cc99f422eebff56e038ee4
+related:
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - README.md
+---
+
+## Repo Contract
+
+`tidas-tools` owns standalone TIDAS and eILCD conversion, validation, export behavior, and the packaged schema and methodology assets consumed by downstream SDK refreshes. Start here when the task may change how TIDAS data is validated, converted, exported, or versioned as tooling.
+
+## AI Load Order
+
+Load docs in this order:
+
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. `ai/task-router.md`
+4. `ai/validation.md`
+5. `ai/architecture.md`
+6. `README.md` only for user-facing CLI examples
+
+Do not start with the SDK repo if the change is really about standalone tooling or upstream schema assets.
+
+## Repo Ownership
+
+This repo owns:
+
+- standalone CLI behavior in `src/tidas_tools/convert.py`, `validate.py`, and `export.py`
+- packaged schema and methodology assets under `src/tidas_tools/tidas/**`
+- packaged eILCD schemas and stylesheets under `src/tidas_tools/eilcd/**`
+- version and export helpers such as `package_versions.py` and `validation_report.py`
+- tests and the SDK dispatch workflow in `.github/workflows/dispatch-tidas-sdk-sync.yml`
+
+This repo does not own:
+
+- generated SDK package surfaces
+- public spec/docs-site presentation
+- workspace integration state after merge
+
+Route those tasks to:
+
+- `tidas-sdk` for generated package surfaces and package release automation
+- `tidas` for public spec/docs-site content
+- `lca-workspace` for root integration after merge
+
+## Runtime Facts
+
+- Python package manager and runner: `uv`
+- Canonical local setup: `uv sync --dev`
+- Canonical local test command: `uv run pytest`
+- Common manual tool probes:
+  - `uv run python src/tidas_tools/convert.py --help`
+  - `uv run python src/tidas_tools/validate.py --help`
+  - `uv run python src/tidas_tools/export.py --help`
+- Release is tag-driven through `v<version>` tags
+
+## Hard Boundaries
+
+- Do not move standalone conversion, validation, or export logic into `tidas-sdk`
+- Do not treat the public docs site as the executable upstream for packaged schemas and methodologies
+- Do not treat a merged repo PR here as workspace-delivery complete if the root repo still needs a submodule bump
+
+## Workspace Integration
+
+A merged PR in `tidas-tools` is repo-complete, not delivery-complete.
+
+If the change must ship through the workspace:
+
+1. merge the child PR into `tidas-tools`
+2. update the `lca-workspace` submodule pointer deliberately
+3. complete any later workspace-level validation that depends on the updated tooling snapshot

--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -1,0 +1,89 @@
+---
+title: tidas-tools Architecture Notes
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: tidas-tools
+language: en
+whenToUse:
+  - when you need a compact mental model of the repo before editing tooling logic, asset trees, or dispatch automation
+  - when deciding which CLI or asset family owns a behavior change
+  - when conversion, validation, export, or downstream SDK dispatch is mentioned without exact paths
+whenToUpdate:
+  - when major tool families or asset locations change
+  - when downstream dispatch or release architecture changes
+  - when stable versus packaged paths move
+checkPaths:
+  - ai/architecture.md
+  - ai/repo.yaml
+  - pyproject.toml
+  - src/tidas_tools/**
+  - .github/workflows/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 19d0d16cb047a533c9cc99f422eebff56e038ee4
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./validation.md
+  - ../README.md
+---
+
+## Repo Shape
+
+This repo packages standalone tooling plus the schema and stylesheet assets those tools execute against.
+
+## Stable Path Map
+
+| Path group | Role |
+| --- | --- |
+| `src/tidas_tools/convert.py` | standalone conversion CLI |
+| `src/tidas_tools/validate.py` | standalone validation CLI |
+| `src/tidas_tools/validation_report.py` | structured validation-report rendering |
+| `src/tidas_tools/export.py` | standalone export CLI |
+| `src/tidas_tools/package_versions.py` | version normalization and export package metadata logic |
+| `src/tidas_tools/tidas/**` | packaged TIDAS schemas and methodologies |
+| `src/tidas_tools/eilcd/**` | packaged eILCD schemas and stylesheets |
+| `tests/**` | automated repo tests |
+| `.github/workflows/dispatch-tidas-sdk-sync.yml` | downstream SDK refresh dispatch contract |
+| `.github/workflows/python-package-deploy.yml` | tag-driven PyPI publish workflow |
+
+## Current Tool Families
+
+### Conversion
+
+`convert.py` owns standalone TIDAS and eILCD conversion behavior.
+
+### Validation
+
+`validate.py` plus `validation_report.py` own standalone validation semantics and structured reporting.
+
+### Export
+
+`export.py` plus `package_versions.py` own database export semantics, version normalization, and archive packaging.
+
+## Upstream Asset Chain
+
+The practical executable chain today is:
+
+`tidas-tools -> tidas-sdk`
+
+Important consequences:
+
+- `tidas-sdk` runtime assets and generated models depend on the packaged assets here
+- schema or methodology changes here usually imply downstream SDK follow-up
+- `tidas` remains the public docs surface, but it is not the executable upstream for tooling behavior
+
+## Release And Dispatch Architecture
+
+- tag `v<version>` publishes `tidas-tools`
+- changes under packaged schema and methodology paths can dispatch downstream SDK refresh workflows
+
+This dispatch path is part of the repo architecture, not just a convenience automation.
+
+## Common Misreads
+
+- public docs changes do not replace executable tool changes here
+- generated SDK output is downstream, not the upstream source of truth
+- a merged child PR does not finish workspace delivery

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -147,7 +147,11 @@
           "kind": "repo-fixture"
         },
         {
-          "path": ".github/workflows/**",
+          "path": ".github/workflows/dispatch-tidas-sdk-sync.yml",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/workflows/python-package-deploy.yml",
           "kind": "automation"
         }
       ],
@@ -174,6 +178,44 @@
         }
       ],
       "reason": "Test, fixture, and automation changes affect how future tooling work is validated and how downstream SDK refresh is triggered."
+    },
+    {
+      "id": "tidas-tools-ai-doc-maintenance-contract",
+      "scope": "repo",
+      "repo": "tidas-tools",
+      "triggers": [
+        {
+          "path": ".github/workflows/ai-doc-lint.yml",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.mjs",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.test.mjs",
+          "kind": "automation"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Repo-local AI doc maintenance automation changes alter the maintenance gate and should refresh the AI contract docs."
     }
   ]
 }

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -1,0 +1,179 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "19d0d16cb047a533c9cc99f422eebff56e038ee4",
+  "rules": [
+    {
+      "id": "tidas-tools-bootstrap-contract",
+      "scope": "repo",
+      "repo": "tidas-tools",
+      "triggers": [
+        {
+          "path": "AGENTS.md",
+          "kind": "doc-contract"
+        },
+        {
+          "path": "README.md",
+          "kind": "doc-entry"
+        },
+        {
+          "path": "README_CN.md",
+          "kind": "doc-entry"
+        },
+        {
+          "path": "ai/**",
+          "kind": "doc-ai-layer"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Entry guidance, repo facts, and routing docs must stay aligned."
+    },
+    {
+      "id": "tidas-tools-runtime-contract",
+      "scope": "repo",
+      "repo": "tidas-tools",
+      "triggers": [
+        {
+          "path": "pyproject.toml",
+          "kind": "runtime-config"
+        },
+        {
+          "path": "src/tidas_tools/convert.py",
+          "kind": "tooling"
+        },
+        {
+          "path": "src/tidas_tools/validate.py",
+          "kind": "tooling"
+        },
+        {
+          "path": "src/tidas_tools/validation_report.py",
+          "kind": "tooling"
+        },
+        {
+          "path": "src/tidas_tools/export.py",
+          "kind": "tooling"
+        },
+        {
+          "path": "src/tidas_tools/package_versions.py",
+          "kind": "tooling"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Core standalone tooling changes alter the repo's executable contract and should refresh the AI bootstrap docs."
+    },
+    {
+      "id": "tidas-tools-asset-contract",
+      "scope": "repo",
+      "repo": "tidas-tools",
+      "triggers": [
+        {
+          "path": "src/tidas_tools/tidas/**",
+          "kind": "tidas-asset"
+        },
+        {
+          "path": "src/tidas_tools/eilcd/**",
+          "kind": "eilcd-asset"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Packaged schemas, methodologies, and stylesheets are executable upstream assets and should refresh the repo contract when they change."
+    },
+    {
+      "id": "tidas-tools-tests-and-automation-contract",
+      "scope": "repo",
+      "repo": "tidas-tools",
+      "triggers": [
+        {
+          "path": "tests/**",
+          "kind": "repo-test"
+        },
+        {
+          "path": "test_data/**",
+          "kind": "repo-fixture"
+        },
+        {
+          "path": ".github/workflows/**",
+          "kind": "automation"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Test, fixture, and automation changes affect how future tooling work is validated and how downstream SDK refresh is triggered."
+    }
+  ]
+}

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -139,7 +139,7 @@
       "notes": [
         "Use uv sync --dev before running local tests if the environment is not prepared.",
         "Manual --help probes for convert, validate, and export are the safest narrow checks when a change only touches one CLI surface.",
-        "AI-doc changes should still run the root warning-only ai-doc-lint."
+        "AI-doc changes should still run the repo-local ai-doc-lint workflow or the equivalent local node command."
       ]
     }
   }

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -1,0 +1,146 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "19d0d16cb047a533c9cc99f422eebff56e038ee4",
+  "repo": {
+    "id": "tidas-tools",
+    "path": "tidas-tools",
+    "canonicalRepo": "tiangong-lca/tidas-tools",
+    "purpose": "Standalone TIDAS conversion, validation, export, and upstream asset repository.",
+    "entryDoc": "AGENTS.md",
+    "taskRouterDoc": "ai/task-router.md",
+    "validationDoc": "ai/validation.md",
+    "architectureDoc": "ai/architecture.md",
+    "readmeDoc": "README.md",
+    "defaultBranch": "main",
+    "dailyTrunk": "main",
+    "routinePrBase": "main",
+    "branchModel": "M1",
+    "workspaceIntegrationRequired": true,
+    "rootIntegrationRule": "lca-workspace/main may bump merged main-branch tooling snapshots when the workspace intends to ship the updated TIDAS tooling state.",
+    "trackedBy": {
+      "workspaceParentIssue": "https://github.com/tiangong-lca/workspace/issues/73",
+      "repoIssue": "https://github.com/tiangong-lca/tidas-tools/issues/34"
+    },
+    "runtime": {
+      "pythonManager": "uv",
+      "baselineSetupCommand": "uv sync --dev",
+      "baselineValidationCommands": [
+        "uv run pytest"
+      ],
+      "manualToolProbeCommands": [
+        "uv run python src/tidas_tools/convert.py --help",
+        "uv run python src/tidas_tools/validate.py --help",
+        "uv run python src/tidas_tools/export.py --help"
+      ],
+      "releaseTagPattern": "v<version>"
+    },
+    "sourceOfTruth": {
+      "stableManualEditPaths": [
+        {
+          "path": "pyproject.toml",
+          "role": "package metadata and dependency baseline"
+        },
+        {
+          "path": "src/tidas_tools/convert.py",
+          "role": "standalone TIDAS and eILCD conversion CLI behavior"
+        },
+        {
+          "path": "src/tidas_tools/validate.py",
+          "role": "standalone validation CLI behavior"
+        },
+        {
+          "path": "src/tidas_tools/validation_report.py",
+          "role": "structured validation-report rendering"
+        },
+        {
+          "path": "src/tidas_tools/export.py",
+          "role": "standalone export CLI behavior"
+        },
+        {
+          "path": "src/tidas_tools/package_versions.py",
+          "role": "package versioning and export version normalization logic"
+        },
+        {
+          "path": "src/tidas_tools/tidas/**",
+          "role": "packaged TIDAS schemas and methodologies"
+        },
+        {
+          "path": "src/tidas_tools/eilcd/**",
+          "role": "packaged eILCD schemas and stylesheets"
+        },
+        {
+          "path": "tests/**",
+          "role": "repo-level automated tests"
+        },
+        {
+          "path": ".github/workflows/dispatch-tidas-sdk-sync.yml",
+          "role": "dispatch contract to downstream tidas-sdk refresh automation"
+        },
+        {
+          "path": ".github/workflows/python-package-deploy.yml",
+          "role": "tag-driven PyPI publish workflow"
+        }
+      ],
+      "nonOwnerBoundaries": [
+        {
+          "repo": "tidas-sdk",
+          "doesNotOwn": [
+            "generated package surfaces",
+            "package-specific release automation"
+          ]
+        },
+        {
+          "repo": "tidas",
+          "doesNotOwn": [
+            "public spec/docs-site presentation"
+          ]
+        },
+        {
+          "repo": "lca-workspace",
+          "doesNotOwn": [
+            "root integration state",
+            "submodule pointer updates"
+          ]
+        }
+      ]
+    },
+    "taskHotspots": [
+      {
+        "topic": "standalone conversion, validation, and export behavior",
+        "paths": [
+          "src/tidas_tools/convert.py",
+          "src/tidas_tools/validate.py",
+          "src/tidas_tools/validation_report.py",
+          "src/tidas_tools/export.py",
+          "src/tidas_tools/package_versions.py"
+        ]
+      },
+      {
+        "topic": "packaged upstream asset changes",
+        "paths": [
+          "src/tidas_tools/tidas/**",
+          "src/tidas_tools/eilcd/**"
+        ]
+      },
+      {
+        "topic": "downstream SDK refresh and release automation",
+        "paths": [
+          ".github/workflows/dispatch-tidas-sdk-sync.yml",
+          ".github/workflows/python-package-deploy.yml",
+          "pyproject.toml"
+        ]
+      }
+    ],
+    "validation": {
+      "baselineLocalCommands": [
+        "uv run pytest"
+      ],
+      "notes": [
+        "Use uv sync --dev before running local tests if the environment is not prepared.",
+        "Manual --help probes for convert, validate, and export are the safest narrow checks when a change only touches one CLI surface.",
+        "AI-doc changes should still run the root warning-only ai-doc-lint."
+      ]
+    }
+  }
+}

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -56,6 +56,7 @@ When working inside `tidas-tools`, load docs in this order:
 | Change downstream SDK dispatch behavior | `.github/workflows/dispatch-tidas-sdk-sync.yml` | `ai/validation.md`, `ai/architecture.md` | This repo owns the dispatch contract that tells `tidas-sdk` to refresh. |
 | Change generated SDK package surfaces | `tidas-sdk`, not this repo | root `ai/task-router.md` | Generated package output belongs downstream in `tidas-sdk`. |
 | Change public spec/docs wording only | `tidas`, not this repo | root `ai/task-router.md` | Public site content belongs in `tidas`. |
+| Change repo-local AI-doc maintenance only | `AGENTS.md`, `ai/**`, `.github/workflows/ai-doc-lint.yml`, `.github/scripts/ai-doc-lint.*` | `ai/validation.md` when present, otherwise `ai/repo.yaml` | Keep the repo-local maintenance gate aligned with root `ai/ci-lint-spec.md` and `ai/review-matrix.md`. |
 | Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
 
 ## Wrong Turns To Avoid

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -1,0 +1,86 @@
+---
+title: tidas-tools Task Router
+docType: router
+scope: repo
+status: active
+authoritative: false
+owner: tidas-tools
+language: en
+whenToUse:
+  - when you already know the task belongs in tidas-tools but need the right next file or next doc
+  - when deciding whether a change belongs in conversion, validation, export, packaged assets, or another repo
+  - when routing between tooling work and handoffs to tidas-sdk, tidas, or lca-workspace
+whenToUpdate:
+  - when new tool families or automation paths appear
+  - when cross-repo boundaries change
+  - when validation routing becomes misleading
+checkPaths:
+  - AGENTS.md
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - pyproject.toml
+  - src/tidas_tools/**
+  - tests/**
+  - .github/workflows/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 19d0d16cb047a533c9cc99f422eebff56e038ee4
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./validation.md
+  - ./architecture.md
+  - ../README.md
+---
+
+## Repo Load Order
+
+When working inside `tidas-tools`, load docs in this order:
+
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. this file
+4. `ai/validation.md` or `ai/architecture.md`
+5. `README.md` only for user-facing CLI examples
+
+## High-Frequency Task Routing
+
+| Task intent | First code paths to inspect | Next docs to load | Notes |
+| --- | --- | --- | --- |
+| Change standalone conversion behavior | `src/tidas_tools/convert.py`, then `src/tidas_tools/eilcd/**` or `src/tidas_tools/tidas/**` as needed | `ai/validation.md`, `ai/architecture.md` | Conversion logic belongs here, not in the SDK repo. |
+| Change standalone validation behavior | `src/tidas_tools/validate.py`, `src/tidas_tools/validation_report.py`, and `src/tidas_tools/tidas/schemas/**` | `ai/validation.md`, `ai/architecture.md` | Validation semantics and report structure live here. |
+| Change export behavior or version normalization | `src/tidas_tools/export.py`, `src/tidas_tools/package_versions.py` | `ai/validation.md`, `ai/architecture.md` | Export-only DB and S3 behavior belongs here. |
+| Change TIDAS schemas or methodologies that feed downstream packages | `src/tidas_tools/tidas/schemas/**`, `src/tidas_tools/tidas/methodologies/**` | `ai/architecture.md`, `ai/validation.md` | These paths are the current executable upstream for `tidas-sdk` refreshes. |
+| Change eILCD schemas or stylesheets | `src/tidas_tools/eilcd/schemas/**`, `src/tidas_tools/eilcd/stylesheets/**` | `ai/validation.md`, `ai/architecture.md` | These are packaged tooling assets, not the public docs site. |
+| Change downstream SDK dispatch behavior | `.github/workflows/dispatch-tidas-sdk-sync.yml` | `ai/validation.md`, `ai/architecture.md` | This repo owns the dispatch contract that tells `tidas-sdk` to refresh. |
+| Change generated SDK package surfaces | `tidas-sdk`, not this repo | root `ai/task-router.md` | Generated package output belongs downstream in `tidas-sdk`. |
+| Change public spec/docs wording only | `tidas`, not this repo | root `ai/task-router.md` | Public site content belongs in `tidas`. |
+| Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
+
+## Wrong Turns To Avoid
+
+### Fixing generated SDK output without fixing the upstream asset or script
+
+If the root cause lives in schemas, methodologies, or tooling logic here, fix it here first and then refresh `tidas-sdk`.
+
+### Treating packaged assets as docs-site only content
+
+The asset trees under `src/tidas_tools/**` are executable tooling inputs, not just published reference docs.
+
+### Treating export behavior as part of the SDK
+
+Database export and zip packaging stay in `tidas-tools`.
+
+## Cross-Repo Handoffs
+
+Use these handoffs when work crosses boundaries:
+
+1. upstream tooling change requires SDK refresh
+   - start here
+   - then update `tidas-sdk`
+2. public explanatory docs need to change as well
+   - update `tidas`
+3. merged repo PR still needs to ship through the workspace
+   - return to `lca-workspace`
+   - do the submodule pointer bump there

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -1,0 +1,63 @@
+---
+title: tidas-tools Validation Guide
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: tidas-tools
+language: en
+whenToUse:
+  - when a tidas-tools change is ready for local validation
+  - when deciding the minimum proof required for conversion, validation, export, asset, or automation changes
+  - when writing PR validation notes for tidas-tools work
+whenToUpdate:
+  - when the repo gains new canonical test wrappers
+  - when change categories require different proof
+  - when release or dispatch behavior changes
+checkPaths:
+  - ai/validation.md
+  - ai/task-router.md
+  - pyproject.toml
+  - src/tidas_tools/**
+  - tests/**
+  - .github/workflows/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 19d0d16cb047a533c9cc99f422eebff56e038ee4
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./architecture.md
+  - ../README.md
+---
+
+## Default Baseline
+
+Unless the change is doc-only, the default local baseline is:
+
+```bash
+uv sync --dev
+uv run pytest
+```
+
+Use narrower manual probes only when the task touches one CLI surface and full tests would add no extra signal.
+
+## Validation Matrix
+
+| Change type | Minimum local proof | Additional proof when risk is higher | Notes |
+| --- | --- | --- | --- |
+| `convert.py` or eILCD asset changes | `uv run pytest`; `uv run python src/tidas_tools/convert.py --help` | run one representative conversion path if the task explicitly changes data transformation behavior | Keep packaged asset and conversion logic aligned. |
+| `validate.py`, `validation_report.py`, or TIDAS schema changes | `uv run pytest`; `uv run python src/tidas_tools/validate.py --help` | run one representative validation path and record entity types touched | Validation categories and packaged schemas both matter here. |
+| `export.py` or `package_versions.py` changes | `uv run pytest`; `uv run python src/tidas_tools/export.py --help` | if the task includes live export proof, record the DB and S3 assumptions separately | Export behavior depends on external DB and object-storage state. |
+| packaged methodology or schema asset changes | `uv run pytest` | record whether `tidas-sdk` follow-up is required; run the relevant manual probe if a specific CLI surface depends on the asset | These paths are the current executable upstream for downstream package refresh. |
+| workflow or release automation changes | `uv run pytest` | inspect the touched workflow and record any tag or dispatch assumptions checked locally | Downstream dispatch and tag-based publish are separate from local tool tests. |
+| AI docs only | run the root warning-only `ai-doc-lint` against touched files | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
+
+## Minimum PR Note Quality
+
+A good PR note for this repo should say:
+
+1. whether `uv run pytest` ran
+2. which manual CLI probes ran, if any
+3. whether downstream `tidas-sdk` follow-up is required
+4. whether any export proof is deferred because it depends on live DB or storage state

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -51,7 +51,7 @@ Use narrower manual probes only when the task touches one CLI surface and full t
 | `export.py` or `package_versions.py` changes | `uv run pytest`; `uv run python src/tidas_tools/export.py --help` | if the task includes live export proof, record the DB and S3 assumptions separately | Export behavior depends on external DB and object-storage state. |
 | packaged methodology or schema asset changes | `uv run pytest` | record whether `tidas-sdk` follow-up is required; run the relevant manual probe if a specific CLI surface depends on the asset | These paths are the current executable upstream for downstream package refresh. |
 | workflow or release automation changes | `uv run pytest` | inspect the touched workflow and record any tag or dispatch assumptions checked locally | Downstream dispatch and tag-based publish are separate from local tool tests. |
-| AI docs only | run the root warning-only `ai-doc-lint` against touched files | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
+| AI docs only | run repo-local `ai-doc-lint` against touched files or the equivalent local PR check | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
 
 ## Minimum PR Note Quality
 


### PR DESCRIPTION
Closes tiangong-lca/tidas-tools#34

## Summary
- Add a checked-in AI contract layer with AGENTS.md and repo-local ai/*.md docs.
- Document standalone tooling ownership, validation entrypoints, and boundaries with tidas and tidas-sdk.

## Validation
- uv run pytest

## Workspace Integration
- If the merged doc change needs to ship in the workspace snapshot, bump the submodule in lca-workspace after merge.