### PR TITLE
fix: stabilize EcoSpold1 ILCD conversion

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-19"
-lastReviewedCommit: "f71a8dda00a63c744e20f292d534b9454fb702fa"
+lastReviewedAt: "2026-05-21"
+lastReviewedCommit: "03a10e0f3c0468d41a948becadf38402a7d5c5d9"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ checkPaths:
   - .githooks/**
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-19
-lastReviewedCommit: f71a8dda00a63c744e20f292d534b9454fb702fa
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 03a10e0f3c0468d41a948becadf38402a7d5c5d9
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -23,8 +23,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-19
-lastReviewedCommit: f71a8dda00a63c744e20f292d534b9454fb702fa
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 03a10e0f3c0468d41a948becadf38402a7d5c5d9
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-19
-lastReviewedCommit: f71a8dda00a63c744e20f292d534b9454fb702fa
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 03a10e0f3c0468d41a948becadf38402a7d5c5d9
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/src/tidas_tools/import_lca/adapters/ecospold1.py
+++ b/src/tidas_tools/import_lca/adapters/ecospold1.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 from typing import Iterable
 import uuid
 import zipfile
@@ -13,6 +14,10 @@ from .base import SourceAdapter
 from ..model import CanonicalEntity
 from ..report import ConversionReport
 from ..store import MemoryCanonicalStore
+
+UUID_RE = re.compile(
+    r"(?P<uuid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+)
 
 
 class EcoSpold1Adapter(SourceAdapter):
@@ -114,10 +119,14 @@ def _process_entity(dataset, label: str, index: int) -> CanonicalEntity:
         ],
     )
     name = name or f"EcoSpold 1 process {index}"
-    process_id = _stable_id(f"ecospold1/process/{label}/{index}/{name}")
+    filename_uuid = _uuid_from_label(label)
+    process_id = filename_uuid or _stable_id(
+        f"ecospold1/process/{label}/{index}/{name}"
+    )
     return CanonicalEntity(
         entity_type="processes",
         internal_id=process_id,
+        external_id=filename_uuid,
         name=name,
         raw={"description": f"Imported from EcoSpold 1 source {label}."},
     )
@@ -148,8 +157,10 @@ def _exchange(exchange, flow: CanonicalEntity, index: int) -> dict:
         or _attr(exchange, "meanAmount")
         or "0"
     )
+    source_number = _attr(exchange, "number")
     return {
-        "internalId": _attr(exchange, "number") or index,
+        "internalId": index,
+        "sourceExchangeNumber": source_number,
         "flow": {"@id": flow.internal_id, "name": flow.name},
         "flowRefId": flow.internal_id,
         "flowName": flow.name,
@@ -198,6 +209,11 @@ def _attr(element, name: str) -> str | None:
         return None
     value = value.strip()
     return value or None
+
+
+def _uuid_from_label(label: str) -> str | None:
+    match = UUID_RE.search(Path(label).name)
+    return match.group("uuid").lower() if match else None
 
 
 def _stable_id(seed: str) -> str:

--- a/src/tidas_tools/import_lca/adapters/ecospold1.py
+++ b/src/tidas_tools/import_lca/adapters/ecospold1.py
@@ -18,6 +18,7 @@ from ..store import MemoryCanonicalStore
 UUID_RE = re.compile(
     r"(?P<uuid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
 )
+FlowKey = tuple[str, ...]
 
 
 class EcoSpold1Adapter(SourceAdapter):
@@ -32,6 +33,7 @@ class EcoSpold1Adapter(SourceAdapter):
         report: ConversionReport,
     ) -> None:
         count = 0
+        flow_cache: dict[FlowKey, CanonicalEntity] = {}
         for label, data in _iter_xml_payloads(Path(source)):
             root = _parse_xml(data)
             if root is None:
@@ -49,8 +51,11 @@ class EcoSpold1Adapter(SourceAdapter):
                 for exchange_index, exchange in enumerate(
                     _exchange_elements(dataset), 1
                 ):
-                    flow = _flow_entity(exchange, label, exchange_index)
-                    store.add(flow)
+                    flow, is_new_flow = _cached_flow_entity(
+                        exchange, exchange_index, flow_cache
+                    )
+                    if is_new_flow:
+                        store.add(flow)
                     exchanges.append(_exchange(exchange, flow, exchange_index))
                 process.raw["exchanges"] = exchanges
                 store.add(process)
@@ -132,21 +137,54 @@ def _process_entity(dataset, label: str, index: int) -> CanonicalEntity:
     )
 
 
-def _flow_entity(exchange, label: str, index: int) -> CanonicalEntity:
-    name = (
-        _attr(exchange, "name") or _attr(exchange, "casNumber") or f"Exchange {index}"
-    )
+def _cached_flow_entity(
+    exchange, index: int, flow_cache: dict[FlowKey, CanonicalEntity]
+) -> tuple[CanonicalEntity, bool]:
+    key = _flow_key(exchange, index)
+    flow = flow_cache.get(key)
+    if flow is None:
+        flow = _flow_entity(exchange, index, key)
+        flow_cache[key] = flow
+        return flow, True
+    return flow, False
+
+
+def _flow_entity(exchange, index: int, key: FlowKey) -> CanonicalEntity:
+    name = _flow_name(exchange, index)
     category = _attr(exchange, "category")
     subcategory = _attr(exchange, "subCategory")
-    flow_id = _stable_id(
-        f"ecospold1/flow/{label}/{name}/{category}/{subcategory}/{_attr(exchange, 'unit')}"
-    )
+    flow_id = _stable_id(_flow_key_seed(key))
     return CanonicalEntity(
         entity_type="flows",
         internal_id=flow_id,
         name=name,
         category_path=[part for part in (category, subcategory) if part],
         raw={"flowType": _flow_type(exchange), "unitName": _attr(exchange, "unit")},
+    )
+
+
+def _flow_key(exchange, index: int) -> FlowKey:
+    return (
+        _key_text(_flow_type(exchange)),
+        _key_text(_flow_name(exchange, index)),
+        _key_text(_attr(exchange, "CASNumber")),
+        _key_text(_attr(exchange, "formula")),
+        _key_text(_attr(exchange, "category")),
+        _key_text(_attr(exchange, "subCategory")),
+        _key_text(_attr(exchange, "unit")),
+    )
+
+
+def _flow_key_seed(key: FlowKey) -> str:
+    return "ecospold1/flow/" + "\x1f".join(key)
+
+
+def _flow_name(exchange, index: int) -> str:
+    return (
+        _attr(exchange, "name")
+        or _attr(exchange, "CASNumber")
+        or _attr(exchange, "number")
+        or f"Exchange {index}"
     )
 
 
@@ -209,6 +247,12 @@ def _attr(element, name: str) -> str | None:
         return None
     value = value.strip()
     return value or None
+
+
+def _key_text(value: str | None) -> str:
+    if value is None:
+        return ""
+    return " ".join(value.strip().split()).casefold()
 
 
 def _uuid_from_label(label: str) -> str | None:

--- a/src/tidas_tools/import_lca/writers/tidas_json.py
+++ b/src/tidas_tools/import_lca/writers/tidas_json.py
@@ -24,6 +24,15 @@ DEFAULT_UNIT_GROUP_ID = str(
 DEFAULT_FLOW_PROPERTY_ID = str(
     uuid.uuid5(uuid.NAMESPACE_URL, "tidas-tools/import/default-flow-property")
 )
+PERMANENT_URI_BASE = "https://lcdn.tiangong.earth"
+PERMANENT_URI_PATHS = {
+    "contacts": "datasetdetail/contact.xhtml",
+    "flowproperties": "datasetdetail/flowproperty.xhtml",
+    "flows": "datasetdetail/productFlow.xhtml",
+    "lifecyclemodels": "datasetdetail/lifecyclemodel.xhtml",
+    "processes": "datasetdetail/process.xhtml",
+    "sources": "datasetdetail/source.xhtml",
+}
 
 
 def write_tidas_package(store: MemoryCanonicalStore, output_dir: str | Path) -> None:
@@ -152,7 +161,22 @@ def _owner_ref() -> dict[str, Any]:
     )
 
 
-def _admin_info(*, process: bool = False) -> dict[str, Any]:
+def _permanent_dataset_uri(
+    category: str, dataset_id: str, version: str = DEFAULT_VERSION
+) -> str:
+    if category == "unitgroups":
+        return f"{PERMANENT_URI_BASE}/unitgroups/{dataset_id}?version={version}"
+    path = PERMANENT_URI_PATHS[category]
+    return f"{PERMANENT_URI_BASE}/{path}?uuid={dataset_id}&version={version}"
+
+
+def _admin_info(
+    *,
+    category: str,
+    dataset_id: str,
+    version: str = DEFAULT_VERSION,
+    process: bool = False,
+) -> dict[str, Any]:
     data_entry = {
         "common:timeStamp": _now(),
         "common:referenceToDataSetFormat": _format_ref(),
@@ -160,11 +184,15 @@ def _admin_info(*, process: bool = False) -> dict[str, Any]:
     if process:
         data_entry["common:referenceToPersonOrEntityEnteringTheData"] = _owner_ref()
 
-    publication = {"common:dataSetVersion": DEFAULT_VERSION}
+    publication = {
+        "common:dataSetVersion": version,
+        "common:permanentDataSetURI": _permanent_dataset_uri(
+            category, dataset_id, version
+        ),
+    }
     if process:
         publication.update(
             {
-                "common:permanentDataSetURI": "https://tiangong.earth/tidas/import",
                 "common:referenceToOwnershipOfDataSet": _owner_ref(),
                 "common:copyright": "false",
                 "common:licenseType": "Free of charge for all users and uses",
@@ -265,7 +293,9 @@ def _contact_payload(
             "contactInformation": {
                 "dataSetInformation": dataset_info,
             },
-            "administrativeInformation": _admin_info(),
+            "administrativeInformation": _admin_info(
+                category="contacts", dataset_id=contact_id
+            ),
         }
     }
 
@@ -339,7 +369,9 @@ def _source_payload(
             "sourceInformation": {
                 "dataSetInformation": dataset_info,
             },
-            "administrativeInformation": _admin_info(),
+            "administrativeInformation": _admin_info(
+                category="sources", dataset_id=source_id
+            ),
         }
     }
 
@@ -394,7 +426,9 @@ def _unit_group_dataset(entity: CanonicalEntity) -> dict[str, Any]:
             "modellingAndValidation": {
                 "complianceDeclarations": _compliance_declarations()
             },
-            "administrativeInformation": _admin_info(),
+            "administrativeInformation": _admin_info(
+                category="unitgroups", dataset_id=entity.internal_id
+            ),
             "units": {"unit": unit_items},
         }
     }
@@ -440,7 +474,9 @@ def _flow_property_dataset(
             "modellingAndValidation": {
                 "complianceDeclarations": _compliance_declarations()
             },
-            "administrativeInformation": _admin_info(),
+            "administrativeInformation": _admin_info(
+                category="flowproperties", dataset_id=entity.internal_id
+            ),
         }
     }
 
@@ -493,7 +529,9 @@ def _flow_dataset(
                 "LCIMethod": {"typeOfDataSet": flow_type},
                 "complianceDeclarations": _compliance_declarations(),
             },
-            "administrativeInformation": _admin_info(),
+            "administrativeInformation": _admin_info(
+                category="flows", dataset_id=entity.internal_id
+            ),
             "flowProperties": {
                 "flowProperty": {
                     "@dataSetInternalID": "1",
@@ -597,7 +635,11 @@ def _process_dataset(entity: CanonicalEntity):
                     "common:referenceToCommissioner": _owner_ref(),
                     "common:intendedApplications": _ml("Converted external LCA data."),
                 },
-                **_admin_info(process=True),
+                **_admin_info(
+                    category="processes",
+                    dataset_id=entity.internal_id,
+                    process=True,
+                ),
             },
             "exchanges": {"exchange": exchange_items},
         }
@@ -612,8 +654,8 @@ def _exchange_item(exchange: dict[str, Any], idx: int) -> dict[str, Any]:
     flow_name = _extract_name(flow) or exchange.get("flowName") or "Flow"
     amount = _real(exchange.get("amount", 1))
     is_input = bool(exchange.get("isInput", False))
-    return {
-        "@dataSetInternalID": str(exchange.get("internalId") or idx),
+    item = {
+        "@dataSetInternalID": str(idx),
         "referenceToFlowDataSet": _ref(
             ref_type="flow data set",
             ref_id=flow_id,
@@ -625,6 +667,11 @@ def _exchange_item(exchange: dict[str, Any], idx: int) -> dict[str, Any]:
         "resultingAmount": amount,
         "dataDerivationTypeStatus": "Unknown derivation",
     }
+    if exchange.get("sourceExchangeNumber"):
+        item["generalComment"] = _ml(
+            f"Source EcoSpold1 exchange number: {exchange['sourceExchangeNumber']}."
+        )
+    return item
 
 
 def _reference_flow_id(exchange_items: list[dict[str, Any]]) -> str:

--- a/tests/test_import_lca_ecospold1.py
+++ b/tests/test_import_lca_ecospold1.py
@@ -138,6 +138,86 @@ def test_ecospold1_import_uses_filename_uuid_and_local_exchange_ids(tmp_path):
     )
 
 
+def test_ecospold1_import_merges_duplicate_flows_across_processes(tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    first_uuid = "00000000-0000-4000-8000-000000000001"
+    second_uuid = "00000000-0000-4000-8000-000000000002"
+    _write_ecospold1_process(
+        source_dir / f"process_{first_uuid}.xml",
+        process_name="market for steel",
+        product_name="steel",
+    )
+    _write_ecospold1_process(
+        source_dir / f"process_{second_uuid}.xml",
+        process_name="market for aluminium",
+        product_name="aluminium",
+    )
+
+    output_dir = tmp_path / "out"
+    status = main(
+        [
+            "--input",
+            str(source_dir),
+            "--output-dir",
+            str(output_dir),
+            "--target",
+            "both",
+        ]
+    )
+
+    report = json.loads(
+        (output_dir / "conversion-report.json").read_text(encoding="utf-8")
+    )
+    first_process = _read_process(output_dir / "tidas", first_uuid)
+    second_process = _read_process(output_dir / "tidas", second_uuid)
+    first_co2_ref = _flow_ref_for_exchange(first_process, "carbon dioxide")
+    second_co2_ref = _flow_ref_for_exchange(second_process, "carbon dioxide")
+
+    assert status == 0
+    assert report["validation"]["tidas"]["ok"] is True
+    assert report["validation"]["ilcd"]["ok"] is True
+    assert report["summary"]["processes"] == 2
+    assert report["summary"]["flows"] == 3
+    assert first_co2_ref == second_co2_ref
+    assert len(list((output_dir / "tidas" / "flows").glob("*.json"))) == 3
+
+
+def _write_ecospold1_process(path, *, process_name, product_name):
+    path.write_text(
+        f"""<?xml version="1.0" encoding="UTF-8"?>
+<ecoSpold xmlns="http://www.EcoInvent.org/EcoSpold01">
+  <dataset>
+    <metaInformation>
+      <processInformation>
+        <referenceFunction name="{process_name}" />
+      </processInformation>
+    </metaInformation>
+    <flowData>
+      <exchange number="1" name="{product_name}" unit="kg" amount="1" outputGroup="0" />
+      <exchange number="2" name="carbon dioxide" unit="kg" meanValue="2.5" outputGroup="4" category="air" subCategory="unspecified" />
+    </flowData>
+  </dataset>
+</ecoSpold>
+""",
+        encoding="utf-8",
+    )
+
+
+def _read_process(tidas_dir, process_id):
+    return json.loads(
+        (tidas_dir / "processes" / f"{process_id}.json").read_text(encoding="utf-8")
+    )["processDataSet"]
+
+
+def _flow_ref_for_exchange(process, flow_name):
+    for exchange in process["exchanges"]["exchange"]:
+        ref = exchange["referenceToFlowDataSet"]
+        if ref["common:shortDescription"]["#text"] == flow_name:
+            return ref["@refObjectId"]
+    raise AssertionError(f"Exchange not found: {flow_name}")
+
+
 def _has_flow_property(tidas_dir, expected_name):
     for path in (tidas_dir / "flowproperties").glob("*.json"):
         data = json.loads(path.read_text(encoding="utf-8"))

--- a/tests/test_import_lca_ecospold1.py
+++ b/tests/test_import_lca_ecospold1.py
@@ -50,6 +50,94 @@ def test_ecospold1_minimal_import_can_write_valid_tidas_and_ilcd(tmp_path):
     assert _has_flow_property(output_dir / "tidas", "Amount in kg")
 
 
+def test_ecospold1_import_uses_filename_uuid_and_local_exchange_ids(tmp_path):
+    process_uuid = "64e926e8-dd48-3704-b902-daaf546087c4"
+    source = tmp_path / f"process_{process_uuid}.xml"
+    source.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<ecoSpold xmlns="http://www.EcoInvent.org/EcoSpold01">
+  <dataset>
+    <metaInformation>
+      <processInformation>
+        <referenceFunction name="hemp lime concrete" />
+      </processInformation>
+    </metaInformation>
+    <flowData>
+      <exchange number="60865" name="Sodium" unit="kg" meanValue="1.0" outputGroup="4" category="emissions to water" subCategory="river" />
+      <exchange number="60865" name="Sodium" unit="kg" meanValue="2.0" outputGroup="4" category="emissions to water" subCategory="ocean" />
+      <exchange number="1" name="hemp lime concrete" unit="kg" amount="1" outputGroup="0" />
+    </flowData>
+  </dataset>
+</ecoSpold>
+""",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "out"
+    status = main(
+        [
+            "--input",
+            str(source),
+            "--output-dir",
+            str(output_dir),
+            "--target",
+            "both",
+        ]
+    )
+
+    report = json.loads(
+        (output_dir / "conversion-report.json").read_text(encoding="utf-8")
+    )
+    process_path = output_dir / "tidas" / "processes" / f"{process_uuid}.json"
+    process = json.loads(process_path.read_text(encoding="utf-8"))["processDataSet"]
+    exchanges = process["exchanges"]["exchange"]
+
+    assert status == 0
+    assert report["validation"]["tidas"]["ok"] is True
+    assert report["validation"]["ilcd"]["ok"] is True
+    assert (
+        process["processInformation"]["dataSetInformation"]["common:UUID"]
+        == process_uuid
+    )
+    assert process["administrativeInformation"]["publicationAndOwnership"][
+        "common:permanentDataSetURI"
+    ] == (
+        "https://lcdn.tiangong.earth/datasetdetail/process.xhtml?"
+        f"uuid={process_uuid}&version=00.00.001"
+    )
+    assert [exchange["@dataSetInternalID"] for exchange in exchanges] == [
+        "1",
+        "2",
+        "3",
+    ]
+    assert exchanges[0]["generalComment"]["#text"] == (
+        "Source EcoSpold1 exchange number: 60865."
+    )
+
+    flow = _find_flow(output_dir / "tidas", "hemp lime concrete")
+    flow_id = flow["flowDataSet"]["flowInformation"]["dataSetInformation"][
+        "common:UUID"
+    ]
+    assert flow["flowDataSet"]["administrativeInformation"]["publicationAndOwnership"][
+        "common:permanentDataSetURI"
+    ] == (
+        "https://lcdn.tiangong.earth/datasetdetail/productFlow.xhtml?"
+        f"uuid={flow_id}&version=00.00.001"
+    )
+
+    unitgroup = next((output_dir / "tidas" / "unitgroups").glob("*.json"))
+    unitgroup_id = unitgroup.stem
+    unitgroup_data = json.loads(unitgroup.read_text(encoding="utf-8"))[
+        "unitGroupDataSet"
+    ]
+    assert (
+        unitgroup_data["administrativeInformation"]["publicationAndOwnership"][
+            "common:permanentDataSetURI"
+        ]
+        == f"https://lcdn.tiangong.earth/unitgroups/{unitgroup_id}?version=00.00.001"
+    )
+
+
 def _has_flow_property(tidas_dir, expected_name):
     for path in (tidas_dir / "flowproperties").glob("*.json"):
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -59,3 +147,14 @@ def _has_flow_property(tidas_dir, expected_name):
         if name == expected_name:
             return True
     return False
+
+
+def _find_flow(tidas_dir, expected_name):
+    for path in (tidas_dir / "flows").glob("*.json"):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        name = data["flowDataSet"]["flowInformation"]["dataSetInformation"]["name"][
+            "baseName"
+        ]["#text"]
+        if name == expected_name:
+            return data
+    raise AssertionError(f"Flow not found: {expected_name}")


### PR DESCRIPTION
Closes #59

## Summary
- Reuse process UUIDs from source filenames when available.
- Generate category-specific permanentDataSetURI values for TIDAS datasets.
- Use local sequential ILCD exchange dataSetInternalID values while preserving source EcoSpold1 exchange numbers in comments.
- Deduplicate generated EcoSpold1 flow records by generated-flow identity fields, reducing the BAFU 2025 sample from 388,701 to 14,959 flows.

## Key Decisions
- Keep flow deduplication based on the fields represented in generated flow records: flow type, name, CAS number, formula, category, subcategory, and unit.
- Do not include process filename or source exchange number in flow UUID generation because they create process-local duplicates.

## Validation
- uv run black --check --target-version py313 src tests
- uv run pytest
- BAFU 2025 ecoSpold1 adapter count check: {'flows': 14959, 'processes': 11747}
- Generated BAFU 2025 ILCD output validates with 0 errors and 0 warnings.

## Risks / Rollback
- Low to medium risk: EcoSpold1 generated flow UUIDs change for duplicated flows, but process exchange references are updated consistently and schema validation passes.

## Follow-ups
- After merge, bump the tidas-tools submodule pointer in lca-workspace so the workspace uses the updated converter.

## Workspace Integration
- Workspace integration remains pending until the root submodule pointer is updated.