### PR TITLE
feat: 调整 exchange.location 为 location code 优先的 string 兼容 schema

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-18"
-lastReviewedCommit: "d1274c18feff56d7e73d092225bf1e1c22882f7f"
+lastReviewedCommit: "2bdd98c2339193752c3b968513c04c9aa64b4643"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: d1274c18feff56d7e73d092225bf1e1c22882f7f
+lastReviewedCommit: 2bdd98c2339193752c3b968513c04c9aa64b4643
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -24,7 +24,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: d1274c18feff56d7e73d092225bf1e1c22882f7f
+lastReviewedCommit: 2bdd98c2339193752c3b968513c04c9aa64b4643
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: d1274c18feff56d7e73d092225bf1e1c22882f7f
+lastReviewedCommit: 2bdd98c2339193752c3b968513c04c9aa64b4643
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/src/tidas_tools/tidas/schemas/tidas_processes.json
+++ b/src/tidas_tools/tidas/schemas/tidas_processes.json
@@ -1394,8 +1394,15 @@
                     "description": "\"Flow data set\" of this Input or Output."
                   },
                   "location": {
-                    "$ref": "tidas_data_types.json#/$defs/String",
-                    "description": "Location where exchange of elementary flow occurs. Used only for those LCIA methods, that make use of this information. This information refers to the entry within the same field in the \"Inputs and Outpts\" section of the \"Process or LCI result data set\"."
+                    "description": "Location where exchange of elementary flow occurs. For technosphere input exchanges this field may also identify the explicit supply-region anchor used by downstream provider-linking logic. Canonical values should use the predefined TIDAS/ILCD location category codes, while legacy non-empty string values remain accepted for external data compatibility.",
+                    "anyOf": [
+                      {
+                        "$ref": "tidas_locations_category.json"
+                      },
+                      {
+                        "$ref": "tidas_data_types.json#/$defs/String"
+                      }
+                    ]
                   },
                   "functionType": {
                     "type": "string",

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2,10 +2,12 @@ import importlib.resources as pkg_resources
 import json
 
 from jsonschema import Draft7Validator
+from referencing import Registry
 
 import tidas_tools.tidas.schemas as schemas
 from tidas_tools.validate import (
     category_validate,
+    retrieve_schema,
     validate_package_dir,
     validate_localized_text_language_constraints,
 )
@@ -31,6 +33,17 @@ def load_tidas_schema(schema_name):
         return json.load(schema_file)
 
 
+def build_tidas_schema_fragment_validator(schema_fragment):
+    return Draft7Validator(schema_fragment, registry=Registry(retrieve=retrieve_schema))
+
+
+def process_exchange_location_schema():
+    schema = load_tidas_schema("tidas_processes.json")
+    return schema["properties"]["processDataSet"]["properties"]["exchanges"][
+        "properties"
+    ]["exchange"]["items"]["properties"]["location"]
+
+
 def test_process_supply_volume_schema_contract():
     schema = load_tidas_schema("tidas_processes.json")
     data_sources_schema = schema["properties"]["processDataSet"]["properties"][
@@ -46,6 +59,36 @@ def test_process_supply_volume_schema_contract():
         "tidas_data_types.json#/$defs/Perc"
     )
     assert "annualSupplyOrProductionVolume" in data_sources_schema["required"]
+
+
+def test_process_exchange_location_schema_prefers_location_codes_but_keeps_string_compatibility():
+    location_schema = process_exchange_location_schema()
+
+    assert location_schema["anyOf"] == [
+        {"$ref": "tidas_locations_category.json"},
+        {"$ref": "tidas_data_types.json#/$defs/String"},
+    ]
+    assert "StringMultiLang" not in json.dumps(location_schema)
+
+
+def test_process_exchange_location_accepts_location_code_and_legacy_string():
+    validator = build_tidas_schema_fragment_validator(
+        process_exchange_location_schema()
+    )
+
+    assert list(validator.iter_errors("CN")) == []
+    assert list(validator.iter_errors("GLO")) == []
+    assert list(validator.iter_errors("Legacy plant area")) == []
+
+
+def test_process_exchange_location_rejects_empty_and_multilang_shapes():
+    validator = build_tidas_schema_fragment_validator(
+        process_exchange_location_schema()
+    )
+
+    assert list(validator.iter_errors(""))
+    assert list(validator.iter_errors({"@xml:lang": "en", "#text": "CN"}))
+    assert list(validator.iter_errors([{"@xml:lang": "en", "#text": "CN"}]))
 
 
 def test_annual_supply_volume_multilang_accepts_numeric_text_with_suffix():


### PR DESCRIPTION
Closes #54

## Summary
- 将 processDataSet.exchanges.exchange[].location 从直接 String ref 调整为 location category code 优先、String 兼容的字段级 schema。
- 保留 legacy non-empty string 兼容，同时明确 technosphere input exchange 可作为 downstream provider-linking 的 supply-region anchor。
- 补充 schema contract 测试，覆盖 location code、legacy string、空字符串和 StringMultiLang 形状。

## Key Decisions
- 不把 exchange.location 改为 StringMultiLang；location code 不是本地化文本。
- 不使用 oneOf；location enum code 同时也是合法 String，oneOf 会误拒 CN/GLO 等 canonical code。
- 强 enum 校验会破坏外部数据兼容，因此当前采用 anyOf 表达 enum-preferred / string-compatible。

## Validation
- uv run pytest tests/test_validate.py -k "exchange_location or supply_volume"
- uv run pytest
- uv run python src/tidas_tools/validate.py --help
- uv run black --check tests/test_validate.py
- uv run docpact validate-config --root . --strict --format json
- uv run docpact lint --root . --worktree --mode enforce --format json --output .docpact/runs/latest.json
- uv run docpact lint --root . --staged --mode enforce --format json --output .docpact/runs/latest.json
- git diff --check && git diff --cached --check

## Risks / Rollback
- Downstream tidas-sdk runtime schema assets and generated types need a follow-up sync after this PR merges.
- Schema remains intentionally compatible with arbitrary non-empty strings, so strict enum-only enforcement should be handled by frontend/profile guidance if needed later.

## Follow-ups
- Refs tiangong-lca/workspace#109.
- After merge, create/execute the tidas-sdk follow-up issue for runtime asset and generated SDK sync.

## Workspace Integration
- After merge, lca-workspace must update the tidas-tools submodule pointer when this schema change should ship through the workspace.