### PR TITLE
feat: validate CAS number checksums

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-19"
-lastReviewedCommit: "c5dbc9efe3c8af0817dd30a29594bd14830d0054"
+lastReviewedCommit: "f71a8dda00a63c744e20f292d534b9454fb702fa"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-19
-lastReviewedCommit: c5dbc9efe3c8af0817dd30a29594bd14830d0054
+lastReviewedCommit: f71a8dda00a63c744e20f292d534b9454fb702fa
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -24,7 +24,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-19
-lastReviewedCommit: c5dbc9efe3c8af0817dd30a29594bd14830d0054
+lastReviewedCommit: f71a8dda00a63c744e20f292d534b9454fb702fa
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-19
-lastReviewedCommit: c5dbc9efe3c8af0817dd30a29594bd14830d0054
+lastReviewedCommit: f71a8dda00a63c744e20f292d534b9454fb702fa
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidas-tools"
-version = "0.0.23"
+version = "0.0.24"
 description = "tidas-tools"
 authors = [
     { name = "Nan LI", email = "linanenv@gmail.com" },

--- a/src/tidas_tools/eilcd/schemas/ILCD_Common_DataTypes.xsd
+++ b/src/tidas_tools/eilcd/schemas/ILCD_Common_DataTypes.xsd
@@ -28,7 +28,7 @@ also available at http://lca.jrc.ec.europa.eu/eplca/doc/ILCD_format_and_editor_l
          <xs:documentation>CAS Number, leading zeros are requried.</xs:documentation>
       </xs:annotation>
       <xs:restriction base="xs:string">
-         <xs:pattern value="\d{2,7}-\d{2}-\d"/>
+         <xs:pattern value="[0-9]{2,7}-[0-9]{2}-[0-9]"/>
       </xs:restriction>
    </xs:simpleType>
    <xs:simpleType name="dateTime">

--- a/src/tidas_tools/tidas/schemas/tidas_data_types.json
+++ b/src/tidas_tools/tidas/schemas/tidas_data_types.json
@@ -4,6 +4,7 @@
     "CASNumber": {
       "description": "CAS Number, leading zeros are requried.",
       "type": "string",
+      "format": "cas-number",
       "pattern": "^[0-9]{2,7}-[0-9]{2}-[0-9]$"
     },
     "FT": {

--- a/src/tidas_tools/validate.py
+++ b/src/tidas_tools/validate.py
@@ -8,7 +8,7 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-from jsonschema import Draft7Validator
+from jsonschema import Draft7Validator, FormatChecker
 from lxml import etree
 from referencing import Registry
 from referencing.jsonschema import DRAFT7
@@ -32,6 +32,8 @@ import tidas_tools.tidas.schemas as schemas
 import tidas_tools.eilcd.schemas as eilcd_schemas
 
 CHINESE_CHARACTER_RE = re.compile(r"[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]")
+CAS_NUMBER_RE = re.compile(r"^[0-9]{2,7}-[0-9]{2}-[0-9]$")
+FORMAT_CHECKER = FormatChecker()
 SUPPORTED_CATEGORIES = [
     "contacts",
     "flowproperties",
@@ -89,6 +91,26 @@ ILCD_SCHEMA_BY_ROOT = {
         "ILCD_LCIAMethodologies.xsd",
     ),
 }
+
+
+def is_valid_cas_number(value: str) -> bool:
+    """Return True when a CAS number has valid structure and check digit."""
+    if not isinstance(value, str) or not CAS_NUMBER_RE.fullmatch(value):
+        return False
+
+    body, check_digit = value.rsplit("-", 1)
+    digits = body.replace("-", "")
+    checksum = sum(
+        int(digit) * weight for weight, digit in enumerate(reversed(digits), start=1)
+    )
+    return checksum % 10 == int(check_digit)
+
+
+@FORMAT_CHECKER.checks("cas-number")
+def _check_cas_number_format(value):
+    if not isinstance(value, str):
+        return True
+    return is_valid_cas_number(value)
 
 
 def validate_elementary_flows_classification_hierarchy(class_items):
@@ -491,7 +513,9 @@ def category_validate(json_file_path: str, category: str, emit_logs: bool = True
         # Add the main schema to the registry
         registry = registry.with_resource(schema_uri, DRAFT7.create_resource(schema))
         # Instantiate validator once per category for efficiency
-        validator = Draft7Validator(schema, registry=registry)
+        validator = Draft7Validator(
+            schema, registry=registry, format_checker=FORMAT_CHECKER
+        )
 
         for filename in sorted(os.listdir(json_file_path)):
             if filename.endswith(".json"):
@@ -615,6 +639,35 @@ def _lxml_error_to_issue(
     )
 
 
+def _collect_ilcd_cas_number_issues(
+    document: etree._ElementTree,
+    category: str,
+    file_path: str,
+) -> list[ValidationIssue]:
+    if category != "flows":
+        return []
+
+    namespaces = {"flow": "http://lca.jrc.it/ILCD/Flow"}
+    issues = []
+    for cas_number in document.xpath("//flow:CASNumber", namespaces=namespaces):
+        value = cas_number.text or ""
+        if not CAS_NUMBER_RE.fullmatch(value) or is_valid_cas_number(value):
+            continue
+
+        issues.append(
+            _make_issue(
+                issue_code="cas_number_checksum_error",
+                category=category,
+                file_path=file_path,
+                location=document.getpath(cas_number),
+                message=f"CASNumber '{value}' has an invalid check digit.",
+                context={"validator": "cas-number"},
+            )
+        )
+
+    return issues
+
+
 def validate_ilcd_file(
     xml_file_path: str | Path,
     schema_cache: dict[str, etree.XMLSchema] | None = None,
@@ -686,12 +739,9 @@ def validate_ilcd_file(
             ],
         )
 
-    if schema.validate(document):
-        return category, []
-
-    return (
-        category,
-        [
+    schema_issues = []
+    if not schema.validate(document):
+        schema_issues = [
             _lxml_error_to_issue(
                 issue_code="ilcd_schema_error",
                 category=category,
@@ -699,8 +749,10 @@ def validate_ilcd_file(
                 error=error,
             )
             for error in schema.error_log
-        ],
-    )
+        ]
+
+    schema_issues.extend(_collect_ilcd_cas_number_issues(document, category, file_path))
+    return category, schema_issues
 
 
 def validate_ilcd_package_dir(input_dir: str, emit_logs: bool = False):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2,12 +2,16 @@ import importlib.resources as pkg_resources
 import json
 
 from jsonschema import Draft7Validator
+from lxml import etree
 from referencing import Registry
 
 import tidas_tools.eilcd.stylesheets as eilcd_stylesheets
 import tidas_tools.tidas.schemas as schemas
 from tidas_tools.validate import (
+    FORMAT_CHECKER,
+    _collect_ilcd_cas_number_issues,
     category_validate,
+    is_valid_cas_number,
     retrieve_schema,
     validate_ilcd_package_dir,
     validate_package_dir,
@@ -25,7 +29,8 @@ def build_data_type_validator(definition_name):
             "$schema": root_schema["$schema"],
             "$defs": root_schema["$defs"],
             **root_schema["$defs"][definition_name],
-        }
+        },
+        format_checker=FORMAT_CHECKER,
     )
 
 
@@ -36,7 +41,11 @@ def load_tidas_schema(schema_name):
 
 
 def build_tidas_schema_fragment_validator(schema_fragment):
-    return Draft7Validator(schema_fragment, registry=Registry(retrieve=retrieve_schema))
+    return Draft7Validator(
+        schema_fragment,
+        registry=Registry(retrieve=retrieve_schema),
+        format_checker=FORMAT_CHECKER,
+    )
 
 
 def process_exchange_location_schema():
@@ -91,6 +100,62 @@ def test_process_exchange_location_rejects_empty_and_multilang_shapes():
     assert list(validator.iter_errors(""))
     assert list(validator.iter_errors({"@xml:lang": "en", "#text": "CN"}))
     assert list(validator.iter_errors([{"@xml:lang": "en", "#text": "CN"}]))
+
+
+def test_cas_number_checksum_validator():
+    assert is_valid_cas_number("64-17-5")
+    assert is_valid_cas_number("7732-18-5")
+    assert is_valid_cas_number("007732-18-5")
+    assert is_valid_cas_number("50-00-0")
+
+    assert not is_valid_cas_number("64-17-6")
+    assert not is_valid_cas_number("7732-18-4")
+    assert not is_valid_cas_number("")
+    assert not is_valid_cas_number("2023600")
+
+
+def test_tidas_cas_number_schema_enforces_checksum_format():
+    validator = build_data_type_validator("CASNumber")
+
+    assert list(validator.iter_errors("64-17-5")) == []
+
+    errors = list(validator.iter_errors("64-17-6"))
+
+    assert [error.validator for error in errors] == ["format"]
+
+
+def test_ilcd_cas_number_supplemental_validation_enforces_checksum():
+    document = etree.ElementTree(etree.fromstring("""
+            <flowDataSet xmlns="http://lca.jrc.it/ILCD/Flow">
+              <flowInformation>
+                <dataSetInformation>
+                  <CASNumber>64-17-6</CASNumber>
+                </dataSetInformation>
+              </flowInformation>
+            </flowDataSet>
+            """))
+
+    issues = _collect_ilcd_cas_number_issues(document, "flows", "flow.xml")
+
+    assert len(issues) == 1
+    assert issues[0].issue_code == "cas_number_checksum_error"
+    assert "invalid check digit" in issues[0].message
+
+
+def test_ilcd_cas_number_supplemental_validation_defers_structure_errors_to_xsd():
+    document = etree.ElementTree(etree.fromstring("""
+            <flowDataSet xmlns="http://lca.jrc.it/ILCD/Flow">
+              <flowInformation>
+                <dataSetInformation>
+                  <CASNumber>2023600</CASNumber>
+                  <CASNumber> 64-17-6 </CASNumber>
+                  <CASNumber />
+                </dataSetInformation>
+              </flowInformation>
+            </flowDataSet>
+            """))
+
+    assert _collect_ilcd_cas_number_issues(document, "flows", "flow.xml") == []
 
 
 def test_annual_supply_volume_multilang_accepts_numeric_text_with_suffix():


### PR DESCRIPTION
## Summary
- add CAS checksum validation for TIDAS JSON via the `cas-number` format
- add supplemental ILCD flow CAS checksum validation after XSD validation
- prepare version `0.0.24` for tag-driven PyPI release

## Validation
- `uv run black --check --target-version py313 src tests`
- `uv run pytest`
- `uv run python src/tidas_tools/validate.py --help`
- `/Users/davidli/.cargo/bin/docpact lint --root . --worktree --format json --output /tmp/tidas-tools-docpact-lint.json`
- pre-push docpact gate passed

## Notes
- No linked Issue for this user-requested release task.
- Workspace integration is still required after merge if this released tooling snapshot should be pinned in `lca-workspace`.
