### PR TITLE
fix: align lifecycle intendedApplications requirement

### DIFF
--- a/src/tidas_tools/tidas/schemas/tidas_lifecyclemodels.json
+++ b/src/tidas_tools/tidas/schemas/tidas_lifecyclemodels.json
@@ -1237,7 +1237,8 @@
                 }
               },
               "required": [
-                "common:referenceToCommissioner"
+                "common:referenceToCommissioner",
+                "common:intendedApplications"
               ]
             },
             "dataGenerator": {


### PR DESCRIPTION
Closes tiangong-lca/tidas-tools#40

## Summary
- Require common:intendedApplications in the lifecycle model commissionerAndGoal block so it matches the process schema.

## Key Decisions
- Keep the lifecycle model schema aligned with the process schema for this shared field requirement.

## Validation
- Loaded both JSON schema files with uv run python and confirmed the commissionerAndGoal required lists now match exactly.

## Risks / Rollback
- Low risk: the change only tightens lifecycle model validation for a field that the process schema already requires.

## Follow-ups
- If consumers rely on the looser lifecycle schema, they may need to backfill common:intendedApplications in existing data.

## Workspace Integration
- Requires a later lca-workspace submodule bump if this schema update should ship through the workspace.