### PR TITLE
Align common:other schema with ILCD extension container semantics

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-04-24"
-lastReviewedCommit: "d71f5dfa68aa49e10860ba6912a7c7ee91509989"
+lastReviewedAt: "2026-04-30"
+lastReviewedCommit: "745103e0005800aa00587e615516286c70e9fb15"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,8 @@ checkPaths:
   - tests/**
   - test_data/**
   - .github/workflows/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: d71f5dfa68aa49e10860ba6912a7c7ee91509989
+lastReviewedAt: 2026-04-30
+lastReviewedCommit: 745103e0005800aa00587e615516286c70e9fb15
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -20,8 +20,8 @@ checkPaths:
   - pyproject.toml
   - src/tidas_tools/**
   - .github/workflows/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: d71f5dfa68aa49e10860ba6912a7c7ee91509989
+lastReviewedAt: 2026-04-30
+lastReviewedCommit: 745103e0005800aa00587e615516286c70e9fb15
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,8 +22,8 @@ checkPaths:
   - tests/**
   - test_data/**
   - .github/workflows/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: d71f5dfa68aa49e10860ba6912a7c7ee91509989
+lastReviewedAt: 2026-04-30
+lastReviewedCommit: 745103e0005800aa00587e615516286c70e9fb15
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/src/tidas_tools/tidas/schemas/tidas_contacts.json
+++ b/src/tidas_tools/tidas/schemas/tidas_contacts.json
@@ -167,7 +167,7 @@
                       ]
                     },
                     "common:other": {
-                      "type": "string"
+                      "$ref": "tidas_data_types.json#/$defs/CommonOther"
                     }
                   },
                   "required": [
@@ -209,18 +209,18 @@
                   "description": "\"Source data set\" of the logo of the organisation or source to be used in reports etc."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
-                "common:UUID", 
-                "common:shortName", 
+                "common:UUID",
+                "common:shortName",
                 "common:name",
                 "classificationInformation"
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -242,11 +242,11 @@
                   "description": "\"Source data set\" of the used version of the ILCD format. If additional data format fields have been integrated into the data set file, using the \"namespace\" option, the used format namespace(s) are to be given. This is the case if the data sets carries additional information as specified by other, particular LCA formats, e.g. of other database networks or LCA softwares."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
-                "common:timeStamp", 
+                "common:timeStamp",
                 "common:referenceToDataSetFormat"
               ]
             },
@@ -271,7 +271,7 @@
                   "description": "\"Contact data set\" of the person or entity who owns this data set. (Note: this is not necessarily the publisher of the data set.)"
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -280,7 +280,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -289,7 +289,7 @@
           ]
         },
         "common:other": {
-          "type": "string"
+          "$ref": "tidas_data_types.json#/$defs/CommonOther"
         }
       },
       "required": [
@@ -303,7 +303,7 @@
       ]
     },
     "common:other": {
-      "type": "string"
+      "$ref": "tidas_data_types.json#/$defs/CommonOther"
     }
   },
   "required": [

--- a/src/tidas_tools/tidas/schemas/tidas_data_types.json
+++ b/src/tidas_tools/tidas/schemas/tidas_data_types.json
@@ -191,6 +191,54 @@
         }
       ]
     },
+    "AnyXmlElement": {
+      "description": "JSON representation of an arbitrary XML element payload.",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/AnyXmlElement"
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/AnyXmlElement"
+          }
+        }
+      ]
+    },
+    "CommonOther": {
+      "description": "ILCD common:other extension container. The container must include at least one non-common extension element; namespace declarations are allowed but do not count as extension content.",
+      "type": "object",
+      "patternProperties": {
+        "^@xmlns(:[A-Za-z_][A-Za-z0-9_.-]*)?$": {
+          "type": "string"
+        },
+        "^(?!(common|xmlns):)([A-Za-z_][A-Za-z0-9_.-]*:)?[A-Za-z_][A-Za-z0-9_.-]*$": {
+          "$ref": "#/$defs/AnyXmlElement"
+        }
+      },
+      "additionalProperties": false,
+      "not": {
+        "propertyNames": {
+          "pattern": "^@xmlns(:[A-Za-z_][A-Za-z0-9_.-]*)?$"
+        }
+      }
+    },
     "GlobalReferenceType": {
       "description": "Represents a reference to another dataset or file. In TIDAS, references must include type, refObjectId, version, uri, and shortDescription.",
       "anyOf": [

--- a/src/tidas_tools/tidas/schemas/tidas_flowproperties.json
+++ b/src/tidas_tools/tidas/schemas/tidas_flowproperties.json
@@ -76,7 +76,7 @@
                           ]
                         },
                         "common:other": {
-                          "type": "string"
+                          "$ref": "tidas_data_types.json#/$defs/CommonOther"
                         }
                       },
                       "required": [
@@ -93,7 +93,7 @@
                   "description": "Free text for general information about the data set. It may contain comments on e.g. information sources used as well as general (internal, not reviewed) quality statements."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -111,7 +111,7 @@
                   "description": "\"Unit group data set\" and its reference unit, in which the Flow property is measured."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -119,7 +119,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -139,7 +139,7 @@
                   "description": "\"Source data set\" of data source(s) used for the data set e.g. a paper, a questionnaire, a monography etc. The main raw data sources should be named, too. [Note: relevant especially for market price data.]"
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               }
             },
@@ -201,7 +201,7 @@
                   ]
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -209,7 +209,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -235,7 +235,7 @@
                   "$ref": "tidas_data_types.json#/$defs/GlobalReferenceType"
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -265,7 +265,7 @@
                   "description": "\"Contact data set\" of the person or entity who owns this data set. (Note: this is not necessarily the publisher of the data set.)"
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -274,7 +274,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -283,7 +283,7 @@
           ]
         },
         "common:other": {
-          "type": "string"
+          "$ref": "tidas_data_types.json#/$defs/CommonOther"
         }
       },
       "required": [

--- a/src/tidas_tools/tidas/schemas/tidas_flows.json
+++ b/src/tidas_tools/tidas/schemas/tidas_flows.json
@@ -59,7 +59,7 @@
                       "$ref": "tidas_data_types.json#/$defs/StringMultiLang"
                     },
                     "common:other": {
-                      "type": "string"
+                      "$ref": "tidas_data_types.json#/$defs/CommonOther"
                     }
                   },
                   "required": [
@@ -196,7 +196,7 @@
                           ]
                         },
                         "common:other": {
-                          "type": "string"
+                          "$ref": "tidas_data_types.json#/$defs/CommonOther"
                         }
                       },
                       "required": [
@@ -395,7 +395,7 @@
                           ]
                         },
                         "common:other": {
-                          "type": "string"
+                          "$ref": "tidas_data_types.json#/$defs/CommonOther"
                         }
                       },
                       "required": [
@@ -429,7 +429,7 @@
                   "description": "Free text for general information about the Flow data set. It may contain information about e.g. the use of the substance, good, service or process in a specific technology or industry-context, information sources used, data selection principles etc."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -445,7 +445,7 @@
                   "$ref": "tidas_data_types.json#/$defs/Int5"
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -459,7 +459,7 @@
                   "$ref": "tidas_locations_category.json"
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               }
             },
@@ -475,12 +475,12 @@
                   "description": "\"Source data set(s)\" of the product's or waste's technical specification, waste data sheet, safety data sheet, etc."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               }
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -503,7 +503,7 @@
                   ]
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -531,7 +531,7 @@
                           ]
                         },
                         "common:other": {
-                          "type": "string"
+                          "$ref": "tidas_data_types.json#/$defs/CommonOther"
                         }
                       },
                       "required": [
@@ -556,7 +556,7 @@
                             ]
                           },
                           "common:other": {
-                            "type": "string"
+                            "$ref": "tidas_data_types.json#/$defs/CommonOther"
                           }
                         },
                         "required": [
@@ -569,7 +569,7 @@
                   ]
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -577,7 +577,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -604,7 +604,7 @@
                   "description": "\"Contact data set\" of the responsible person or entity that has documented this data set, i.e. entered the data and the descriptive information."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -633,7 +633,7 @@
                   "description": "\"Contact data set\" of the person or entity who owns this data set. (Note: this is not necessarily the publisher of the data set.)"
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -642,7 +642,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -704,7 +704,7 @@
                       "$ref": "tidas_data_types.json#/$defs/StringMultiLang"
                     },
                     "common:other": {
-                      "type": "string"
+                      "$ref": "tidas_data_types.json#/$defs/CommonOther"
                     }
                   },
                   "required": [
@@ -764,7 +764,7 @@
                         "$ref": "tidas_data_types.json#/$defs/StringMultiLang"
                       },
                       "common:other": {
-                        "type": "string"
+                        "$ref": "tidas_data_types.json#/$defs/CommonOther"
                       }
                     },
                     "required": [
@@ -777,7 +777,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -785,7 +785,7 @@
           ]
         },
         "common:other": {
-          "type": "string"
+          "$ref": "tidas_data_types.json#/$defs/CommonOther"
         }
       },
       "required": [

--- a/src/tidas_tools/tidas/schemas/tidas_lciamethods.json
+++ b/src/tidas_tools/tidas/schemas/tidas_lciamethods.json
@@ -171,7 +171,7 @@
                           ]
                         },
                         "common:other": {
-                          "type": "string"
+                          "$ref": "tidas_data_types.json#/$defs/CommonOther"
                         }
                       },
                       "required": [
@@ -228,7 +228,7 @@
                   "description": "\"Source data set(s)\" of external documents / files with further documentative information on the data set including on underlying data sources (e.g. time, geographical coverage, impact models, characterisation factors, substance property databases employed, etc.). (Note: can indirectly reference to digital file.)"
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -246,7 +246,7 @@
                   "description": "\"Flow property data set\" of the reference quantity (flow property), in which the impact indicator values are measured."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -269,7 +269,7 @@
                   "description": "Description of the valid time span of the data set including information on limited usability within sub-time spans, if any."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -346,7 +346,7 @@
                   "description": "Further explanation on additional aspects of the location, both regarding the intervention and the impact: whether certain areas are exempted from the location, whether data is only valid for certain sub-locations within the location indicated, or whether impact indicator values for certain elementary flows are extrapolated from another geographical area than indicated. Information on the use of generic intervention and/or impact locations, and other restrictions."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               }
             },
@@ -379,7 +379,7 @@
                   "description": "\"Source data set(s)\" of flowchart(s) and/or pictures depicting the LCIA method(ology)."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -388,7 +388,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -494,7 +494,7 @@
                   "description": "\"Source data set(s)\" of the data source(s) used for the data set e.g. paper, questionnaire, monography etc. The main data sources e.g. for underlying substance properties are named, too."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -720,7 +720,7 @@
                       "description": "\"Source data set\" of the complete review report."
                     },
                     "common:other": {
-                      "type": "string"
+                      "$ref": "tidas_data_types.json#/$defs/CommonOther"
                     }
                   },
                   "required": [
@@ -748,7 +748,7 @@
                   ]
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -824,7 +824,7 @@
                           ]
                         },
                         "common:other": {
-                          "type": "string"
+                          "$ref": "tidas_data_types.json#/$defs/CommonOther"
                         }
                       },
                       "required": [
@@ -901,7 +901,7 @@
                             ]
                           },
                           "common:other": {
-                            "type": "string"
+                            "$ref": "tidas_data_types.json#/$defs/CommonOther"
                           }
                         },
                         "required": [
@@ -919,7 +919,7 @@
                   ]
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -927,7 +927,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -935,7 +935,7 @@
             "dataSources",
             "validation",
             "complianceDeclarations"
-          ] 
+          ]
         },
         "administrativeInformation": {
           "description": "Information required for data set management and administration.",
@@ -958,7 +958,7 @@
                   "description": "Documentation of the intended application(s) of data collection and data set modelling. This indicates / includes information on the level of detail, the specifidity, and the quality ambition in the effort."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               }
             },
@@ -971,7 +971,7 @@
                   "description": "\"Contact data set\" of the person(s), working group(s), organisation(s) or database network, that generated the data set, i.e. being responsible for its correctness regarding methods, inventory, and documentation."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -1028,7 +1028,7 @@
                   ]
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -1067,10 +1067,10 @@
                     "Final draft for external review",
                     "Data set finalised; unpublished",
                     "Under revision",
-                    "Withdrawn", 
+                    "Withdrawn",
                     "Data set finalised; subsystems published",
                     "Data set finalised; entirely published"
-                  ] 
+                  ]
                 },
                 "common:referenceToUnchangedRepublication": {
                   "$ref": "tidas_data_types.json#/$defs/GlobalReferenceType",
@@ -1093,7 +1093,7 @@
                   "description": "Access restrictions / use conditions for this data set as free text or referring to e.g. license conditions. In case of no restrictions \"None\" is entered."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -1103,7 +1103,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -1196,7 +1196,7 @@
                       "description": "General information about the data set, including e.g. general (internal, not reviewed) quality statements as well as information sources used. (Note: Please also check the more specific fields e.g. on \"Intended application\", \"Advice on data set use\" and the fields in the \"Modelling and validation\" section to avoid overlapping entries.)"
                     },
                     "common:other": {
-                      "type": "string"
+                      "$ref": "tidas_data_types.json#/$defs/CommonOther"
                     }
                   },
                   "required": [
@@ -1301,7 +1301,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -1309,7 +1309,7 @@
           ]
         },
         "common:other": {
-          "type": "string"
+          "$ref": "tidas_data_types.json#/$defs/CommonOther"
         }
       },
       "required": [

--- a/src/tidas_tools/tidas/schemas/tidas_lifecyclemodels.json
+++ b/src/tidas_tools/tidas/schemas/tidas_lifecyclemodels.json
@@ -66,7 +66,7 @@
                       "description": "Further, quantitative specifying information on the good, service or function in technical term(s): qualifying constituent(s)-content and / or energy-content per unit etc. as appropriate. Separated by commata. (Note: non-qualifying flow properties, CAS No, Synonyms, Chemical formulas etc. are to be documented exclusively in the \"Flow data set\" of the reference flow of this life cycle model.)"
                     },
                     "common:other": {
-                      "type": "string"
+                      "$ref": "tidas_data_types.json#/$defs/CommonOther"
                     }
                   },
                   "required": [
@@ -232,11 +232,11 @@
                                   }
                                 }
                               }
-                            }      
+                            }
                           ]
                         },
                         "common:other": {
-                          "type": "string"
+                          "$ref": "tidas_data_types.json#/$defs/CommonOther"
                         }
                       },
                       "required": [
@@ -261,7 +261,7 @@
                   "description": "\"Source data set(s)\" of detailed LCI or LCA study or other study on the process or product represented by this data set, as well as documents / files with overarching documentative information on technology, geographical and / or time aspects etc. on the level of the life cycle model. (Note: can indirectly reference to electronic and online files.)"
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -280,7 +280,7 @@
                   "pattern": "^-?\\d+$"
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -617,13 +617,13 @@
                                 }
                               },
                               "common:other": {
-                                "type": "string"
+                                "$ref": "tidas_data_types.json#/$defs/CommonOther"
                               }
                             },
                             "required": [
-                            "@dataSetInternalID",
-                            "@multiplicationFactor",
-                            "referenceToProcess"
+                              "@dataSetInternalID",
+                              "@multiplicationFactor",
+                              "referenceToProcess"
                             ]
                           }
                         },
@@ -804,8 +804,8 @@
                                                   }
                                                 },
                                                 "required": [
-                                                "@id",
-                                                "@flowUUID"
+                                                  "@id",
+                                                  "@flowUUID"
                                                 ]
                                               }
                                             }
@@ -863,8 +863,8 @@
                                                   }
                                                 },
                                                 "required": [
-                                                "@id",
-                                                "@flowUUID"
+                                                  "@id",
+                                                  "@flowUUID"
                                                 ]
                                               },
                                               {
@@ -891,7 +891,7 @@
                                                       "enum": [
                                                         "true",
                                                         "false"
-                                                      ] 
+                                                      ]
                                                     }
                                                   },
                                                   "required": [
@@ -917,13 +917,13 @@
                               ]
                             },
                             "common:other": {
-                              "type": "string"
+                              "$ref": "tidas_data_types.json#/$defs/CommonOther"
                             }
                           },
                           "required": [
-                          "@dataSetInternalID",
-                          "@multiplicationFactor",
-                          "referenceToProcess"
+                            "@dataSetInternalID",
+                            "@multiplicationFactor",
+                            "referenceToProcess"
                           ]
                         }
                       ]
@@ -935,7 +935,7 @@
                   "description": "\"Source data set\" of the flow diagramm(s), and/or screenshot(s) of the life cycle model represented by this data set. For clearer illustration and documentation of the model. Note: The source data set references the actual picture as jpd or png file or as e.g. pdf file with several pictures."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -962,7 +962,7 @@
                   "description": "Specific methodological advice for data set users that requires attention. E.g. on inclusion/exclusion of whole life cycle stages, specific use phase behavior to be modelled, and other methodological advices."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               }
             },
@@ -989,7 +989,7 @@
                           "description": "\"Source data set\" of the complete review report."
                         },
                         "common:other": {
-                          "type": "string"
+                          "$ref": "tidas_data_types.json#/$defs/CommonOther"
                         }
                       },
                       "required": [
@@ -1014,7 +1014,7 @@
                             "description": "\"Source data set\" of the complete review report."
                           },
                           "common:other": {
-                            "type": "string"
+                            "$ref": "tidas_data_types.json#/$defs/CommonOther"
                           }
                         },
                         "required": [
@@ -1025,7 +1025,7 @@
                   ]
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -1101,7 +1101,7 @@
                           ]
                         },
                         "common:other": {
-                          "type": "string"
+                          "$ref": "tidas_data_types.json#/$defs/CommonOther"
                         }
                       },
                       "required": [
@@ -1178,7 +1178,7 @@
                             ]
                           },
                           "common:other": {
-                            "type": "string"
+                            "$ref": "tidas_data_types.json#/$defs/CommonOther"
                           }
                         },
                         "required": [
@@ -1196,7 +1196,7 @@
                   ]
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -1204,7 +1204,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -1233,7 +1233,7 @@
                   "description": "Documentation of the intended application(s) of data collection and data set modelling. This indicates / includes information on the level of detail, the specifidity, and the quality ambition in the effort."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -1250,7 +1250,7 @@
                   "description": "\"Contact data set\" of the person(s), working group(s), organisation(s) or database network, that generated the data set, i.e. being responsible for its correctness regarding methods, inventory, and documentative information."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               }
             },
@@ -1271,7 +1271,7 @@
                   "description": "\"Contact data set\" of the responsible person or entity that has documented this data set, i.e. entered the data and the descriptive information."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -1286,7 +1286,7 @@
               "properties": {
                 "common:dataSetVersion": {
                   "type": "string",
-                  "description": "Version number of data set. First two digits refer to major updates, the second two digits to minor revisions and error corrections etc. The third three digits are intended for automatic and internal counting of versions during data set development. Together with the data set's UUID, the \"Data set version\" uniquely identifies each data set." 
+                  "description": "Version number of data set. First two digits refer to major updates, the second two digits to minor revisions and error corrections etc. The third three digits are intended for automatic and internal counting of versions during data set development. Together with the data set's UUID, the \"Data set version\" uniquely identifies each data set."
                 },
                 "common:referenceToPrecedingDataSetVersion": {
                   "$ref": "tidas_data_types.json#/$defs/GlobalReferenceType",
@@ -1307,7 +1307,7 @@
                   "enum": [
                     "true",
                     "false"
-                  ] 
+                  ]
                 },
                 "common:referenceToEntitiesWithExclusiveAccess": {
                   "$ref": "tidas_data_types.json#/$defs/GlobalReferenceType",
@@ -1329,7 +1329,7 @@
                   "description": "Access restrictions / use conditions for this data set as free text or referring to e.g. license conditions. In case of no restrictions \"None\" is entered."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -1341,7 +1341,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -1351,7 +1351,7 @@
           ]
         },
         "common:other": {
-          "type": "string"
+          "$ref": "tidas_data_types.json#/$defs/CommonOther"
         }
       },
       "required": [

--- a/src/tidas_tools/tidas/schemas/tidas_processes.json
+++ b/src/tidas_tools/tidas/schemas/tidas_processes.json
@@ -58,7 +58,7 @@
                       "$ref": "tidas_data_types.json#/$defs/StringMultiLang"
                     },
                     "common:other": {
-                      "type": "string"
+                      "$ref": "tidas_data_types.json#/$defs/CommonOther"
                     }
                   },
                   "required": [
@@ -240,11 +240,11 @@
                                   }
                                 }
                               }
-                            }      
+                            }
                           ]
                         },
                         "common:other": {
-                          "type": "string"
+                          "$ref": "tidas_data_types.json#/$defs/CommonOther"
                         }
                       },
                       "required": [
@@ -265,7 +265,7 @@
                   "description": "\"Source data set(s)\" of detailed LCA study on the process or product represented by this data set, as well as documents / files with overarching documentative information on technology, geographical and / or time aspects etc. (e.g. basic engineering studies, process simulation results, patents, plant documentation, model behind the parameterisation of the \"Mathematical model\" section, etc.) (Note: can indirectly reference to digital file.)"
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -295,7 +295,7 @@
                   "$ref": "tidas_data_types.json#/$defs/StringMultiLang"
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -319,7 +319,7 @@
                   "description": "Description of the valid time span of the data set including information on limited usability within sub-time spans, if any."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -345,7 +345,7 @@
                       "description": "Further explanations about additional aspects of the location: e.g. a company and/or site description and address, whether for certain sub-areas within the \"Location\" the data set is not valid, whether data is only valid for certain regions within the location indicated, or whether certain elementary flows or intermediate product flows are extrapolated from another geographical area."
                     },
                     "common:other": {
-                      "type": "string"
+                      "$ref": "tidas_data_types.json#/$defs/CommonOther"
                     }
                   },
                   "required": [
@@ -368,12 +368,12 @@
                       "description": "Further explanations about additional aspects of the location: e.g. a company and/or site description and address, whether for certain sub-areas within the \"Location\" the data set is not valid, whether data is only valid for certain regions within the location indicated, or whether certain elementary flows or intermediate product flows are extrapolated from another geographical area."
                     },
                     "common:other": {
-                      "type": "string"
+                      "$ref": "tidas_data_types.json#/$defs/CommonOther"
                     }
                   }
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -404,7 +404,7 @@
                   "description": "\"Source data set\" of the flow diagramm(s) and/or photo(s) of the good, service, technology, plant etc represented by this data set. For clearer illustration and documentation of data set."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -450,7 +450,7 @@
                         "normal",
                         "triangular",
                         "uniform"
-                      ] 
+                      ]
                     },
                     "relativeStandardDeviation95In": {
                       "$ref": "tidas_data_types.json#/$defs/Perc"
@@ -459,17 +459,17 @@
                       "$ref": "tidas_data_types.json#/$defs/StringMultiLang"
                     },
                     "common:other": {
-                      "type": "string"
+                      "$ref": "tidas_data_types.json#/$defs/CommonOther"
                     }
                   }
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               }
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -557,8 +557,8 @@
                   "description": "\"Source data set\"(s) where the generally used LCA methods including the LCI method principles and specific approaches, the modelling constants details, as well as any other applied methodological conventions are described."
                 },
                 "common:other": {
-                  "type": "string"
-              }
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
+                }
               },
               "required": [
                 "typeOfDataSet"
@@ -569,7 +569,7 @@
               "properties": {
                 "dataCutOffAndCompletenessPrinciples": {
                   "$ref": "tidas_data_types.json#/$defs/FTMultiLang",
-                  "description": "Principles applied in data collection regarding completeness of (also intermediate) product and waste flows and of elementary flows. Examples are: cut-off rules, systematic exclusion of infrastructure, services or auxiliaries, etc. systematic exclusion of air in incineration processes, coling water, etc."  
+                  "description": "Principles applied in data collection regarding completeness of (also intermediate) product and waste flows and of elementary flows. Examples are: cut-off rules, systematic exclusion of infrastructure, services or auxiliaries, etc. systematic exclusion of air in incineration processes, coling water, etc."
                 },
                 "deviationsFromCutOffAndCompletenessPrinciples": {
                   "$ref": "tidas_data_types.json#/$defs/FTMultiLang",
@@ -624,8 +624,8 @@
                   "description": "Specific methodological advice for data set users that requires attention. E.g. on inclusion/exclusion of recycling e.g. in material data sets, specific use phase behavior to be modelled, and other methodological advices. See also field \"Technological applicability\"."
                 },
                 "common:other": {
-                  "type": "string"
-              }
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
+                }
               },
               "required": [
                 "dataCutOffAndCompletenessPrinciples",
@@ -692,7 +692,7 @@
                   "description": "Completeness of coverage of elementary flows that contribute to other problem fields that are named here as free text, preferably using the same terminology as for the specified environmental problems."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               }
             },
@@ -985,7 +985,7 @@
                       "description": "\"Source data set\" of the complete review report."
                     },
                     "common:other": {
-                      "type": "string"
+                      "$ref": "tidas_data_types.json#/$defs/CommonOther"
                     }
                   },
                   "required": [
@@ -1013,7 +1013,7 @@
                   ]
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -1089,7 +1089,7 @@
                           ]
                         },
                         "common:other": {
-                          "type": "string"
+                          "$ref": "tidas_data_types.json#/$defs/CommonOther"
                         }
                       },
                       "required": [
@@ -1166,7 +1166,7 @@
                             ]
                           },
                           "common:other": {
-                            "type": "string"
+                            "$ref": "tidas_data_types.json#/$defs/CommonOther"
                           }
                         },
                         "required": [
@@ -1184,7 +1184,7 @@
                   ]
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -1192,14 +1192,14 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
             "LCIMethodAndAllocation",
             "validation",
             "complianceDeclarations"
-          ] 
+          ]
         },
         "administrativeInformation": {
           "description": "Information on data set management and administration.",
@@ -1222,7 +1222,7 @@
                   "description": "Documentation of the intended application(s) of data collection and data set modelling. This indicates / includes information on the level of detail, the specifidity, and the quality ambition in the effort."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -1239,7 +1239,7 @@
                   "description": "\"Contact data set\" of the person(s), working group(s), organisation(s) or database network, that generated the data set, i.e. being responsible for its correctness regarding methods, inventory, and documentation."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               }
             },
@@ -1267,7 +1267,7 @@
                   "description": "\"Source data set\": Names exclusively the producer or operator of the good, service or technology represented by this data set, which officially has approved this data set in all its parts. In case of nationally or internationally averaged data sets, this will be the respective business association. If no official approval has been given, the entry \"No official approval by producer or operator\" is to be entered and the reference will point to an empty \"Contact data set\". [Notes: The producer or operator may only be named here, if a written approval of this data set was given. A recognition of this data set by any other organisation then the producer/operator of the good, service, or process is not to be stated here, but as a \"review\" in the validation section.]"
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -1307,7 +1307,7 @@
                     "Final draft for external review",
                     "Data set finalised; unpublished",
                     "Under revision",
-                    "Withdrawn", 
+                    "Withdrawn",
                     "Data set finalised; subsystems published",
                     "Data set finalised; entirely published"
                   ]
@@ -1356,7 +1356,7 @@
                   "description": "Access restrictions / use conditions for this data set as free text or referring to e.g. license conditions. In case of no restrictions \"None\" is entered."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -1368,7 +1368,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -1494,7 +1494,7 @@
                         "description": "\"Source data set\" of data source(s) used for the value of this specific Input or Output, especially if differing from the general data source used for this data set."
                       },
                       "common:other": {
-                        "type": "string"
+                        "$ref": "tidas_data_types.json#/$defs/CommonOther"
                       }
                     }
                   },
@@ -1503,7 +1503,7 @@
                     "description": "General comment on this specific Input or Output, e.g. commenting on the data sources used and their specific representatuveness etc., on the status of \"finalisation\" of an entry as workflow information, etc."
                   },
                   "common:other": {
-                    "type": "string"
+                    "$ref": "tidas_data_types.json#/$defs/CommonOther"
                   }
                 },
                 "required": [
@@ -1517,7 +1517,7 @@
               }
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -1559,7 +1559,7 @@
                       "description": "General comment on this specific Input or Output, e.g. commenting on the data sources used and their specific representatuveness etc., on the status of \"finalisation\" of an entry as workflow information, etc."
                     },
                     "common:other": {
-                      "type": "string"
+                      "$ref": "tidas_data_types.json#/$defs/CommonOther"
                     }
                   },
                   "required": [
@@ -1598,7 +1598,7 @@
                         "description": "General comment on this specific Input or Output, e.g. commenting on the data sources used and their specific representatuveness etc., on the status of \"finalisation\" of an entry as workflow information, etc."
                       },
                       "common:other": {
-                        "type": "string"
+                        "$ref": "tidas_data_types.json#/$defs/CommonOther"
                       }
                     },
                     "required": [
@@ -1610,12 +1610,12 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           }
         },
         "common:other": {
-          "type": "string"
+          "$ref": "tidas_data_types.json#/$defs/CommonOther"
         }
       },
       "required": [

--- a/src/tidas_tools/tidas/schemas/tidas_sources.json
+++ b/src/tidas_tools/tidas/schemas/tidas_sources.json
@@ -72,7 +72,7 @@
                           }
                         },
                         "common:other": {
-                          "type": "string"
+                          "$ref": "tidas_data_types.json#/$defs/CommonOther"
                         }
                       },
                       "required": [
@@ -99,7 +99,7 @@
                     "Direct measurement",
                     "Oral communication",
                     "Personal written communication",
-                    "Questionnaire", 
+                    "Questionnaire",
                     "Software or database",
                     "Other unpublished and grey literature"
                   ]
@@ -127,7 +127,7 @@
                   "description": "\"Source data set\" of the logo of the organisation or source to be used in reports etc."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -137,7 +137,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -160,7 +160,7 @@
                   "description": "\"Source data set\" of the used version of the ILCD format. If additional data format fields have been integrated into the data set file, using the \"namespace\" option, the used format namespace(s) are to be given. This is the case if the data sets carries additional information as specified by other, particular LCA formats, e.g. of other database networks or LCA softwares."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -190,7 +190,7 @@
                   "description": "\"Contact data set\" of the person or entity who owns this data set. (Note: this is not necessarily the publisher of the data set.)"
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -199,7 +199,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -208,7 +208,7 @@
           ]
         },
         "common:other": {
-          "type": "string"
+          "$ref": "tidas_data_types.json#/$defs/CommonOther"
         }
       },
       "required": [

--- a/src/tidas_tools/tidas/schemas/tidas_unitgroups.json
+++ b/src/tidas_tools/tidas/schemas/tidas_unitgroups.json
@@ -75,7 +75,7 @@
                           }
                         },
                         "common:other": {
-                          "type": "string"
+                          "$ref": "tidas_data_types.json#/$defs/CommonOther"
                         }
                       },
                       "required": [
@@ -92,7 +92,7 @@
                   "description": "Free text for general information about the data set. E.g. coverage of different unit systems, information sources used, etc."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -105,10 +105,10 @@
               "type": "object",
               "properties": {
                 "referenceToReferenceUnit": {
-                   "$ref": "tidas_data_types.json#/$defs/Int5"
+                  "$ref": "tidas_data_types.json#/$defs/Int5"
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -116,7 +116,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -148,7 +148,7 @@
                           ]
                         },
                         "common:other": {
-                          "type": "string"
+                          "$ref": "tidas_data_types.json#/$defs/CommonOther"
                         }
                       },
                       "required": [
@@ -173,7 +173,7 @@
                             ]
                           },
                           "common:other": {
-                            "type": "string"
+                            "$ref": "tidas_data_types.json#/$defs/CommonOther"
                           }
                         },
                         "required": [
@@ -186,7 +186,7 @@
                   ]
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -194,7 +194,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -206,7 +206,7 @@
           "properties": {
             "dataEntryBy": {
               "type": "object",
-               "properties": {
+              "properties": {
                 "common:timeStamp": {
                   "$ref": "tidas_data_types.json#/$defs/dateTime",
                   "description": "Date and time stamp of data set generation, typically an automated entry (\"last saved\")."
@@ -216,7 +216,7 @@
                   "description": "\"Source data set\" of the used version of the ILCD format. If additional data format fields have been integrated into the data set file, using the \"namespace\" option, the used format namespace(s) are to be given. This is the case if the data sets carries additional information as specified by other, particular LCA formats, e.g. of other database networks or LCA softwares."
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -245,7 +245,7 @@
                   "description": "\"Contact data set\" of the person or entity who owns this data set. (Note: this is not necessarily the publisher of the data set.)"
                 },
                 "common:other": {
-                  "type": "string"
+                  "$ref": "tidas_data_types.json#/$defs/CommonOther"
                 }
               },
               "required": [
@@ -254,7 +254,7 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           },
           "required": [
@@ -284,7 +284,7 @@
                       "description": "General comment on each single unit, typically giving the long name and unit system from which this unit stems, and (if necessary) referring to specifc data sources used, or for workflow purposes about status of \"finalisation\" of an entry etc."
                     },
                     "common:other": {
-                      "type": "string"
+                      "$ref": "tidas_data_types.json#/$defs/CommonOther"
                     }
                   }
                 },
@@ -312,12 +312,12 @@
               ]
             },
             "common:other": {
-              "type": "string"
+              "$ref": "tidas_data_types.json#/$defs/CommonOther"
             }
           }
         },
         "common:other": {
-          "type": "string"
+          "$ref": "tidas_data_types.json#/$defs/CommonOther"
         }
       },
       "required": [

--- a/src/tidas_tools/validate.py
+++ b/src/tidas_tools/validate.py
@@ -9,12 +9,21 @@ import sys
 from jsonschema import Draft7Validator
 from referencing import Registry
 from referencing.jsonschema import DRAFT7
-from .tidas_log import setup_logging
-from .validation_report import (
-    ValidationIssue,
-    build_category_report,
-    build_package_report,
-)
+
+if __package__:
+    from .tidas_log import setup_logging
+    from .validation_report import (
+        ValidationIssue,
+        build_category_report,
+        build_package_report,
+    )
+else:
+    from tidas_tools.tidas_log import setup_logging
+    from tidas_tools.validation_report import (
+        ValidationIssue,
+        build_category_report,
+        build_package_report,
+    )
 
 import tidas_tools.tidas.schemas as schemas
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -111,6 +111,86 @@ def test_string_multilang_schema_accepts_valid_localized_text():
     assert errors == []
 
 
+def test_common_other_schema_accepts_non_common_extension_elements():
+    validator = build_data_type_validator("CommonOther")
+
+    errors = list(
+        validator.iter_errors(
+            {
+                "@xmlns:ecn": "http://echa.europa.eu/schema/ecn",
+                "ecn:ECNumber": "600-786-0",
+                "customElement": {
+                    "@unit": "kg",
+                    "#text": "1.0",
+                },
+            }
+        )
+    )
+
+    assert errors == []
+
+
+def test_common_other_schema_rejects_legacy_string_payload():
+    validator = build_data_type_validator("CommonOther")
+
+    errors = list(validator.iter_errors("legacy extension text"))
+
+    assert errors
+
+
+def test_common_other_schema_requires_extension_content():
+    validator = build_data_type_validator("CommonOther")
+
+    assert list(validator.iter_errors({}))
+    assert list(
+        validator.iter_errors({"@xmlns:ecn": "http://echa.europa.eu/schema/ecn"})
+    )
+
+
+def test_common_other_schema_rejects_common_namespace_children():
+    validator = build_data_type_validator("CommonOther")
+
+    errors = list(validator.iter_errors({"common:note": "not allowed here"}))
+
+    assert errors
+
+
+def test_common_other_schema_references_common_other_definition():
+    schema_dir = pkg_resources.files(schemas)
+    expected = {"$ref": "tidas_data_types.json#/$defs/CommonOther"}
+    mismatches = []
+
+    for schema_file_path in sorted(
+        item
+        for item in schema_dir.iterdir()
+        if item.name.startswith("tidas_") and item.name.endswith(".json")
+    ):
+        if schema_file_path.name in {
+            "tidas_data_types.json",
+            "tidas_flows_elementary_category.json",
+            "tidas_flows_product_category.json",
+            "tidas_processes_category.json",
+        }:
+            continue
+
+        schema = json.loads(schema_file_path.read_text(encoding="utf-8"))
+
+        def walk(node, path=""):
+            if isinstance(node, dict):
+                for key, value in node.items():
+                    child_path = f"{path}/{key}" if path else key
+                    if key == "common:other" and value != expected:
+                        mismatches.append(f"{schema_file_path.name}:{child_path}")
+                    walk(value, child_path)
+            elif isinstance(node, list):
+                for index, value in enumerate(node):
+                    walk(value, f"{path}/{index}")
+
+        walk(schema)
+
+    assert mismatches == []
+
+
 def test_validate_localized_text_language_constraints_reports_nested_paths():
     payload = {
         "processDataSet": {


### PR DESCRIPTION
Closes #42

## Summary
- Adds shared CommonOther and AnyXmlElement schema definitions matching the ILCD common:other extension-container shape.
- Replaces all packaged TIDAS schema common:other string definitions with CommonOther references.
- Keeps validate.py runnable through both the package entry point and the documented direct script probe.

## Key Decisions
- Proceed with strict object-only CommonOther after the accessible current database scan found no string-valued common:other records.
- Namespace declaration attributes such as @xmlns:ecn are allowed but do not count as extension content; at least one non-common extension element is required.
- Legacy string payloads are intentionally rejected by the schema and covered by tests.

## Validation
- DB scan via available Supabase publishable-key REST access: tiangong-lca-next/.env contacts rows=359, string common:other hits=0; other accessible TIDAS tables returned 0 rows.
- DB scan via available Supabase publishable-key REST access: tiangong-lca-next/.env.development contacts rows=352, string common:other hits=0; other accessible TIDAS tables returned 0 rows.
- uv run pytest
- uv run python src/tidas_tools/validate.py --help
- SDK example flow probe now reports 10 remaining schema issues and 0 common:other issues.

## Risks / Rollback
- Current shell/workspace did not include direct Postgres or service-role credentials, so the DB scan is limited to the rows visible through the available Supabase publishable-key REST environments.

## Follow-ups
- Regenerate/update downstream tidas-sdk generated TypeScript Zod and Python Pydantic surfaces after this schema change lands.

## Workspace Integration
- After merge, lca-workspace needs a tidas-tools submodule pointer bump when this schema snapshot should ship through the workspace.