### PR TITLE
[codex] Add tidas-tools cross-platform CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: test (${{ matrix.os }} / ${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x64
+          - os: windows-latest
+            arch: x64
+          - os: macos-latest
+            arch: arm64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: python -m pip install --upgrade uv
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
## Summary
- Add a regular CI workflow for pull requests and main pushes.
- Run uv sync --dev and uv run pytest across ubuntu x64, windows x64, macOS arm64, and ubuntu arm64.

## Validation
- uv run --python 3.12 pytest
- scripts/docpact-gate.sh ran during push
- YAML syntax parsed locally before push
- GitHub Actions checks pending on this PR