### PR TITLE
Fix annual supply volume localized text contract

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: 2026-05-15
-lastReviewedCommit: 6e174e3d73457faeca32ef9ff3508c9640d757fe
+lastReviewedAt: "2026-05-18"
+lastReviewedCommit: "d1274c18feff56d7e73d092225bf1e1c22882f7f"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ checkPaths:
   - .githooks/**
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-15
-lastReviewedCommit: 6e174e3d73457faeca32ef9ff3508c9640d757fe
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: d1274c18feff56d7e73d092225bf1e1c22882f7f
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -23,8 +23,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-15
-lastReviewedCommit: 6e174e3d73457faeca32ef9ff3508c9640d757fe
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: d1274c18feff56d7e73d092225bf1e1c22882f7f
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-15
-lastReviewedCommit: 6e174e3d73457faeca32ef9ff3508c9640d757fe
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: d1274c18feff56d7e73d092225bf1e1c22882f7f
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/src/tidas_tools/tidas/schemas/tidas_data_types.json
+++ b/src/tidas_tools/tidas/schemas/tidas_data_types.json
@@ -83,6 +83,36 @@
         }
       ]
     },
+    "AnnualSupplyOrProductionVolumeTextItem": {
+      "description": "Language-tagged annual supply or production volume text. The text must start with a real number followed by whitespace and a non-empty unit or context suffix.",
+      "allOf": [
+        {
+          "$ref": "#/$defs/LocalizedText500Item"
+        },
+        {
+          "properties": {
+            "#text": {
+              "pattern": "^[+-]?(\\d+(\\.\\d*)?|\\.\\d+)([Ee][+-]?\\d+)?\\s+\\S.*$"
+            }
+          }
+        }
+      ]
+    },
+    "AnnualSupplyOrProductionVolumeMultiLang": {
+      "description": "Multi-language annual supply or production volume text with a numeric prefix and unit or context suffix.",
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AnnualSupplyOrProductionVolumeTextItem"
+          },
+          "uniqueItems": true
+        },
+        {
+          "$ref": "#/$defs/AnnualSupplyOrProductionVolumeTextItem"
+        }
+      ]
+    },
     "LocalizedText1000Item": {
       "description": "Language-tagged text with a maximum length of 1000 characters.",
       "allOf": [

--- a/src/tidas_tools/tidas/schemas/tidas_processes.json
+++ b/src/tidas_tools/tidas/schemas/tidas_processes.json
@@ -604,7 +604,7 @@
                   "description": "Percentage of the overall supply, consumption, or production of the specific good, service, or technology represented by this data set, in the region/market of the stated \"Location\". For multi-functional processes the market share of the specific technology is stated. If data that is representative for a process operated in one \"Location\" is used for another \"Location\", the entry is '0'. The representativity for the original \"Location\" is documented in the field \"Deviation from data treatment and extrapolation principles, explanations\"."
                 },
                 "annualSupplyOrProductionVolume": {
-                  "$ref": "tidas_data_types.json#/$defs/Real",
+                  "$ref": "tidas_data_types.json#/$defs/AnnualSupplyOrProductionVolumeMultiLang",
                   "description": "Supply / consumption or production volume of the specific good, service, or technology in the region/market of the stated \"Location\". The market volume is given in absolute numbers per year, in common units, for the stated \"Reference year\". For multi-fucntional processes the data should be given for all co-functions (good and services)."
                 },
                 "samplingProcedure": {

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -40,12 +40,50 @@ def test_process_supply_volume_schema_contract():
     properties = data_sources_schema["properties"]
 
     assert properties["annualSupplyOrProductionVolume"]["$ref"] == (
-        "tidas_data_types.json#/$defs/Real"
+        "tidas_data_types.json#/$defs/AnnualSupplyOrProductionVolumeMultiLang"
     )
     assert properties["percentageSupplyOrProductionCovered"]["$ref"] == (
         "tidas_data_types.json#/$defs/Perc"
     )
     assert "annualSupplyOrProductionVolume" in data_sources_schema["required"]
+
+
+def test_annual_supply_volume_multilang_accepts_numeric_text_with_suffix():
+    validator = build_data_type_validator("AnnualSupplyOrProductionVolumeMultiLang")
+
+    assert (
+        list(validator.iter_errors({"@xml:lang": "en", "#text": "123 kg/year"})) == []
+    )
+    assert (
+        list(
+            validator.iter_errors(
+                [
+                    {"@xml:lang": "en", "#text": "1.23E+4 kg/year"},
+                    {"@xml:lang": "zh-CN", "#text": "123 千克/年"},
+                ]
+            )
+        )
+        == []
+    )
+
+
+def test_annual_supply_volume_multilang_rejects_missing_suffix():
+    validator = build_data_type_validator("AnnualSupplyOrProductionVolumeMultiLang")
+
+    assert list(validator.iter_errors({"@xml:lang": "en", "#text": "123"}))
+    assert list(validator.iter_errors({"@xml:lang": "en", "#text": "123 "}))
+
+
+def test_annual_supply_volume_multilang_rejects_non_numeric_prefix():
+    validator = build_data_type_validator("AnnualSupplyOrProductionVolumeMultiLang")
+
+    assert list(validator.iter_errors({"@xml:lang": "en", "#text": "abc kg/year"}))
+
+
+def test_annual_supply_volume_multilang_keeps_localized_language_rules():
+    validator = build_data_type_validator("AnnualSupplyOrProductionVolumeMultiLang")
+
+    assert list(validator.iter_errors({"@xml:lang": "en", "#text": "123 千克/年"}))
 
 
 def test_category_validate(tmp_path):


### PR DESCRIPTION
Closes tiangong-lca/tidas-tools#52

## Summary
- Adds a field-specific `AnnualSupplyOrProductionVolumeMultiLang` schema that preserves the `StringMultiLang` object/array shape.
- Constrains each localized `#text` value to a `Real`-compatible numeric prefix followed by whitespace and a non-empty unit/context suffix.
- Updates `tidas_processes.json` to use the new field-specific definition while keeping `annualSupplyOrProductionVolume` required.
- Records docpact review evidence for the governed asset/test contract docs required by this schema and test change.

## Key Decisions
- Do not modify the generic `StringMultiLang` definition, so unrelated localized text fields are unaffected.
- Keep `percentageSupplyOrProductionCovered` on `Perc` to preserve the separate percentage coverage contract.

## Validation
- `uv run pytest tests/test_validate.py::test_process_supply_volume_schema_contract tests/test_validate.py::test_annual_supply_volume_multilang_accepts_numeric_text_with_suffix tests/test_validate.py::test_annual_supply_volume_multilang_rejects_missing_suffix tests/test_validate.py::test_annual_supply_volume_multilang_rejects_non_numeric_prefix tests/test_validate.py::test_annual_supply_volume_multilang_keeps_localized_language_rules`
- `uv run pytest`
- `uv run black --target-version py312 --check tests/test_validate.py`
- `git diff --check`
- `docpact lint --root . --base origin/main --head HEAD --mode enforce --format json --output .docpact/runs/issue-52-after-review.json`

## Risks / Rollback
- External data missing `annualSupplyOrProductionVolume` will still fail validation because the field remains required by design.

## Follow-ups
- Sync `tidas-sdk` generated Python and TypeScript surfaces from this `tidas-tools` change after merge.

## Workspace Integration
- Workspace integration remains pending until the `tidas-tools` merge is eligible and `lca-workspace` bumps the submodule pointer.
