### PR TITLE
Improve EcoSpold2 import mapping and validation performance

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-21"
-lastReviewedCommit: "03a10e0f3c0468d41a948becadf38402a7d5c5d9"
+lastReviewedCommit: "2a93b8a63a04bb0c4ce05513faee6077972f82e3"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 03a10e0f3c0468d41a948becadf38402a7d5c5d9
+lastReviewedCommit: 2a93b8a63a04bb0c4ce05513faee6077972f82e3
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ tidas-import --input <source_file_or_dir> --output-dir <output_directory> --targ
 
 ### (1) Tool Functionalities
 
-This tool validates whether TIDAS JSON data or eILCD/ILCD XML data complies with the packaged schema standards.
+This tool validates whether TIDAS JSON data or eILCD/ILCD XML data complies with the packaged schema standards. TIDAS JSON validation uses a compiled schema fast path and falls back to complete error collection when a schema issue is found.
 
 ### (2) Command-line Arguments
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ is available.
 
 ```bash
 tidas-import --input <source_file_or_dir> --output-dir <output_directory> --detect-only
+tidas-import --input <source_file_or_dir> --output-dir <output_directory> --target both --validation-jobs 0
 ```
 
 ---
@@ -104,6 +105,7 @@ This tool validates whether TIDAS JSON data or eILCD/ILCD XML data complies with
 | `--input-dir` | `-i` | Directory containing data to validate |
 | `--verbose` | `-v` | Enable verbose logging |
 | `--data-format` | | Input data format to validate: `tidas`, `ilcd`, or `eilcd` (default: `tidas`) |
+| `--jobs` | | Number of parallel validation worker processes; use `0` for all CPU cores |
 
 ### (3) Usage Example
 
@@ -113,6 +115,9 @@ tidas-validate --input-dir <TIDAS_data_directory> --data-format tidas
 
 # Validate eILCD/ILCD XML data format
 tidas-validate --input-dir <eILCD_data_directory> --data-format ilcd
+
+# Validate large packages with all CPU cores
+tidas-validate --input-dir <TIDAS_data_directory> --data-format tidas --jobs 0
 ```
 
 ## 5. TIDAS Export Tool Documentation

--- a/README_CN.md
+++ b/README_CN.md
@@ -113,6 +113,7 @@ tidas-convert --input-dir <eILCD数据目录> --output-dir <TIDAS数据输出目
 
 ```bash
 tidas-import --input <源文件或目录> --output-dir <输出目录> --detect-only
+tidas-import --input <源文件或目录> --output-dir <输出目录> --target both --validation-jobs 0
 ```
 
 ---
@@ -131,6 +132,7 @@ tidas-import --input <源文件或目录> --output-dir <输出目录> --detect-o
 | `--input-dir` | `-i` | 待验证数据所在目录 |
 | `--verbose` | `-v` | 开启详细日志模式 |
 | `--data-format` | | 待验证的数据格式：`tidas`、`ilcd` 或 `eilcd`（默认：`tidas`） |
+| `--jobs` | | 并行校验进程数；使用 `0` 表示使用全部 CPU 核心 |
 
 ### （三）使用示例
 
@@ -140,6 +142,9 @@ tidas-validate --input-dir <TIDAS数据目录> --data-format tidas
 
 # 验证 eILCD/ILCD XML 数据格式
 tidas-validate --input-dir <eILCD数据目录> --data-format ilcd
+
+# 使用全部 CPU 核心校验大型数据包
+tidas-validate --input-dir <TIDAS数据目录> --data-format tidas --jobs 0
 ```
 
 ## 五、TIDAS 数据导出工具使用说明

--- a/README_CN.md
+++ b/README_CN.md
@@ -122,7 +122,7 @@ tidas-import --input <源文件或目录> --output-dir <输出目录> --target b
 
 ### （一）工具功能说明
 
-本工具用于验证 TIDAS JSON 数据或 eILCD/ILCD XML 数据是否符合随包提供的 schema 规范要求。
+本工具用于验证 TIDAS JSON 数据或 eILCD/ILCD XML 数据是否符合随包提供的 schema 规范要求。TIDAS JSON 校验会先使用编译型 schema 快速路径，发现 schema 问题时再回退到完整错误收集。
 
 ### （二）命令行参数说明
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,7 +25,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 03a10e0f3c0468d41a948becadf38402a7d5c5d9
+lastReviewedCommit: 2a93b8a63a04bb0c4ce05513faee6077972f82e3
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -63,7 +63,7 @@ This repo packages standalone tooling plus the schema, methodology, and styleshe
 
 ### Validation
 
-`validate.py` plus `validation_report.py` own standalone validation semantics and structured reporting. The validator covers TIDAS JSON with packaged JSON schemas and eILCD/ILCD XML with packaged XSD schemas.
+`validate.py` plus `validation_report.py` own standalone validation semantics and structured reporting. The validator covers TIDAS JSON with packaged JSON schemas and eILCD/ILCD XML with packaged XSD schemas. TIDAS JSON validation uses a compiled `fastjsonschema` fast path for files that pass schema validation, while falling back to `jsonschema` for complete error collection when the fast path detects a schema failure.
 
 ### Export
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 03a10e0f3c0468d41a948becadf38402a7d5c5d9
+lastReviewedCommit: 2a93b8a63a04bb0c4ce05513faee6077972f82e3
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "tqdm>=4.67.3",
     "xmltodict>=1.0.4",
     "PyYAML>=6.0.3",
+    "fastjsonschema>=2.21.2",
 ]
 
 [project.scripts]

--- a/src/tidas_tools/import_lca/adapters/ecospold2.py
+++ b/src/tidas_tools/import_lca/adapters/ecospold2.py
@@ -104,11 +104,13 @@ def _parse_xml(data: bytes):
 
 
 def _datasets(root) -> list:
-    datasets = root.xpath(".//*[local-name()='activityDataset']")
+    datasets = root.xpath(
+        ".//*[local-name()='activityDataset' or local-name()='childActivityDataset']"
+    )
     if datasets:
         return datasets
     local_name = etree.QName(root).localname
-    return [root] if local_name == "activityDataset" else []
+    return [root] if local_name in {"activityDataset", "childActivityDataset"} else []
 
 
 def _exchange_elements(dataset) -> list:
@@ -130,11 +132,13 @@ def _process_entity(dataset, label: str, index: int) -> CanonicalEntity:
     name = name or f"EcoSpold 2 activity {index}"
     activity_id = _attr(activity, "id") if activity is not None else None
     activity_uuid = _uuid_value(activity_id)
-    filename_uuid = _uuid_from_label(label)
-    process_id = (
-        activity_uuid
-        or filename_uuid
-        or _stable_id(f"ecospold2/process/{label}/{index}/{name}")
+    filename_uuids = _uuids_from_label(label)
+    process_id = _process_id(
+        label=label,
+        index=index,
+        name=name,
+        activity_uuid=activity_uuid,
+        filename_uuids=filename_uuids,
     )
     description = _first_text(
         dataset,
@@ -146,12 +150,14 @@ def _process_entity(dataset, label: str, index: int) -> CanonicalEntity:
     return CanonicalEntity(
         entity_type="processes",
         internal_id=process_id,
-        external_id=activity_id or filename_uuid,
+        external_id=activity_id or (filename_uuids[0] if filename_uuids else None),
         name=name,
         raw={
             "description": description or f"Imported from EcoSpold 2 source {label}.",
             "location": _location(dataset),
             "referenceYear": _reference_year(dataset),
+            "sourceActivityId": activity_id,
+            "sourceFileUUIDs": filename_uuids,
         },
     )
 
@@ -230,6 +236,21 @@ def _flow_name(element, index: int) -> str:
         )
         or f"EcoSpold 2 exchange {index}"
     )
+
+
+def _process_id(
+    *,
+    label: str,
+    index: int,
+    name: str,
+    activity_uuid: str | None,
+    filename_uuids: list[str],
+) -> str:
+    if len(filename_uuids) == 1:
+        return filename_uuids[0]
+    if len(filename_uuids) > 1:
+        return _stable_id(f"ecospold2/process/file/{Path(label).stem}")
+    return activity_uuid or _stable_id(f"ecospold2/process/{label}/{index}/{name}")
 
 
 def _exchange(element, flow: CanonicalEntity, index: int) -> dict[str, Any]:
@@ -420,9 +441,8 @@ def _key_text(value: str | None) -> str:
     return " ".join(value.strip().split()).casefold()
 
 
-def _uuid_from_label(label: str) -> str | None:
-    match = UUID_RE.search(Path(label).name)
-    return match.group("uuid").lower() if match else None
+def _uuids_from_label(label: str) -> list[str]:
+    return [match.group("uuid").lower() for match in UUID_RE.finditer(Path(label).name)]
 
 
 def _uuid_value(value: str | None) -> str | None:

--- a/src/tidas_tools/import_lca/adapters/ecospold2.py
+++ b/src/tidas_tools/import_lca/adapters/ecospold2.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 from typing import Any, Iterable
 import uuid
 import zipfile
@@ -13,6 +14,12 @@ from .base import SourceAdapter
 from ..model import CanonicalEntity
 from ..report import ConversionReport
 from ..store import MemoryCanonicalStore
+
+UUID_RE = re.compile(
+    r"(?P<uuid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+)
+YEAR_RE = re.compile(r"\b(?P<year>\d{4})\b")
+FlowKey = tuple[str, ...]
 
 
 class EcoSpold2Adapter(SourceAdapter):
@@ -27,6 +34,7 @@ class EcoSpold2Adapter(SourceAdapter):
         report: ConversionReport,
     ) -> None:
         count = 0
+        flow_cache: dict[str, CanonicalEntity] = {}
         for label, data in _iter_xml_payloads(Path(source)):
             root = _parse_xml(data)
             if root is None:
@@ -43,8 +51,11 @@ class EcoSpold2Adapter(SourceAdapter):
                 for exchange_index, element in enumerate(
                     _exchange_elements(dataset), 1
                 ):
-                    flow = _flow_entity(element, label, exchange_index)
-                    store.add(flow)
+                    flow, is_new_flow = _cached_flow_entity(
+                        element, exchange_index, flow_cache
+                    )
+                    if is_new_flow:
+                        store.add(flow)
                     exchanges.append(_exchange(element, flow, exchange_index))
                 process.raw["exchanges"] = _reference_first(exchanges)
                 store.add(process)
@@ -52,10 +63,7 @@ class EcoSpold2Adapter(SourceAdapter):
                 report.add_issue(
                     severity="warning",
                     code="ecospold2_minimal_mapping",
-                    message=(
-                        "Mapped EcoSpold 2 activity dataset with the current "
-                        "minimal adapter."
-                    ),
+                    message="Mapped EcoSpold 2 activity dataset.",
                     source_object=label,
                     context={
                         "process_id": process.internal_id,
@@ -121,10 +129,12 @@ def _process_entity(dataset, label: str, index: int) -> CanonicalEntity:
     )
     name = name or f"EcoSpold 2 activity {index}"
     activity_id = _attr(activity, "id") if activity is not None else None
+    activity_uuid = _uuid_value(activity_id)
+    filename_uuid = _uuid_from_label(label)
     process_id = (
-        activity_id
-        if _is_uuid(activity_id)
-        else _stable_id(f"ecospold2/process/{label}/{index}/{name}")
+        activity_uuid
+        or filename_uuid
+        or _stable_id(f"ecospold2/process/{label}/{index}/{name}")
     )
     description = _first_text(
         dataset,
@@ -136,32 +146,89 @@ def _process_entity(dataset, label: str, index: int) -> CanonicalEntity:
     return CanonicalEntity(
         entity_type="processes",
         internal_id=process_id,
-        external_id=activity_id,
+        external_id=activity_id or filename_uuid,
         name=name,
-        raw={"description": description or f"Imported from EcoSpold 2 source {label}."},
+        raw={
+            "description": description or f"Imported from EcoSpold 2 source {label}.",
+            "location": _location(dataset),
+            "referenceYear": _reference_year(dataset),
+        },
     )
 
 
-def _flow_entity(element, label: str, index: int) -> CanonicalEntity:
-    name = _first_text(element, [".//*[local-name()='name']/text()", ".//@name"])
-    name = name or f"EcoSpold 2 exchange {index}"
-    flow_external_id = (
+def _cached_flow_entity(
+    element, index: int, flow_cache: dict[str, CanonicalEntity]
+) -> tuple[CanonicalEntity, bool]:
+    flow_id = _flow_id(element, index)
+    flow = flow_cache.get(flow_id)
+    if flow is None:
+        flow = _flow_entity(element, index, flow_id)
+        flow_cache[flow_id] = flow
+        return flow, True
+    return flow, False
+
+
+def _flow_entity(element, index: int, flow_id: str) -> CanonicalEntity:
+    raw = {"flowType": _flow_type(element), "unitName": _unit_name(element)}
+    cas_number = _cas_number(element)
+    sum_formula = _sum_formula(element)
+    if cas_number:
+        raw["CASNumber"] = cas_number
+    if sum_formula:
+        raw["sumFormula"] = sum_formula
+    return CanonicalEntity(
+        entity_type="flows",
+        internal_id=flow_id,
+        external_id=_flow_external_id(element),
+        name=_flow_name(element, index),
+        category_path=_category_path(element),
+        raw=raw,
+    )
+
+
+def _flow_id(element, index: int) -> str:
+    flow_uuid = _uuid_value(_flow_external_id(element))
+    if flow_uuid:
+        return flow_uuid
+    return _stable_id(_flow_key_seed(_flow_key(element, index)))
+
+
+def _flow_external_id(element) -> str | None:
+    return (
         _attr(element, "intermediateExchangeId")
         or _attr(element, "elementaryExchangeId")
         or _attr(element, "id")
     )
-    flow_id = (
-        flow_external_id
-        if _is_uuid(flow_external_id)
-        else _stable_id(f"ecospold2/flow/{label}/{name}/{_flow_type(element)}")
+
+
+def _flow_key(element, index: int) -> FlowKey:
+    return (
+        _key_text(etree.QName(element).localname),
+        _key_text(_flow_type(element)),
+        _key_text(_flow_name(element, index)),
+        _key_text(_cas_number(element)),
+        _key_text(_sum_formula(element)),
+        _key_text(" / ".join(_category_path(element))),
+        _key_text(_unit_name(element)),
     )
-    return CanonicalEntity(
-        entity_type="flows",
-        internal_id=flow_id,
-        external_id=flow_external_id,
-        name=name,
-        category_path=_category_path(element),
-        raw={"flowType": _flow_type(element), "unitName": _unit_name(element)},
+
+
+def _flow_key_seed(key: FlowKey) -> str:
+    return "ecospold2/flow/" + "\x1f".join(key)
+
+
+def _flow_name(element, index: int) -> str:
+    return (
+        _first_text(
+            element,
+            [
+                "./*[local-name()='name']/text()",
+                "./@name",
+                ".//*[local-name()='name']/text()",
+                ".//@name",
+            ],
+        )
+        or f"EcoSpold 2 exchange {index}"
     )
 
 
@@ -169,12 +236,17 @@ def _exchange(element, flow: CanonicalEntity, index: int) -> dict[str, Any]:
     amount = _attr(element, "amount") or "0"
     return {
         "internalId": index,
+        "sourceExchangeId": _source_exchange_id(element),
         "flow": {"@id": flow.internal_id, "name": flow.name},
         "flowRefId": flow.internal_id,
         "flowName": flow.name,
         "isInput": _is_input(element),
         "amount": amount,
     }
+
+
+def _source_exchange_id(element) -> str | None:
+    return _attr(element, "id") or _flow_external_id(element)
 
 
 def _reference_first(exchanges: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -213,15 +285,95 @@ def _category_path(element) -> list[str]:
     compartment = _first_text(
         element,
         [
-            ".//*[local-name()='compartment']/*[local-name()='compartment']/text()",
-            ".//*[local-name()='classificationValue']/text()",
+            "./*[local-name()='compartment']/*[local-name()='compartment']/text()",
+            "./*[local-name()='compartment']/@compartment",
         ],
     )
     subcompartment = _first_text(
         element,
-        [".//*[local-name()='compartment']/*[local-name()='subcompartment']/text()"],
+        [
+            "./*[local-name()='compartment']/*[local-name()='subcompartment']/text()",
+            "./*[local-name()='compartment']/@subcompartment",
+        ],
     )
-    return [part for part in (compartment, subcompartment) if part]
+    parts = [part for part in (compartment, subcompartment) if part]
+    parts.extend(
+        value
+        for value in _all_texts(
+            element, [".//*[local-name()='classificationValue']/text()"]
+        )
+        if value not in parts
+    )
+    return parts
+
+
+def _cas_number(element) -> str | None:
+    return _first_text(
+        element,
+        [
+            "./*[local-name()='CASNumber']/text()",
+            "./*[local-name()='casNumber']/text()",
+            "./@CASNumber",
+            "./@casNumber",
+        ],
+    )
+
+
+def _sum_formula(element) -> str | None:
+    return _first_text(
+        element,
+        [
+            "./*[local-name()='sumFormula']/text()",
+            "./*[local-name()='formula']/text()",
+            "./@sumFormula",
+            "./@formula",
+            "./@chemicalFormula",
+        ],
+    )
+
+
+def _location(dataset) -> str | None:
+    value = _first_text(
+        dataset,
+        [
+            ".//*[local-name()='activityDescription']/*[local-name()='geography']/*[local-name()='shortname']/text()",
+            ".//*[local-name()='geography']/*[local-name()='shortname']/text()",
+            ".//*[local-name()='geography']/@shortname",
+            ".//*[local-name()='geography']/@location",
+            ".//*[local-name()='activity']/@geography",
+        ],
+    )
+    return _location_code(value)
+
+
+def _location_code(value: str | None) -> str | None:
+    if not value:
+        return None
+    text = value.strip()
+    if text.casefold() == "row":
+        return "GLO"
+    if text.upper() == text and re.fullmatch(r"[A-Z]{2,7}|EU-[A-Z0-9&-]+", text):
+        return text
+    return None
+
+
+def _reference_year(dataset) -> int | None:
+    value = _first_text(
+        dataset,
+        [
+            ".//*[local-name()='activityDescription']/*[local-name()='timePeriod']/*[local-name()='startDate']/text()",
+            ".//*[local-name()='timePeriod']/@startDate",
+            ".//*[local-name()='timePeriod']/@startYear",
+            ".//*[local-name()='timePeriod']/*[local-name()='startYear']/text()",
+            ".//*[local-name()='timePeriod']/*[local-name()='startDate']/text()",
+        ],
+    )
+    if not value:
+        return None
+    match = YEAR_RE.search(value)
+    if not match:
+        return None
+    return int(match.group("year"))
 
 
 def _first_element(element, expression: str):
@@ -241,6 +393,17 @@ def _first_text(element, expressions: list[str]) -> str | None:
     return None
 
 
+def _all_texts(element, expressions: list[str]) -> list[str]:
+    texts = []
+    for expression in expressions:
+        values = element.xpath(expression)
+        for value in values:
+            text = value if isinstance(value, str) else getattr(value, "text", None)
+            if text and text.strip():
+                texts.append(text.strip())
+    return texts
+
+
 def _attr(element, name: str) -> str | None:
     if element is None:
         return None
@@ -251,14 +414,24 @@ def _attr(element, name: str) -> str | None:
     return value or None
 
 
-def _is_uuid(value: str | None) -> bool:
+def _key_text(value: str | None) -> str:
+    if value is None:
+        return ""
+    return " ".join(value.strip().split()).casefold()
+
+
+def _uuid_from_label(label: str) -> str | None:
+    match = UUID_RE.search(Path(label).name)
+    return match.group("uuid").lower() if match else None
+
+
+def _uuid_value(value: str | None) -> str | None:
     if not value:
-        return False
+        return None
     try:
-        uuid.UUID(str(value))
+        return str(uuid.UUID(str(value)))
     except ValueError:
-        return False
-    return True
+        return None
 
 
 def _stable_id(seed: str) -> str:

--- a/src/tidas_tools/import_lca/cli.py
+++ b/src/tidas_tools/import_lca/cli.py
@@ -52,6 +52,7 @@ else:
 
 TARGETS = {"tidas", "ilcd", "both"}
 FROM_FORMATS = {"auto", *SUPPORTED_FORMATS}
+DEFAULT_VALIDATION_JOBS = 1
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -97,6 +98,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--fail-on-warning",
         action="store_true",
         help="Return a non-zero exit code when warnings are present.",
+    )
+    parser.add_argument(
+        "--validation-jobs",
+        type=int,
+        default=DEFAULT_VALIDATION_JOBS,
+        help=(
+            "Number of parallel validation worker processes. "
+            "Use 0 to use all CPU cores. Defaults to 1."
+        ),
     )
     parser.add_argument(
         "--detect-only",
@@ -226,7 +236,9 @@ def run_import(args: argparse.Namespace) -> int:
 
     tidas_dir = Path(report.tidas_dir)
     write_tidas_package(store, tidas_dir)
-    tidas_validation = validate_package_dir(str(tidas_dir), emit_logs=False)
+    tidas_validation = validate_package_dir(
+        str(tidas_dir), emit_logs=False, jobs=args.validation_jobs
+    )
     report.validation["tidas"] = tidas_validation
     if not tidas_validation["ok"]:
         report.add_issue(
@@ -242,7 +254,9 @@ def run_import(args: argparse.Namespace) -> int:
     if args.target in {"ilcd", "both"}:
         ilcd_dir = Path(report.ilcd_dir)
         write_ilcd_from_tidas(tidas_dir, ilcd_dir)
-        ilcd_validation = validate_ilcd_package_dir(str(ilcd_dir), emit_logs=False)
+        ilcd_validation = validate_ilcd_package_dir(
+            str(ilcd_dir), emit_logs=False, jobs=args.validation_jobs
+        )
         report.validation["ilcd"] = ilcd_validation
         if not ilcd_validation["ok"]:
             report.add_issue(

--- a/src/tidas_tools/import_lca/writers/tidas_json.py
+++ b/src/tidas_tools/import_lca/writers/tidas_json.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from functools import lru_cache
 import json
 from pathlib import Path
+import re
 from typing import Any
 import uuid
 
@@ -488,6 +490,16 @@ def _flow_dataset(
 ):
     flow_type = _flow_type(entity.raw.get("flowType"))
     classification = _flow_classification(flow_type)
+    dataset_info = {
+        "common:UUID": entity.internal_id,
+        "name": _name_parts(entity.name or "Flow"),
+        "classificationInformation": classification,
+    }
+    cas_number = _cas_number(entity.raw.get("CASNumber"))
+    if cas_number:
+        dataset_info["CASNumber"] = cas_number
+    if _text(entity.raw.get("sumFormula")):
+        dataset_info["sumFormula"] = str(entity.raw["sumFormula"]).strip()
     generated_flow_property = _generated_flow_property_for(entity, generated_units)
     flow_property_id = (
         entity.raw.get("flowPropertyRefId")
@@ -518,11 +530,7 @@ def _flow_dataset(
             "@locations": "../ILCDLocations.xml",
             "@xsi:schemaLocation": "http://lca.jrc.it/ILCD/Flow ../../schemas/ILCD_FlowDataSet.xsd",
             "flowInformation": {
-                "dataSetInformation": {
-                    "common:UUID": entity.internal_id,
-                    "name": _name_parts(entity.name or "Flow"),
-                    "classificationInformation": classification,
-                },
+                "dataSetInformation": dataset_info,
                 "quantitativeReference": {"referenceToReferenceFlowProperty": "1"},
             },
             "modellingAndValidation": {
@@ -554,6 +562,8 @@ def _process_dataset(entity: CanonicalEntity):
         _exchange_item(exchange, idx) for idx, exchange in enumerate(exchanges, 1)
     ]
     reference_flow = _reference_flow_id(exchange_items)
+    reference_year = _reference_year(entity.raw.get("referenceYear"))
+    location = _location_code(entity.raw.get("location"))
     if not exchange_items:
         exchange_items = [
             {
@@ -618,9 +628,9 @@ def _process_dataset(entity: CanonicalEntity):
                     "@type": "Reference flow(s)",
                     "referenceToReferenceFlow": reference_flow,
                 },
-                "time": {"common:referenceYear": 2026},
+                "time": {"common:referenceYear": reference_year},
                 "geography": {
-                    "locationOfOperationSupplyOrProduction": {"@location": "GLO"}
+                    "locationOfOperationSupplyOrProduction": {"@location": location}
                 },
             },
             "modellingAndValidation": {
@@ -670,6 +680,10 @@ def _exchange_item(exchange: dict[str, Any], idx: int) -> dict[str, Any]:
     if exchange.get("sourceExchangeNumber"):
         item["generalComment"] = _ml(
             f"Source EcoSpold1 exchange number: {exchange['sourceExchangeNumber']}."
+        )
+    elif exchange.get("sourceExchangeId"):
+        item["generalComment"] = _ml(
+            f"Source EcoSpold2 exchange id: {exchange['sourceExchangeId']}."
         )
     return item
 
@@ -751,6 +765,55 @@ def _generated_flow_property_for(
         return None
     generated = generated_units.get(str(unit_name).strip())
     return generated[1] if generated else None
+
+
+def _reference_year(value: Any) -> int:
+    if value is None:
+        return 2026
+    text = str(value).strip()
+    match = re.search(r"\b(\d{4})\b", text)
+    if not match:
+        return 2026
+    return int(match.group(1))
+
+
+def _cas_number(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text if re.fullmatch(r"[0-9]{2,7}-[0-9]{2}-[0-9]", text) else None
+
+
+def _location_code(value: Any) -> str:
+    if value is None:
+        return "GLO"
+    text = str(value).strip()
+    if not text:
+        return "GLO"
+    if text.casefold() == "row":
+        return "GLO"
+    if text in _location_codes():
+        return text
+    return "GLO"
+
+
+@lru_cache(maxsize=1)
+def _location_codes() -> frozenset[str]:
+    schema_path = (
+        Path(__file__).resolve().parents[2]
+        / "tidas"
+        / "schemas"
+        / "tidas_locations_category.json"
+    )
+    try:
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    except OSError:
+        return frozenset({"GLO"})
+    return frozenset(
+        option["const"]
+        for option in schema.get("oneOf", [])
+        if isinstance(option, dict) and isinstance(option.get("const"), str)
+    )
 
 
 def _flow_classification(flow_type: str) -> dict[str, Any]:

--- a/src/tidas_tools/validate.py
+++ b/src/tidas_tools/validate.py
@@ -1,5 +1,7 @@
 import argparse
+from collections.abc import Callable
 from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass
 from functools import lru_cache
 import importlib.resources as pkg_resources
 import json
@@ -10,6 +12,7 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+import fastjsonschema
 from jsonschema import Draft7Validator, FormatChecker
 from lxml import etree
 from referencing import Registry
@@ -95,8 +98,14 @@ ILCD_SCHEMA_BY_ROOT = {
     ),
 }
 _TIDAS_WORKER_CATEGORY: str | None = None
-_TIDAS_WORKER_VALIDATOR: Draft7Validator | None = None
+_TIDAS_WORKER_VALIDATOR: "TidasSchemaValidator | None" = None
 _ILCD_WORKER_SCHEMA_CACHE: dict[str, etree.XMLSchema] | None = None
+
+
+@dataclass(frozen=True)
+class TidasSchemaValidator:
+    strict_validator: Draft7Validator
+    fast_validator: Callable[[dict], dict] | None
 
 
 def is_valid_cas_number(value: str) -> bool:
@@ -114,6 +123,12 @@ def is_valid_cas_number(value: str) -> bool:
 
 @FORMAT_CHECKER.checks("cas-number")
 def _check_cas_number_format(value):
+    if not isinstance(value, str):
+        return True
+    return is_valid_cas_number(value)
+
+
+def _fast_check_cas_number_format(value):
     if not isinstance(value, str):
         return True
     return is_valid_cas_number(value)
@@ -437,9 +452,9 @@ def _collect_classification_issues(json_item: dict, category: str, file_path: st
     return issues
 
 
-def _collect_item_issues(
+def _collect_strict_schema_issues(
     validator: Draft7Validator, json_item: dict, category: str, file_path: str
-):
+) -> list[ValidationIssue]:
     issues = []
     try:
         for schema_error in validator.iter_errors(json_item):
@@ -467,6 +482,41 @@ def _collect_item_issues(
                 message=f"Validation error: {e}",
             )
         )
+
+    return issues
+
+
+def _collect_schema_issues(
+    validator: TidasSchemaValidator, json_item: dict, category: str, file_path: str
+) -> list[ValidationIssue]:
+    if validator.fast_validator is not None:
+        try:
+            validator.fast_validator(json_item)
+            return []
+        except fastjsonschema.JsonSchemaValueException:
+            pass
+        except fastjsonschema.JsonSchemaException as e:
+            logging.debug(
+                "fastjsonschema skipped for %s after validation engine error: %s",
+                file_path,
+                e,
+            )
+        except Exception as e:
+            logging.debug(
+                "fastjsonschema skipped for %s after unexpected error: %s",
+                file_path,
+                e,
+            )
+
+    return _collect_strict_schema_issues(
+        validator.strict_validator, json_item, category, file_path
+    )
+
+
+def _collect_item_issues(
+    validator: TidasSchemaValidator, json_item: dict, category: str, file_path: str
+):
+    issues = _collect_schema_issues(validator, json_item, category, file_path)
 
     localized_text_errors = validate_localized_text_language_constraints(json_item)
     for message in localized_text_errors:
@@ -514,6 +564,63 @@ def _load_tidas_schema(schema_filename: str) -> dict:
         return json.load(schema_file)
 
 
+def _fastjsonschema_schema_handler(uri: str) -> dict:
+    schema_name = Path(uri.split("#", 1)[0]).name
+    if not schema_name:
+        raise fastjsonschema.JsonSchemaDefinitionException(
+            f"Unsupported empty schema reference: {uri}"
+        )
+    schema = _load_tidas_schema(schema_name)
+    return _normalize_fastjsonschema_schema({**schema, "$id": schema_name})
+
+
+def _normalize_fastjsonschema_schema(node):
+    if isinstance(node, dict):
+        normalized = {
+            key: _normalize_fastjsonschema_schema(value) for key, value in node.items()
+        }
+        if normalized.get("then") == {}:
+            normalized.pop("then")
+        if normalized.get("else") == {}:
+            normalized.pop("else")
+        return normalized
+    if isinstance(node, list):
+        return [_normalize_fastjsonschema_schema(value) for value in node]
+    return node
+
+
+@lru_cache(maxsize=1)
+def _fastjsonschema_handlers() -> dict[str, Callable[[str], dict]]:
+    schemas_root = pkg_resources.files(schemas)
+    handlers: dict[str, Callable[[str], dict]] = {"": _fastjsonschema_schema_handler}
+    for schema_path in schemas_root.iterdir():
+        if not schema_path.name.startswith("tidas_") or not schema_path.name.endswith(
+            ".json"
+        ):
+            continue
+        handlers[schema_path.name] = _fastjsonschema_schema_handler
+        handlers[f"./{schema_path.name}"] = _fastjsonschema_schema_handler
+    return handlers
+
+
+def _compile_fast_tidas_schema_definition(
+    schema_id: str, schema_definition: dict
+) -> Callable[[dict], dict]:
+    schema = _normalize_fastjsonschema_schema({**schema_definition, "$id": schema_id})
+    return fastjsonschema.compile(
+        schema,
+        handlers=_fastjsonschema_handlers(),
+        formats={"cas-number": _fast_check_cas_number_format},
+        use_default=False,
+    )
+
+
+def _compile_fast_tidas_schema(schema_filename: str) -> Callable[[dict], dict]:
+    return _compile_fast_tidas_schema_definition(
+        schema_filename, _load_tidas_schema(schema_filename)
+    )
+
+
 @lru_cache(maxsize=1)
 def _tidas_schema_registry() -> Registry:
     registry = Registry(retrieve=retrieve_schema)
@@ -531,21 +638,31 @@ def _tidas_schema_registry() -> Registry:
     return registry.crawl()
 
 
-def _build_tidas_validator(category: str) -> Draft7Validator:
+def _build_tidas_validator(category: str) -> TidasSchemaValidator:
     schema_file_path = pkg_resources.files(schemas) / f"tidas_{category.lower()}.json"
     schema_uri = f"file://{schema_file_path}"
-    schema = {**_load_tidas_schema(schema_file_path.name), "$id": schema_uri}
-    return Draft7Validator(
-        schema,
+    strict_schema = {**_load_tidas_schema(schema_file_path.name), "$id": schema_uri}
+    strict_validator = Draft7Validator(
+        strict_schema,
         registry=_tidas_schema_registry(),
         format_checker=FORMAT_CHECKER,
     )
+    try:
+        fast_validator = _compile_fast_tidas_schema(schema_file_path.name)
+    except Exception as e:
+        logging.debug(
+            "fastjsonschema compilation skipped for %s: %s",
+            schema_file_path.name,
+            e,
+        )
+        fast_validator = None
+    return TidasSchemaValidator(strict_validator, fast_validator)
 
 
 def _collect_tidas_file_issues(
     full_path: str,
     category: str,
-    validator: Draft7Validator,
+    validator: TidasSchemaValidator,
 ) -> list[ValidationIssue]:
     try:
         with open(full_path, "r") as json_file:

--- a/src/tidas_tools/validate.py
+++ b/src/tidas_tools/validate.py
@@ -1,4 +1,6 @@
 import argparse
+from concurrent.futures import ProcessPoolExecutor
+from functools import lru_cache
 import importlib.resources as pkg_resources
 import json
 import logging
@@ -34,6 +36,7 @@ import tidas_tools.eilcd.schemas as eilcd_schemas
 CHINESE_CHARACTER_RE = re.compile(r"[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]")
 CAS_NUMBER_RE = re.compile(r"^[0-9]{2,7}-[0-9]{2}-[0-9]$")
 FORMAT_CHECKER = FormatChecker()
+DEFAULT_VALIDATION_JOBS = 1
 SUPPORTED_CATEGORIES = [
     "contacts",
     "flowproperties",
@@ -91,6 +94,9 @@ ILCD_SCHEMA_BY_ROOT = {
         "ILCD_LCIAMethodologies.xsd",
     ),
 }
+_TIDAS_WORKER_CATEGORY: str | None = None
+_TIDAS_WORKER_VALIDATOR: Draft7Validator | None = None
+_ILCD_WORKER_SCHEMA_CACHE: dict[str, etree.XMLSchema] | None = None
 
 
 def is_valid_cas_number(value: str) -> bool:
@@ -481,6 +487,7 @@ def _collect_item_issues(
     return issues
 
 
+@lru_cache(maxsize=None)
 def retrieve_schema(uri):
     """Custom retrieval function for schema references"""
     # Handle both local and remote references
@@ -500,56 +507,140 @@ def retrieve_schema(uri):
     return None
 
 
-def category_validate(json_file_path: str, category: str, emit_logs: bool = True):
+@lru_cache(maxsize=None)
+def _load_tidas_schema(schema_filename: str) -> dict:
+    schema_file_path = pkg_resources.files(schemas) / schema_filename
+    with schema_file_path.open() as schema_file:
+        return json.load(schema_file)
+
+
+@lru_cache(maxsize=1)
+def _tidas_schema_registry() -> Registry:
+    registry = Registry(retrieve=retrieve_schema)
+    schemas_root = pkg_resources.files(schemas)
+    schema_files = sorted(
+        schema_path
+        for schema_path in schemas_root.iterdir()
+        if schema_path.name.startswith("tidas_") and schema_path.name.endswith(".json")
+    )
+    for schema_path in schema_files:
+        registry = registry.with_resource(
+            f"file://{schema_path}",
+            DRAFT7.create_resource(_load_tidas_schema(schema_path.name)),
+        )
+    return registry.crawl()
+
+
+def _build_tidas_validator(category: str) -> Draft7Validator:
     schema_file_path = pkg_resources.files(schemas) / f"tidas_{category.lower()}.json"
     schema_uri = f"file://{schema_file_path}"
+    schema = {**_load_tidas_schema(schema_file_path.name), "$id": schema_uri}
+    return Draft7Validator(
+        schema,
+        registry=_tidas_schema_registry(),
+        format_checker=FORMAT_CHECKER,
+    )
+
+
+def _collect_tidas_file_issues(
+    full_path: str,
+    category: str,
+    validator: Draft7Validator,
+) -> list[ValidationIssue]:
+    try:
+        with open(full_path, "r") as json_file:
+            json_item = json.load(json_file)
+    except Exception as e:
+        return [
+            _make_issue(
+                issue_code="invalid_json",
+                category=category,
+                file_path=full_path,
+                message=f"Invalid JSON: {type(e).__name__}: {e}",
+            )
+        ]
+
+    return _collect_item_issues(validator, json_item, category, full_path)
+
+
+def _init_tidas_validation_worker(category: str) -> None:
+    global _TIDAS_WORKER_CATEGORY, _TIDAS_WORKER_VALIDATOR
+    _TIDAS_WORKER_CATEGORY = category
+    _TIDAS_WORKER_VALIDATOR = _build_tidas_validator(category)
+
+
+def _collect_tidas_file_issues_worker(full_path: str) -> list[ValidationIssue]:
+    if _TIDAS_WORKER_CATEGORY is None or _TIDAS_WORKER_VALIDATOR is None:
+        raise RuntimeError("TIDAS validation worker was not initialized")
+    return _collect_tidas_file_issues(
+        full_path, _TIDAS_WORKER_CATEGORY, _TIDAS_WORKER_VALIDATOR
+    )
+
+
+def _normalize_jobs(jobs: int | None) -> int:
+    if jobs is None:
+        return DEFAULT_VALIDATION_JOBS
+    if jobs <= 0:
+        return os.cpu_count() or 1
+    return jobs
+
+
+def _map_chunksize(item_count: int, jobs: int) -> int:
+    if item_count <= 0 or jobs <= 1:
+        return 1
+    return max(1, min(64, item_count // (jobs * 16) or 1))
+
+
+def category_validate(
+    json_file_path: str,
+    category: str,
+    emit_logs: bool = True,
+    jobs: int | None = DEFAULT_VALIDATION_JOBS,
+):
     issues = []
+    json_files = [
+        os.path.join(json_file_path, filename)
+        for filename in sorted(os.listdir(json_file_path))
+        if filename.endswith(".json")
+    ]
+    worker_count = min(_normalize_jobs(jobs), len(json_files)) if json_files else 1
 
-    with schema_file_path.open() as f:
-        schema = json.load(f)
-
-        # Create registry with our retrieve function
-        registry = Registry(retrieve=retrieve_schema)
-        # Add the main schema to the registry
-        registry = registry.with_resource(schema_uri, DRAFT7.create_resource(schema))
-        # Instantiate validator once per category for efficiency
-        validator = Draft7Validator(
-            schema, registry=registry, format_checker=FORMAT_CHECKER
+    if worker_count <= 1:
+        validator = _build_tidas_validator(category)
+        results = (
+            (full_path, _collect_tidas_file_issues(full_path, category, validator))
+            for full_path in json_files
         )
+    else:
+        with ProcessPoolExecutor(
+            max_workers=worker_count,
+            initializer=_init_tidas_validation_worker,
+            initargs=(category,),
+        ) as executor:
+            item_results = executor.map(
+                _collect_tidas_file_issues_worker,
+                json_files,
+                chunksize=_map_chunksize(len(json_files), worker_count),
+            )
+            results = zip(json_files, item_results)
 
-        for filename in sorted(os.listdir(json_file_path)):
-            if filename.endswith(".json"):
-                full_path = os.path.join(json_file_path, filename)
-                try:
-                    with open(full_path, "r") as json_file:
-                        json_item = json.load(json_file)
-                except Exception as e:
-                    issues.append(
-                        _make_issue(
-                            issue_code="invalid_json",
-                            category=category,
-                            file_path=full_path,
-                            message=f"Invalid JSON: {type(e).__name__}: {e}",
-                        )
-                    )
-                    continue
-
-                item_issues = _collect_item_issues(
-                    validator, json_item, category, full_path
-                )
-                issues.extend(item_issues)
-
-                if emit_logs:
-                    if item_issues:
-                        for issue in item_issues:
-                            logging.error(f"ERROR: {full_path} {issue.message}")
-                    else:
-                        logging.info(f"INFO: {full_path} PASSED.")
+    for full_path, item_issues in results:
+        issues.extend(item_issues)
+        if emit_logs:
+            if item_issues:
+                for issue in item_issues:
+                    logging.error(f"ERROR: {full_path} {issue.message}")
+            else:
+                logging.info(f"INFO: {full_path} PASSED.")
 
     return build_category_report(category, issues)
 
 
-def validate_package_dir(input_dir: str, emit_logs: bool = False):
+def validate_package_dir(
+    input_dir: str,
+    emit_logs: bool = False,
+    jobs: int | None = DEFAULT_VALIDATION_JOBS,
+):
     schemas_root = pkg_resources.files(schemas)
     category_reports = []
     for category in SUPPORTED_CATEGORIES:
@@ -570,7 +661,9 @@ def validate_package_dir(input_dir: str, emit_logs: bool = False):
                 )
             continue
 
-        category_report = category_validate(category_dir, category, emit_logs=emit_logs)
+        category_report = category_validate(
+            category_dir, category, emit_logs=emit_logs, jobs=jobs
+        )
         category_reports.append(category_report)
 
     return build_package_report(input_dir, category_reports)
@@ -755,13 +848,51 @@ def validate_ilcd_file(
     return category, schema_issues
 
 
-def validate_ilcd_package_dir(input_dir: str, emit_logs: bool = False):
+def _init_ilcd_validation_worker() -> None:
+    global _ILCD_WORKER_SCHEMA_CACHE
+    _ILCD_WORKER_SCHEMA_CACHE = {}
+
+
+def _validate_ilcd_file_worker(
+    xml_file_path: Path,
+) -> tuple[str, list[ValidationIssue]]:
+    if _ILCD_WORKER_SCHEMA_CACHE is None:
+        raise RuntimeError("ILCD validation worker was not initialized")
+    return validate_ilcd_file(xml_file_path, schema_cache=_ILCD_WORKER_SCHEMA_CACHE)
+
+
+def validate_ilcd_package_dir(
+    input_dir: str,
+    emit_logs: bool = False,
+    jobs: int | None = DEFAULT_VALIDATION_JOBS,
+):
     schema_cache: dict[str, etree.XMLSchema] = {}
     issues_by_category: dict[str, list[ValidationIssue]] = defaultdict(list)
     seen_categories = set()
+    xml_files = list(_iter_ilcd_xml_files(input_dir))
+    worker_count = min(_normalize_jobs(jobs), len(xml_files)) if xml_files else 1
 
-    for xml_file_path in _iter_ilcd_xml_files(input_dir):
-        category, issues = validate_ilcd_file(xml_file_path, schema_cache=schema_cache)
+    if worker_count <= 1:
+        results = (
+            (
+                xml_file_path,
+                validate_ilcd_file(xml_file_path, schema_cache=schema_cache),
+            )
+            for xml_file_path in xml_files
+        )
+    else:
+        with ProcessPoolExecutor(
+            max_workers=worker_count,
+            initializer=_init_ilcd_validation_worker,
+        ) as executor:
+            item_results = executor.map(
+                _validate_ilcd_file_worker,
+                xml_files,
+                chunksize=_map_chunksize(len(xml_files), worker_count),
+            )
+            results = zip(xml_files, item_results)
+
+    for xml_file_path, (category, issues) in results:
         seen_categories.add(category)
         issues_by_category[category].extend(issues)
 
@@ -805,6 +936,15 @@ def main():
         default="tidas",
         help="Input data format to validate. Defaults to TIDAS JSON.",
     )
+    parser.add_argument(
+        "--jobs",
+        type=int,
+        default=DEFAULT_VALIDATION_JOBS,
+        help=(
+            "Number of parallel validation worker processes. "
+            "Use 0 to use all CPU cores. Defaults to 1."
+        ),
+    )
     try:
         args = parser.parse_args()
 
@@ -815,14 +955,22 @@ def main():
         if args.report_format == "text":
             setup_logging(args.verbose, "validate")
             if data_format == "ilcd":
-                report = validate_ilcd_package_dir(args.input_dir, emit_logs=True)
+                report = validate_ilcd_package_dir(
+                    args.input_dir, emit_logs=True, jobs=args.jobs
+                )
             else:
-                report = validate_package_dir(args.input_dir, emit_logs=True)
+                report = validate_package_dir(
+                    args.input_dir, emit_logs=True, jobs=args.jobs
+                )
         else:
             if data_format == "ilcd":
-                report = validate_ilcd_package_dir(args.input_dir, emit_logs=False)
+                report = validate_ilcd_package_dir(
+                    args.input_dir, emit_logs=False, jobs=args.jobs
+                )
             else:
-                report = validate_package_dir(args.input_dir, emit_logs=False)
+                report = validate_package_dir(
+                    args.input_dir, emit_logs=False, jobs=args.jobs
+                )
             print(json.dumps(report, indent=2, ensure_ascii=False))
 
         if not report["ok"]:

--- a/tests/test_import_lca_ecospold2.py
+++ b/tests/test_import_lca_ecospold2.py
@@ -210,6 +210,54 @@ def test_ecospold2_import_keeps_distinct_native_flow_uuids(tmp_path):
     assert set(co2_refs) == {first_flow_id, second_flow_id}
 
 
+def test_ecospold2_import_reads_child_activity_datasets_without_process_collisions(
+    tmp_path,
+):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    activity_id = "bbbbbbbb-0000-4000-8000-000000000001"
+    first_product_id = "cccccccc-0000-4000-8000-000000000001"
+    second_product_id = "cccccccc-0000-4000-8000-000000000002"
+    _write_ecospold2_process(
+        source_dir / f"{activity_id}_{first_product_id}.spold",
+        process_name="multi output activity",
+        product_name="first reference product",
+        dataset_element="childActivityDataset",
+        activity_id=activity_id,
+        product_id=first_product_id,
+    )
+    _write_ecospold2_process(
+        source_dir / f"{activity_id}_{second_product_id}.spold",
+        process_name="multi output activity",
+        product_name="second reference product",
+        dataset_element="childActivityDataset",
+        activity_id=activity_id,
+        product_id=second_product_id,
+    )
+
+    output_dir = tmp_path / "out"
+    status = main(
+        [
+            "--input",
+            str(source_dir),
+            "--output-dir",
+            str(output_dir),
+            "--target",
+            "both",
+        ]
+    )
+
+    report = json.loads(
+        (output_dir / "conversion-report.json").read_text(encoding="utf-8")
+    )
+
+    assert status == 0
+    assert report["validation"]["tidas"]["ok"] is True
+    assert report["validation"]["ilcd"]["ok"] is True
+    assert report["summary"]["processes"] == 2
+    assert len(list((output_dir / "tidas" / "processes").glob("*.json"))) == 2
+
+
 def _has_flow_property(tidas_dir, expected_name):
     for path in (tidas_dir / "flowproperties").glob("*.json"):
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -221,18 +269,28 @@ def _has_flow_property(tidas_dir, expected_name):
     return False
 
 
-def _write_ecospold2_process(path, *, process_name, product_name):
+def _write_ecospold2_process(
+    path,
+    *,
+    process_name,
+    product_name,
+    dataset_element="activityDataset",
+    activity_id=None,
+    product_id=None,
+):
+    activity_attribute = f' id="{activity_id}"' if activity_id else ""
+    product_attribute = f' intermediateExchangeId="{product_id}"' if product_id else ""
     path.write_text(
         f"""<?xml version="1.0" encoding="UTF-8"?>
 <ecoSpold xmlns="http://www.EcoInvent.org/EcoSpold02">
-  <activityDataset>
+  <{dataset_element}>
     <activityDescription>
-      <activity>
+      <activity{activity_attribute}>
         <activityName xml:lang="en">{process_name}</activityName>
       </activity>
     </activityDescription>
     <flowData>
-      <intermediateExchange amount="1">
+      <intermediateExchange amount="1"{product_attribute}>
         <name xml:lang="en">{product_name}</name>
         <unitName xml:lang="en">kg</unitName>
         <outputGroup>0</outputGroup>
@@ -247,7 +305,7 @@ def _write_ecospold2_process(path, *, process_name, product_name):
         <outputGroup>4</outputGroup>
       </elementaryExchange>
     </flowData>
-  </activityDataset>
+  </{dataset_element}>
 </ecoSpold>
 """,
         encoding="utf-8",

--- a/tests/test_import_lca_ecospold2.py
+++ b/tests/test_import_lca_ecospold2.py
@@ -16,6 +16,12 @@ def test_ecospold2_minimal_import_can_write_valid_tidas_and_ilcd(tmp_path):
           <text xml:lang="en" index="1">Minimal EcoSpold 2 fixture</text>
         </generalComment>
       </activity>
+      <timePeriod>
+        <startDate>2024-01-01</startDate>
+      </timePeriod>
+      <geography>
+        <shortname xml:lang="en">CH</shortname>
+      </geography>
     </activityDescription>
     <flowData>
       <intermediateExchange id="11111111-1111-4111-8111-111111111111" amount="1">
@@ -30,6 +36,8 @@ def test_ecospold2_minimal_import_can_write_valid_tidas_and_ilcd(tmp_path):
       </intermediateExchange>
       <elementaryExchange id="44444444-4444-4444-8444-444444444444" amount="1.5">
         <name xml:lang="en">carbon dioxide</name>
+        <CASNumber>124-38-9</CASNumber>
+        <sumFormula>CO2</sumFormula>
         <unitName xml:lang="en">kg</unitName>
         <compartment>
           <compartment xml:lang="en">air</compartment>
@@ -67,6 +75,139 @@ def test_ecospold2_minimal_import_can_write_valid_tidas_and_ilcd(tmp_path):
     assert report["validation"]["tidas"]["ok"] is True
     assert report["validation"]["ilcd"]["ok"] is True
     assert _has_flow_property(output_dir / "tidas", "Amount in kg")
+    process = _read_process(
+        output_dir / "tidas", "22222222-2222-4222-8222-222222222222"
+    )
+    process_info = process["processInformation"]
+    assert process_info["time"]["common:referenceYear"] == 2024
+    assert (
+        process_info["geography"]["locationOfOperationSupplyOrProduction"]["@location"]
+        == "CH"
+    )
+    assert process["exchanges"]["exchange"][0]["generalComment"]["#text"] == (
+        "Source EcoSpold2 exchange id: 11111111-1111-4111-8111-111111111111."
+    )
+    co2 = _find_flow(output_dir / "tidas", "carbon dioxide")["flowDataSet"][
+        "flowInformation"
+    ]["dataSetInformation"]
+    assert co2["CASNumber"] == "124-38-9"
+    assert co2["sumFormula"] == "CO2"
+
+
+def test_ecospold2_import_uses_filename_uuid_and_merges_generated_flows(tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    first_uuid = "00000000-0000-4000-8000-000000000101"
+    second_uuid = "00000000-0000-4000-8000-000000000102"
+    _write_ecospold2_process(
+        source_dir / f"process_{first_uuid}.spold",
+        process_name="market for steel",
+        product_name="steel",
+    )
+    _write_ecospold2_process(
+        source_dir / f"process_{second_uuid}.spold",
+        process_name="market for aluminium",
+        product_name="aluminium",
+    )
+
+    output_dir = tmp_path / "out"
+    status = main(
+        [
+            "--input",
+            str(source_dir),
+            "--output-dir",
+            str(output_dir),
+            "--target",
+            "both",
+        ]
+    )
+
+    report = json.loads(
+        (output_dir / "conversion-report.json").read_text(encoding="utf-8")
+    )
+    first_process = _read_process(output_dir / "tidas", first_uuid)
+    second_process = _read_process(output_dir / "tidas", second_uuid)
+    first_co2_ref = _flow_ref_for_exchange(first_process, "carbon dioxide")
+    second_co2_ref = _flow_ref_for_exchange(second_process, "carbon dioxide")
+
+    assert status == 0
+    assert report["validation"]["tidas"]["ok"] is True
+    assert report["validation"]["ilcd"]["ok"] is True
+    assert report["summary"]["processes"] == 2
+    assert report["summary"]["flows"] == 3
+    assert first_co2_ref == second_co2_ref
+    assert len(list((output_dir / "tidas" / "flows").glob("*.json"))) == 3
+
+
+def test_ecospold2_import_keeps_distinct_native_flow_uuids(tmp_path):
+    source = tmp_path / "activity.spold"
+    first_flow_id = "aaaaaaaa-0000-4000-8000-000000000001"
+    second_flow_id = "aaaaaaaa-0000-4000-8000-000000000002"
+    source.write_text(
+        f"""<?xml version="1.0" encoding="UTF-8"?>
+<ecoSpold xmlns="http://www.EcoInvent.org/EcoSpold02">
+  <activityDataset>
+    <activityDescription>
+      <activity id="22222222-2222-4222-8222-222222222222">
+        <activityName xml:lang="en">market for duplicate named emissions</activityName>
+      </activity>
+    </activityDescription>
+    <flowData>
+      <intermediateExchange id="11111111-1111-4111-8111-111111111111" amount="1">
+        <name xml:lang="en">test product</name>
+        <unitName xml:lang="en">kg</unitName>
+        <outputGroup>0</outputGroup>
+      </intermediateExchange>
+      <elementaryExchange id="{first_flow_id}" amount="1.5">
+        <name xml:lang="en">carbon dioxide</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment>
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">low population density</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup>
+      </elementaryExchange>
+      <elementaryExchange id="{second_flow_id}" amount="2.5">
+        <name xml:lang="en">carbon dioxide</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment>
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">low population density</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup>
+      </elementaryExchange>
+    </flowData>
+  </activityDataset>
+</ecoSpold>
+""",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "out"
+    status = main(
+        [
+            "--input",
+            str(source),
+            "--output-dir",
+            str(output_dir),
+            "--target",
+            "both",
+        ]
+    )
+
+    report = json.loads(
+        (output_dir / "conversion-report.json").read_text(encoding="utf-8")
+    )
+    process = _read_process(
+        output_dir / "tidas", "22222222-2222-4222-8222-222222222222"
+    )
+    co2_refs = _flow_refs_for_exchanges(process, "carbon dioxide")
+
+    assert status == 0
+    assert report["validation"]["tidas"]["ok"] is True
+    assert report["validation"]["ilcd"]["ok"] is True
+    assert report["summary"]["flows"] == 3
+    assert set(co2_refs) == {first_flow_id, second_flow_id}
 
 
 def _has_flow_property(tidas_dir, expected_name):
@@ -78,3 +219,69 @@ def _has_flow_property(tidas_dir, expected_name):
         if name == expected_name:
             return True
     return False
+
+
+def _write_ecospold2_process(path, *, process_name, product_name):
+    path.write_text(
+        f"""<?xml version="1.0" encoding="UTF-8"?>
+<ecoSpold xmlns="http://www.EcoInvent.org/EcoSpold02">
+  <activityDataset>
+    <activityDescription>
+      <activity>
+        <activityName xml:lang="en">{process_name}</activityName>
+      </activity>
+    </activityDescription>
+    <flowData>
+      <intermediateExchange amount="1">
+        <name xml:lang="en">{product_name}</name>
+        <unitName xml:lang="en">kg</unitName>
+        <outputGroup>0</outputGroup>
+      </intermediateExchange>
+      <elementaryExchange amount="2.5">
+        <name xml:lang="en">carbon dioxide</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment>
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">unspecified</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup>
+      </elementaryExchange>
+    </flowData>
+  </activityDataset>
+</ecoSpold>
+""",
+        encoding="utf-8",
+    )
+
+
+def _read_process(tidas_dir, process_id):
+    return json.loads(
+        (tidas_dir / "processes" / f"{process_id}.json").read_text(encoding="utf-8")
+    )["processDataSet"]
+
+
+def _flow_ref_for_exchange(process, flow_name):
+    refs = _flow_refs_for_exchanges(process, flow_name)
+    if not refs:
+        raise AssertionError(f"Exchange not found: {flow_name}")
+    return refs[0]
+
+
+def _flow_refs_for_exchanges(process, flow_name):
+    refs = []
+    for exchange in process["exchanges"]["exchange"]:
+        ref = exchange["referenceToFlowDataSet"]
+        if ref["common:shortDescription"]["#text"] == flow_name:
+            refs.append(ref["@refObjectId"])
+    return refs
+
+
+def _find_flow(tidas_dir, expected_name):
+    for path in (tidas_dir / "flows").glob("*.json"):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        name = data["flowDataSet"]["flowInformation"]["dataSetInformation"]["name"][
+            "baseName"
+        ]["#text"]
+        if name == expected_name:
+            return data
+    raise AssertionError(f"Flow not found: {expected_name}")

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -266,12 +266,42 @@ def test_validate_package_dir_returns_structured_report(tmp_path):
     assert report["issues"][0]["category"] == "sources"
 
 
+def test_validate_package_dir_supports_parallel_jobs(tmp_path):
+    package_dir = tmp_path / "package"
+    sources_dir = package_dir / "sources"
+    sources_dir.mkdir(parents=True)
+    (sources_dir / "bad-1.json").write_text("{}", encoding="utf-8")
+    (sources_dir / "bad-2.json").write_text("{}", encoding="utf-8")
+
+    report = validate_package_dir(str(package_dir), jobs=2)
+
+    assert report["ok"] is False
+    assert report["summary"]["issue_count"] == 2
+    assert {issue["file_path"].rsplit("/", 1)[-1] for issue in report["issues"]} == {
+        "bad-1.json",
+        "bad-2.json",
+    }
+
+
 def test_validate_ilcd_package_dir_accepts_valid_location_xml(tmp_path):
     source_path = pkg_resources.files(eilcd_stylesheets) / "ILCDLocations_Reference.xml"
     xml_path = tmp_path / "ILCDLocations.xml"
     xml_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
 
     report = validate_ilcd_package_dir(str(tmp_path))
+
+    assert report["ok"] is True
+    assert report["summary"]["category_count"] == 1
+    assert report["categories"][0]["category"] == "locations"
+
+
+def test_validate_ilcd_package_dir_supports_parallel_jobs(tmp_path):
+    source_path = pkg_resources.files(eilcd_stylesheets) / "ILCDLocations_Reference.xml"
+    for index in range(2):
+        xml_path = tmp_path / f"ILCDLocations-{index}.xml"
+        xml_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    report = validate_ilcd_package_dir(str(tmp_path), jobs=2)
 
     assert report["ok"] is True
     assert report["summary"]["category_count"] == 1

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,6 +1,8 @@
 import importlib.resources as pkg_resources
 import json
 
+import fastjsonschema
+import pytest
 from jsonschema import Draft7Validator
 from lxml import etree
 from referencing import Registry
@@ -9,7 +11,12 @@ import tidas_tools.eilcd.stylesheets as eilcd_stylesheets
 import tidas_tools.tidas.schemas as schemas
 from tidas_tools.validate import (
     FORMAT_CHECKER,
+    SUPPORTED_CATEGORIES,
+    _build_tidas_validator,
+    _compile_fast_tidas_schema_definition,
     _collect_ilcd_cas_number_issues,
+    _collect_schema_issues,
+    _collect_strict_schema_issues,
     category_validate,
     is_valid_cas_number,
     retrieve_schema,
@@ -140,6 +147,59 @@ def test_tidas_cas_number_schema_enforces_checksum_format():
     errors = list(validator.iter_errors("64-17-6"))
 
     assert [error.validator for error in errors] == ["format"]
+
+
+def test_fastjsonschema_tidas_validator_supports_refs_and_cas_format():
+    validator = _compile_fast_tidas_schema_definition(
+        "test_schema.json",
+        {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {"cas": {"$ref": "tidas_data_types.json#/$defs/CASNumber"}},
+            "required": ["cas"],
+        },
+    )
+
+    assert validator({"cas": "64-17-5"}) == {"cas": "64-17-5"}
+
+    with pytest.raises(fastjsonschema.JsonSchemaValueException) as exc_info:
+        validator({"cas": "64-17-6"})
+
+    assert exc_info.value.rule == "format"
+
+
+def test_fastjsonschema_tidas_validator_does_not_apply_defaults():
+    validator = _compile_fast_tidas_schema_definition(
+        "test_defaults.json",
+        {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {"name": {"type": "string", "default": "generated"}},
+        },
+    )
+    payload = {}
+
+    assert validator(payload) == {}
+    assert payload == {}
+
+
+def test_fastjsonschema_compiles_all_packaged_tidas_category_schemas():
+    for category in SUPPORTED_CATEGORIES:
+        assert _build_tidas_validator(category).fast_validator is not None
+
+
+def test_fastjsonschema_schema_failure_falls_back_to_strict_error_collection():
+    validator = _build_tidas_validator("sources")
+    payload = {}
+
+    fast_path_issues = _collect_schema_issues(validator, payload, "sources", "bad.json")
+    strict_issues = _collect_strict_schema_issues(
+        validator.strict_validator, payload, "sources", "bad.json"
+    )
+
+    assert [issue.message for issue in fast_path_issues] == [
+        issue.message for issue in strict_issues
+    ]
 
 
 def test_ilcd_cas_number_supplemental_validation_enforces_checksum():

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,5 +1,6 @@
 import importlib.resources as pkg_resources
 import json
+from pathlib import Path
 
 import fastjsonschema
 import pytest
@@ -337,7 +338,7 @@ def test_validate_package_dir_supports_parallel_jobs(tmp_path):
 
     assert report["ok"] is False
     assert report["summary"]["issue_count"] == 2
-    assert {issue["file_path"].rsplit("/", 1)[-1] for issue in report["issues"]} == {
+    assert {Path(issue["file_path"]).name for issue in report["issues"]} == {
         "bad-1.json",
         "bad-2.json",
     }


### PR DESCRIPTION
Closes #61

## Summary
- Read both EcoSpold2 activityDataset and childActivityDataset files and avoid process collisions for filenames containing multiple UUIDs.
- Preserve source exchange identifiers, process location/reference-year metadata, and cautious flow identity during TIDAS/ILCD writing.
- Speed up validation with worker parallelism, preloaded schema references, and a compiled TIDAS JSON schema fast path with strict fallback.

## Key Decisions
- Use the filename UUID directly only when exactly one UUID is present; derive a stable filename-based UUID when EcoSpold2 filenames contain multiple UUIDs.
- Keep complete schema error reporting by falling back to jsonschema whenever the compiled fast path detects an invalid record.

## Validation
- uv run black --check --target-version py313 src tests
- uv run pytest: 62 passed in 175.88s
- scripts/docpact validate-config --root . --strict
- scripts/docpact lint --root . --worktree --mode enforce
- tidas-validate on generated ecoinvent EcoSpold2 TIDAS output with --jobs 8: ok=true, 0 issues, 38.36s

## Risks / Rollback
- Low-to-medium risk: EcoSpold2 import mapping changes affect generated identifiers and metadata, but tests cover childActivityDataset import, flow deduplication, and validation compatibility.

## Follow-ups
- After merge, bump the tidas-tools submodule pointer in lca-workspace for delivery integration.

## Workspace Integration
- Workspace Integration remains Pending until the root workspace records the merged tidas-tools commit.