### PR TITLE
fix: align process supply volume schema

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 5b9d2d7dec1d52a891aaf558c3e2318c9440595a
+lastReviewedAt: 2026-05-15
+lastReviewedCommit: 6e174e3d73457faeca32ef9ff3508c9640d757fe
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ checkPaths:
   - .githooks/**
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 5b9d2d7dec1d52a891aaf558c3e2318c9440595a
+lastReviewedAt: 2026-05-15
+lastReviewedCommit: 6e174e3d73457faeca32ef9ff3508c9640d757fe
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -23,8 +23,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 5b9d2d7dec1d52a891aaf558c3e2318c9440595a
+lastReviewedAt: 2026-05-15
+lastReviewedCommit: 6e174e3d73457faeca32ef9ff3508c9640d757fe
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 5b9d2d7dec1d52a891aaf558c3e2318c9440595a
+lastReviewedAt: 2026-05-15
+lastReviewedCommit: 6e174e3d73457faeca32ef9ff3508c9640d757fe
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/src/tidas_tools/tidas/schemas/tidas_processes.json
+++ b/src/tidas_tools/tidas/schemas/tidas_processes.json
@@ -604,7 +604,7 @@
                   "description": "Percentage of the overall supply, consumption, or production of the specific good, service, or technology represented by this data set, in the region/market of the stated \"Location\". For multi-functional processes the market share of the specific technology is stated. If data that is representative for a process operated in one \"Location\" is used for another \"Location\", the entry is '0'. The representativity for the original \"Location\" is documented in the field \"Deviation from data treatment and extrapolation principles, explanations\"."
                 },
                 "annualSupplyOrProductionVolume": {
-                  "$ref": "tidas_data_types.json#/$defs/StringMultiLang",
+                  "$ref": "tidas_data_types.json#/$defs/Real",
                   "description": "Supply / consumption or production volume of the specific good, service, or technology in the region/market of the stated \"Location\". The market volume is given in absolute numbers per year, in common units, for the stated \"Reference year\". For multi-fucntional processes the data should be given for all co-functions (good and services)."
                 },
                 "samplingProcedure": {
@@ -629,7 +629,8 @@
               },
               "required": [
                 "dataCutOffAndCompletenessPrinciples",
-                "referenceToDataSource"
+                "referenceToDataSource",
+                "annualSupplyOrProductionVolume"
               ]
             },
             "completeness": {

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -25,6 +25,29 @@ def build_data_type_validator(definition_name):
     )
 
 
+def load_tidas_schema(schema_name):
+    schema_file_path = pkg_resources.files(schemas) / schema_name
+    with schema_file_path.open() as schema_file:
+        return json.load(schema_file)
+
+
+def test_process_supply_volume_schema_contract():
+    schema = load_tidas_schema("tidas_processes.json")
+    data_sources_schema = schema["properties"]["processDataSet"]["properties"][
+        "modellingAndValidation"
+    ]["properties"]["dataSourcesTreatmentAndRepresentativeness"]
+
+    properties = data_sources_schema["properties"]
+
+    assert properties["annualSupplyOrProductionVolume"]["$ref"] == (
+        "tidas_data_types.json#/$defs/Real"
+    )
+    assert properties["percentageSupplyOrProductionCovered"]["$ref"] == (
+        "tidas_data_types.json#/$defs/Perc"
+    )
+    assert "annualSupplyOrProductionVolume" in data_sources_schema["required"]
+
+
 def test_category_validate(tmp_path):
     sources_dir = tmp_path / "sources"
     sources_dir.mkdir()


### PR DESCRIPTION
## Summary

- Change `annualSupplyOrProductionVolume` from `StringMultiLang` to the existing numeric `Real` schema type.
- Make `annualSupplyOrProductionVolume` required under `dataSourcesTreatmentAndRepresentativeness`.
- Add a regression test that locks `annualSupplyOrProductionVolume` as `Real`, keeps `percentageSupplyOrProductionCovered` as `Perc`, and checks required-field coverage.

Closes #50

## Validation

- `python3 -m json.tool src/tidas_tools/tidas/schemas/tidas_processes.json >/dev/null`
- `uv run pytest -q`
- `uv run python src/tidas_tools/validate.py --help >/dev/null`

## Follow-up

- Downstream `tidas-sdk` generation should consume this source schema change.
- `tiangong-lca-next` should adapt the process form/schema so this field is entered as a numeric value and saved as a TIDAS `Real` string.
