### PR TITLE
Upgrade docpact CI pin to 0.1.4

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: 7984b9bc9f820da7bc31520e8334c9fddedc85d4
+lastReviewedAt: "2026-04-24"
+lastReviewedCommit: "d71f5dfa68aa49e10860ba6912a7c7ee91509989"
 
 catalog:
   repos:

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -20,7 +20,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
-        run: cargo install docpact --version 0.1.2 --force
+        run: cargo install docpact --version 0.1.4 --force
 
       - name: Validate docpact config
         run: docpact validate-config --root . --strict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ checkPaths:
   - test_data/**
   - .github/workflows/**
 lastReviewedAt: 2026-04-24
-lastReviewedCommit: d93cd6dcc3cddeedb16dd6a382e73de8e3eaae27
+lastReviewedCommit: d71f5dfa68aa49e10860ba6912a7c7ee91509989
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,7 +21,7 @@ checkPaths:
   - src/tidas_tools/**
   - .github/workflows/**
 lastReviewedAt: 2026-04-24
-lastReviewedCommit: d93cd6dcc3cddeedb16dd6a382e73de8e3eaae27
+lastReviewedCommit: d71f5dfa68aa49e10860ba6912a7c7ee91509989
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -23,7 +23,7 @@ checkPaths:
   - test_data/**
   - .github/workflows/**
 lastReviewedAt: 2026-04-24
-lastReviewedCommit: d93cd6dcc3cddeedb16dd6a382e73de8e3eaae27
+lastReviewedCommit: d71f5dfa68aa49e10860ba6912a7c7ee91509989
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes #38

## Summary
- Upgrade .github/workflows/ai-doc-lint.yml from docpact 0.1.2 to 0.1.4.
- Preserve the existing ai-doc-lint workflow/check name and command shape.
- Refresh governed doc review metadata required by the repo-local docpact rules for workflow changes.

## Key Decisions
- Do not change runtime code, package versions, release automation, or root workspace submodule pointers.

## Validation
- docpact validate-config --root . --strict with docpact 0.1.4.
- docpact lint --root . --worktree --mode enforce with docpact 0.1.4.
- docpact lint --root . --base origin/main --head HEAD --mode enforce with docpact 0.1.4.

## Risks / Rollback
- Root workspace integration remains pending until this child PR merges and the submodule pointer is deliberately bumped.

## Workspace Integration
- Part of tiangong-lca/workspace#77; child issue keeps Workspace Integration Pending.