### PR TITLE
chore: release tidas-tools 0.0.22

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-04-30"
-lastReviewedCommit: "745103e0005800aa00587e615516286c70e9fb15"
+lastReviewedAt: "2026-05-07"
+lastReviewedCommit: "384b5573dedcf2b0e6711fbf2292ef537b38f518"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,8 @@ checkPaths:
   - tests/**
   - test_data/**
   - .github/workflows/**
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 1137823f533dbef0be5d98fd14e5f22776d68830
+lastReviewedAt: 2026-05-07
+lastReviewedCommit: 384b5573dedcf2b0e6711fbf2292ef537b38f518
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -20,8 +20,8 @@ checkPaths:
   - pyproject.toml
   - src/tidas_tools/**
   - .github/workflows/**
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 1137823f533dbef0be5d98fd14e5f22776d68830
+lastReviewedAt: 2026-05-07
+lastReviewedCommit: 384b5573dedcf2b0e6711fbf2292ef537b38f518
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,8 +22,8 @@ checkPaths:
   - tests/**
   - test_data/**
   - .github/workflows/**
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 1137823f533dbef0be5d98fd14e5f22776d68830
+lastReviewedAt: 2026-05-07
+lastReviewedCommit: 384b5573dedcf2b0e6711fbf2292ef537b38f518
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidas-tools"
-version = "0.0.21"
+version = "0.0.22"
 description = "tidas-tools"
 authors = [
     { name = "Nan LI", email = "linanenv@gmail.com" },


### PR DESCRIPTION
## Summary
- bump tidas-tools package version to 0.0.22
- prepare the next PyPI release tag v0.0.22

## Validation
- uv sync --dev
- uv run pytest (14 passed)
- uv run python src/tidas_tools/validate.py --help
- uv run --with build python -m build
- verified wheel and sdist metadata report Version: 0.0.22