### PR TITLE
feat: preserve EcoSpold import trace metadata

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-21"
-lastReviewedCommit: "2a93b8a63a04bb0c4ce05513faee6077972f82e3"
+lastReviewedCommit: "0c5ff07c81df294a55801456df0f1a06e7771388"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 2a93b8a63a04bb0c4ce05513faee6077972f82e3
+lastReviewedCommit: 0c5ff07c81df294a55801456df0f1a06e7771388
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,7 +25,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 2a93b8a63a04bb0c4ce05513faee6077972f82e3
+lastReviewedCommit: 0c5ff07c81df294a55801456df0f1a06e7771388
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 2a93b8a63a04bb0c4ce05513faee6077972f82e3
+lastReviewedCommit: 0c5ff07c81df294a55801456df0f1a06e7771388
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/src/tidas_tools/import_lca/adapters/ecospold1.py
+++ b/src/tidas_tools/import_lca/adapters/ecospold1.py
@@ -11,6 +11,7 @@ import zipfile
 from lxml import etree
 
 from .base import SourceAdapter
+from .xml_trace import element_trace
 from ..model import CanonicalEntity
 from ..report import ConversionReport
 from ..store import MemoryCanonicalStore
@@ -18,6 +19,7 @@ from ..store import MemoryCanonicalStore
 UUID_RE = re.compile(
     r"(?P<uuid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
 )
+YEAR_RE = re.compile(r"\b(?P<year>\d{4})\b")
 FlowKey = tuple[str, ...]
 
 
@@ -47,6 +49,17 @@ class EcoSpold1Adapter(SourceAdapter):
             datasets = _datasets(root)
             for index, dataset in enumerate(datasets, start=1):
                 process = _process_entity(dataset, label, index)
+                source_refs = []
+                for source_entity in _source_entities(dataset):
+                    store.add(source_entity)
+                    source_refs.append(
+                        {
+                            "id": source_entity.internal_id,
+                            "name": source_entity.name or "Imported source",
+                        }
+                    )
+                if source_refs:
+                    process.raw["sourceRefs"] = source_refs
                 exchanges = []
                 for exchange_index, exchange in enumerate(
                     _exchange_elements(dataset), 1
@@ -62,9 +75,9 @@ class EcoSpold1Adapter(SourceAdapter):
                 count += 1
                 report.add_issue(
                     severity="warning",
-                    code="ecospold1_minimal_mapping",
+                    code="ecospold1_mapping_with_trace",
                     message=(
-                        "Mapped EcoSpold 1 dataset with the current minimal adapter."
+                        "Mapped EcoSpold 1 dataset and preserved source trace metadata."
                     ),
                     source_object=label,
                     context={
@@ -114,6 +127,15 @@ def _exchange_elements(dataset) -> list:
 
 
 def _process_entity(dataset, label: str, index: int) -> CanonicalEntity:
+    reference_function = _first_element(
+        dataset, ".//*[local-name()='referenceFunction']"
+    )
+    geography = _first_element(dataset, ".//*[local-name()='geography']")
+    technology = _first_element(dataset, ".//*[local-name()='technology']")
+    time_period = _first_element(dataset, ".//*[local-name()='timePeriod']")
+    representativeness = _first_element(
+        dataset, ".//*[local-name()='representativeness']"
+    )
     name = _first_text(
         dataset,
         [
@@ -128,13 +150,99 @@ def _process_entity(dataset, label: str, index: int) -> CanonicalEntity:
     process_id = filename_uuid or _stable_id(
         f"ecospold1/process/{label}/{index}/{name}"
     )
+    technology_text = _attr(technology, "text") or _attr(
+        reference_function, "includedProcesses"
+    )
+    time_description = _text_or_attrs(
+        time_period,
+        [
+            "startDate",
+            "endDate",
+            "startYear",
+            "endYear",
+            "dataValidForEntirePeriod",
+        ],
+    )
+    description = _first_text(
+        dataset,
+        [
+            ".//*[local-name()='referenceFunction']/@generalComment",
+            ".//*[local-name()='technology']/@text",
+            ".//*[local-name()='timePeriod']/text()",
+        ],
+    )
     return CanonicalEntity(
         entity_type="processes",
         internal_id=process_id,
         external_id=filename_uuid,
         name=name,
-        raw={"description": f"Imported from EcoSpold 1 source {label}."},
+        raw={
+            "description": description or f"Imported from EcoSpold 1 source {label}.",
+            "sourceFormat": "ecospold1",
+            "sourceLabel": label,
+            "sourceTrace": {
+                "format": "ecospold1",
+                "sourceObject": label,
+                "dataset": element_trace(dataset, exclude_child_names={"flowData"}),
+            },
+            "location": _attr(geography, "location"),
+            "locationDescription": _attr(geography, "text"),
+            "referenceYear": _year_from(
+                _attr(time_period, "startDate") or _attr(time_period, "startYear")
+            ),
+            "dataSetValidUntil": _year_from(
+                _attr(time_period, "endDate") or _attr(time_period, "endYear")
+            ),
+            "timeDescription": time_description,
+            "technologyDescription": technology_text,
+            "dataCollectionPeriod": _period_text(time_period),
+            "productionVolume": _attr(representativeness, "productionVolume"),
+            "samplingProcedure": _attr(representativeness, "samplingProcedure"),
+            "uncertaintyAdjustments": _attr(
+                representativeness, "uncertaintyAdjustments"
+            ),
+            "useAdviceForDataSet": _attr(representativeness, "extrapolations"),
+            "sourceCategory": _attr(reference_function, "category"),
+            "sourceSubCategory": _attr(reference_function, "subCategory"),
+            "sourceLocalCategory": _attr(reference_function, "localCategory"),
+            "sourceLocalSubCategory": _attr(reference_function, "localSubCategory"),
+        },
     )
+
+
+def _source_entities(dataset) -> list[CanonicalEntity]:
+    entities = []
+    for source in dataset.xpath(".//*[local-name()='source']"):
+        source_number = _attr(source, "sourceNumber")
+        title = _attr(source, "title")
+        author = _attr(source, "firstAuthor")
+        year = _attr(source, "year")
+        text = _attr(source, "text")
+        name = title or author or source_number or "EcoSpold 1 source"
+        seed = "\x1f".join(
+            part or "" for part in (source_number, title, author, year, text)
+        )
+        source_id = _stable_id(f"ecospold1/source/{seed}")
+        citation = ", ".join(part for part in (author, title, year) if part)
+        entities.append(
+            CanonicalEntity(
+                entity_type="sources",
+                internal_id=source_id,
+                external_id=source_number,
+                name=name,
+                raw={
+                    "shortName": name,
+                    "sourceCitation": citation or text or name,
+                    "description": text,
+                    "sourceTrace": {
+                        "format": "ecospold1",
+                        "sourceObject": "source",
+                        "source": element_trace(source),
+                    },
+                },
+            )
+        )
+    return entities
 
 
 def _cached_flow_entity(
@@ -154,12 +262,24 @@ def _flow_entity(exchange, index: int, key: FlowKey) -> CanonicalEntity:
     category = _attr(exchange, "category")
     subcategory = _attr(exchange, "subCategory")
     flow_id = _stable_id(_flow_key_seed(key))
+    raw = {
+        "flowType": _flow_type(exchange),
+        "unitName": _attr(exchange, "unit"),
+        "CASNumber": _attr(exchange, "CASNumber"),
+        "sumFormula": _attr(exchange, "formula"),
+        "synonyms": _attr(exchange, "localName"),
+        "sourceTrace": {
+            "format": "ecospold1",
+            "sourceObject": "exchange",
+            "exchange": element_trace(exchange),
+        },
+    }
     return CanonicalEntity(
         entity_type="flows",
         internal_id=flow_id,
         name=name,
         category_path=[part for part in (category, subcategory) if part],
-        raw={"flowType": _flow_type(exchange), "unitName": _attr(exchange, "unit")},
+        raw=raw,
     )
 
 
@@ -204,6 +324,18 @@ def _exchange(exchange, flow: CanonicalEntity, index: int) -> dict:
         "flowName": flow.name,
         "isInput": _direction(exchange) == "Input",
         "amount": amount,
+        "minimumAmount": _attr(exchange, "minValue") or _attr(exchange, "minAmount"),
+        "maximumAmount": _attr(exchange, "maxValue") or _attr(exchange, "maxAmount"),
+        "uncertaintyDistributionType": _uncertainty_type(
+            _attr(exchange, "uncertaintyType")
+        ),
+        "relativeStandardDeviation95In": _attr(exchange, "standardDeviation95"),
+        "generalComment": _attr(exchange, "generalComment"),
+        "sourceTrace": {
+            "format": "ecospold1",
+            "sourceObject": "exchange",
+            "exchange": element_trace(exchange),
+        },
     }
 
 
@@ -241,7 +373,14 @@ def _first_text(element, expressions: list[str]) -> str | None:
     return None
 
 
+def _first_element(element, expression: str):
+    values = element.xpath(expression)
+    return values[0] if values else None
+
+
 def _attr(element, name: str) -> str | None:
+    if element is None:
+        return None
     value = element.get(name)
     if value is None:
         return None
@@ -258,6 +397,58 @@ def _key_text(value: str | None) -> str:
 def _uuid_from_label(label: str) -> str | None:
     match = UUID_RE.search(Path(label).name)
     return match.group("uuid").lower() if match else None
+
+
+def _year_from(value: str | None) -> int | None:
+    if not value:
+        return None
+    match = YEAR_RE.search(value)
+    return int(match.group("year")) if match else None
+
+
+def _period_text(element) -> str | None:
+    if element is None:
+        return None
+    start = _attr(element, "startDate") or _attr(element, "startYear")
+    end = _attr(element, "endDate") or _attr(element, "endYear")
+    parts = [part for part in (start, end) if part]
+    if parts:
+        return " - ".join(parts)
+    return _text_or_attrs(element, [])
+
+
+def _text_or_attrs(element, attr_names: list[str]) -> str | None:
+    if element is None:
+        return None
+    text = _first_text(element, ["./text()"])
+    if text:
+        return text
+    parts = []
+    for name in attr_names:
+        value = _attr(element, name)
+        if value:
+            parts.append(f"{name}={value}")
+    return "; ".join(parts) if parts else None
+
+
+def _uncertainty_type(value: str | None) -> str | None:
+    if not value:
+        return None
+    text = value.strip().casefold().replace("_", "-")
+    mapping = {
+        "0": "undefined",
+        "undefined": "undefined",
+        "1": "log-normal",
+        "lognormal": "log-normal",
+        "log-normal": "log-normal",
+        "2": "normal",
+        "normal": "normal",
+        "3": "triangular",
+        "triangular": "triangular",
+        "4": "uniform",
+        "uniform": "uniform",
+    }
+    return mapping.get(text)
 
 
 def _stable_id(seed: str) -> str:

--- a/src/tidas_tools/import_lca/adapters/ecospold2.py
+++ b/src/tidas_tools/import_lca/adapters/ecospold2.py
@@ -11,6 +11,7 @@ import zipfile
 from lxml import etree
 
 from .base import SourceAdapter
+from .xml_trace import element_trace
 from ..model import CanonicalEntity
 from ..report import ConversionReport
 from ..store import MemoryCanonicalStore
@@ -46,7 +47,7 @@ class EcoSpold2Adapter(SourceAdapter):
                 )
                 continue
             for index, dataset in enumerate(_datasets(root), start=1):
-                process = _process_entity(dataset, label, index)
+                process = _process_entity(dataset, label, index, root)
                 exchanges = []
                 for exchange_index, element in enumerate(
                     _exchange_elements(dataset), 1
@@ -62,8 +63,10 @@ class EcoSpold2Adapter(SourceAdapter):
                 count += 1
                 report.add_issue(
                     severity="warning",
-                    code="ecospold2_minimal_mapping",
-                    message="Mapped EcoSpold 2 activity dataset.",
+                    code="ecospold2_mapping_with_trace",
+                    message=(
+                        "Mapped EcoSpold 2 activity dataset and preserved source trace metadata."
+                    ),
                     source_object=label,
                     context={
                         "process_id": process.internal_id,
@@ -119,7 +122,7 @@ def _exchange_elements(dataset) -> list:
     )
 
 
-def _process_entity(dataset, label: str, index: int) -> CanonicalEntity:
+def _process_entity(dataset, label: str, index: int, root) -> CanonicalEntity:
     activity = _first_element(dataset, ".//*[local-name()='activity']")
     name = _first_text(
         dataset,
@@ -147,6 +150,22 @@ def _process_entity(dataset, label: str, index: int) -> CanonicalEntity:
             ".//*[local-name()='activity']/*[local-name()='includedActivitiesStart']/text()",
         ],
     )
+    time_period = _first_element(
+        dataset, ".//*[local-name()='activityDescription']/*[local-name()='timePeriod']"
+    )
+    if time_period is None:
+        time_period = _first_element(dataset, ".//*[local-name()='timePeriod']")
+    geography = _first_element(
+        dataset, ".//*[local-name()='activityDescription']/*[local-name()='geography']"
+    )
+    if geography is None:
+        geography = _first_element(dataset, ".//*[local-name()='geography']")
+    technology = _first_element(
+        dataset, ".//*[local-name()='activityDescription']/*[local-name()='technology']"
+    )
+    if technology is None:
+        technology = _first_element(dataset, ".//*[local-name()='technology']")
+    file_attributes = _first_element(root, ".//*[local-name()='fileAttributes']")
     return CanonicalEntity(
         entity_type="processes",
         internal_id=process_id,
@@ -155,9 +174,44 @@ def _process_entity(dataset, label: str, index: int) -> CanonicalEntity:
         raw={
             "description": description or f"Imported from EcoSpold 2 source {label}.",
             "location": _location(dataset),
+            "locationDescription": _first_text(
+                geography,
+                [
+                    "./*[local-name()='comment']/*[local-name()='text']/text()",
+                    "./*[local-name()='comment']/text()",
+                    "./*[local-name()='shortname']/text()",
+                ],
+            ),
             "referenceYear": _reference_year(dataset),
+            "dataSetValidUntil": _end_year(time_period),
+            "timeDescription": _time_description(time_period),
+            "technologyDescription": _first_text(
+                technology,
+                [
+                    "./*[local-name()='comment']/*[local-name()='text']/text()",
+                    "./*[local-name()='comment']/text()",
+                    ".//*[local-name()='text']/text()",
+                ],
+            ),
+            "technologicalApplicability": description,
             "sourceActivityId": activity_id,
             "sourceFileUUIDs": filename_uuids,
+            "sourceFormat": "ecospold2",
+            "sourceLabel": label,
+            "sourceTrace": {
+                "format": "ecospold2",
+                "sourceObject": label,
+                "rootAttributes": element_trace(
+                    root,
+                    exclude_child_names={"activityDataset", "childActivityDataset"},
+                ),
+                "fileAttributes": (
+                    element_trace(file_attributes)
+                    if file_attributes is not None
+                    else None
+                ),
+                "dataset": element_trace(dataset, exclude_child_names={"flowData"}),
+            },
         },
     )
 
@@ -175,7 +229,16 @@ def _cached_flow_entity(
 
 
 def _flow_entity(element, index: int, flow_id: str) -> CanonicalEntity:
-    raw = {"flowType": _flow_type(element), "unitName": _unit_name(element)}
+    raw = {
+        "flowType": _flow_type(element),
+        "unitName": _unit_name(element),
+        "unitId": _attr(element, "unitId"),
+        "sourceTrace": {
+            "format": "ecospold2",
+            "sourceObject": "exchange",
+            "exchange": element_trace(element),
+        },
+    }
     cas_number = _cas_number(element)
     sum_formula = _sum_formula(element)
     if cas_number:
@@ -263,6 +326,23 @@ def _exchange(element, flow: CanonicalEntity, index: int) -> dict[str, Any]:
         "flowName": flow.name,
         "isInput": _is_input(element),
         "amount": amount,
+        "activityLinkId": _attr(element, "activityLinkId"),
+        "productionVolumeAmount": _attr(element, "productionVolumeAmount"),
+        "isCalculatedAmount": _attr(element, "isCalculatedAmount"),
+        "dataDerivationTypeStatus": _data_derivation_type(element),
+        "uncertaintyDistributionType": _uncertainty_distribution_type(element),
+        "generalComment": _first_text(
+            element,
+            [
+                "./*[local-name()='comment']/*[local-name()='text']/text()",
+                "./*[local-name()='comment']/text()",
+            ],
+        ),
+        "sourceTrace": {
+            "format": "ecospold2",
+            "sourceObject": "exchange",
+            "exchange": element_trace(element),
+        },
     }
 
 
@@ -280,6 +360,32 @@ def _reference_first(exchanges: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for index, exchange in enumerate(ordered, start=1):
         exchange["internalId"] = index
     return ordered
+
+
+def _data_derivation_type(element) -> str | None:
+    value = _attr(element, "isCalculatedAmount")
+    if value and value.casefold() == "true":
+        return "Calculated"
+    return None
+
+
+def _uncertainty_distribution_type(element) -> str | None:
+    uncertainty = _first_element(element, "./*[local-name()='uncertainty']")
+    if uncertainty is None:
+        return None
+    for child in uncertainty:
+        if not isinstance(child.tag, str):
+            continue
+        local_name = etree.QName(child).localname.casefold()
+        mapping = {
+            "lognormal": "log-normal",
+            "normal": "normal",
+            "triangular": "triangular",
+            "uniform": "uniform",
+        }
+        if local_name in mapping:
+            return mapping[local_name]
+    return None
 
 
 def _is_input(element) -> bool:
@@ -397,12 +503,70 @@ def _reference_year(dataset) -> int | None:
     return int(match.group("year"))
 
 
+def _end_year(time_period) -> int | None:
+    if time_period is None:
+        return None
+    value = _first_text(
+        time_period,
+        [
+            "./*[local-name()='endDate']/text()",
+            "./*[local-name()='endYear']/text()",
+            "./@endDate",
+            "./@endYear",
+        ],
+    )
+    if not value:
+        return None
+    match = YEAR_RE.search(value)
+    return int(match.group("year")) if match else None
+
+
+def _time_description(time_period) -> str | None:
+    if time_period is None:
+        return None
+    start = _first_text(
+        time_period,
+        [
+            "./*[local-name()='startDate']/text()",
+            "./*[local-name()='startYear']/text()",
+            "./@startDate",
+            "./@startYear",
+        ],
+    )
+    end = _first_text(
+        time_period,
+        [
+            "./*[local-name()='endDate']/text()",
+            "./*[local-name()='endYear']/text()",
+            "./@endDate",
+            "./@endYear",
+        ],
+    )
+    comment = _first_text(
+        time_period,
+        [
+            "./*[local-name()='comment']/*[local-name()='text']/text()",
+            "./*[local-name()='comment']/text()",
+        ],
+    )
+    parts = []
+    if start or end:
+        parts.append(" - ".join(part for part in (start, end) if part))
+    if comment:
+        parts.append(comment)
+    return "; ".join(parts) if parts else None
+
+
 def _first_element(element, expression: str):
+    if element is None:
+        return None
     values = element.xpath(expression)
     return values[0] if values else None
 
 
 def _first_text(element, expressions: list[str]) -> str | None:
+    if element is None:
+        return None
     for expression in expressions:
         values = element.xpath(expression)
         for value in values:

--- a/src/tidas_tools/import_lca/adapters/xml_trace.py
+++ b/src/tidas_tools/import_lca/adapters/xml_trace.py
@@ -1,0 +1,63 @@
+"""Helpers for preserving source XML in import trace payloads."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from lxml import etree
+
+XML_NAMESPACE = "http://www.w3.org/XML/1998/namespace"
+
+
+def element_trace(
+    element,
+    *,
+    exclude_child_names: Iterable[str] = (),
+) -> dict[str, Any]:
+    """Return a compact, JSON/XML-safe trace for an XML element."""
+
+    excluded = set(exclude_child_names)
+    qname = etree.QName(element)
+    trace: dict[str, Any] = {"name": qname.localname}
+    if qname.namespace:
+        trace["namespace"] = qname.namespace
+
+    attributes = _attributes(element)
+    if attributes:
+        trace["attributes"] = attributes
+
+    text = _clean_text(element.text)
+    if text:
+        trace["text"] = text
+
+    children = []
+    for child in element:
+        if not isinstance(child.tag, str):
+            continue
+        if etree.QName(child).localname in excluded:
+            continue
+        children.append(element_trace(child, exclude_child_names=excluded))
+    if children:
+        trace["children"] = children
+
+    return trace
+
+
+def _attributes(element) -> list[dict[str, str]]:
+    attributes = []
+    for key, value in sorted(element.attrib.items()):
+        qname = etree.QName(key)
+        item = {"name": qname.localname, "value": value}
+        if qname.namespace == XML_NAMESPACE:
+            item["prefix"] = "xml"
+        elif qname.namespace:
+            item["namespace"] = qname.namespace
+        attributes.append(item)
+    return attributes
+
+
+def _clean_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    text = " ".join(value.split())
+    return text or None

--- a/src/tidas_tools/import_lca/writers/tidas_json.py
+++ b/src/tidas_tools/import_lca/writers/tidas_json.py
@@ -15,16 +15,31 @@ from ..store import MemoryCanonicalStore
 from .tidas_package import ensure_tidas_package_dirs
 
 DEFAULT_VERSION = "00.00.001"
-IMPORT_CONTACT_ID = str(uuid.uuid5(uuid.NAMESPACE_URL, "tidas-tools/import/contact"))
-FORMAT_SOURCE_ID = str(uuid.uuid5(uuid.NAMESPACE_URL, "tidas-tools/import/ilcd-format"))
+IMPORT_ID_NAMESPACE = "tidas-tools/import"
+IMPORT_TRACE_NAMESPACE = "https://tiangong.earth/tidas/import-trace/1.0"
+IMPORT_TRACE_MARKER = "TIDAS_IMPORT_TRACE_V1"
+PLACEHOLDER_PREFIX = "TIDAS_IMPORT_PLACEHOLDER"
+PLACEHOLDER_UNSPECIFIED_TEXT = f"{PLACEHOLDER_PREFIX}:UNSPECIFIED_TEXT"
+PLACEHOLDER_IMPORT_ACTOR = f"{PLACEHOLDER_PREFIX}:IMPORT_ACTOR"
+PLACEHOLDER_COMPLIANCE_NOT_DEFINED = f"{PLACEHOLDER_PREFIX}:COMPLIANCE_NOT_DEFINED"
+PLACEHOLDER_DATA_CUTOFF = f"{PLACEHOLDER_PREFIX}:DATA_CUTOFF_NOT_AVAILABLE"
+PLACEHOLDER_DATA_SOURCE = f"{PLACEHOLDER_PREFIX}:DATA_SOURCE_NOT_AVAILABLE"
+PLACEHOLDER_ANNUAL_VOLUME = f"0 {PLACEHOLDER_PREFIX}:ANNUAL_VOLUME_NOT_AVAILABLE"
+PLACEHOLDER_CONVERTED_APPLICATION = f"{PLACEHOLDER_PREFIX}:CONVERTED_EXTERNAL_LCA_DATA"
+IMPORT_CONTACT_ID = str(
+    uuid.uuid5(uuid.NAMESPACE_URL, f"{IMPORT_ID_NAMESPACE}/contact")
+)
+FORMAT_SOURCE_ID = str(
+    uuid.uuid5(uuid.NAMESPACE_URL, f"{IMPORT_ID_NAMESPACE}/ilcd-format")
+)
 COMPLIANCE_SOURCE_ID = str(
-    uuid.uuid5(uuid.NAMESPACE_URL, "tidas-tools/import/not-defined-compliance")
+    uuid.uuid5(uuid.NAMESPACE_URL, f"{IMPORT_ID_NAMESPACE}/not-defined-compliance")
 )
 DEFAULT_UNIT_GROUP_ID = str(
-    uuid.uuid5(uuid.NAMESPACE_URL, "tidas-tools/import/default-unit-group")
+    uuid.uuid5(uuid.NAMESPACE_URL, f"{IMPORT_ID_NAMESPACE}/default-unit-group")
 )
 DEFAULT_FLOW_PROPERTY_ID = str(
-    uuid.uuid5(uuid.NAMESPACE_URL, "tidas-tools/import/default-flow-property")
+    uuid.uuid5(uuid.NAMESPACE_URL, f"{IMPORT_ID_NAMESPACE}/default-flow-property")
 )
 PERMANENT_URI_BASE = "https://lcdn.tiangong.earth"
 PERMANENT_URI_PATHS = {
@@ -112,7 +127,7 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
 
 
 def _ml(text: str, lang: str = "en") -> dict[str, str]:
-    return {"@xml:lang": lang, "#text": text or "Not specified"}
+    return {"@xml:lang": lang, "#text": text or PLACEHOLDER_UNSPECIFIED_TEXT}
 
 
 def _now() -> str:
@@ -149,7 +164,7 @@ def _compliance_ref() -> dict[str, Any]:
     return _ref(
         ref_type="source data set",
         ref_id=COMPLIANCE_SOURCE_ID,
-        short_description="Not defined compliance system",
+        short_description=PLACEHOLDER_COMPLIANCE_NOT_DEFINED,
         category="sources",
     )
 
@@ -158,7 +173,7 @@ def _owner_ref() -> dict[str, Any]:
     return _ref(
         ref_type="contact data set",
         ref_id=IMPORT_CONTACT_ID,
-        short_description="tidas-tools import",
+        short_description=PLACEHOLDER_IMPORT_ACTOR,
         category="contacts",
     )
 
@@ -230,8 +245,8 @@ def _compliance_declarations(process: bool = False) -> dict[str, Any]:
 def _default_contact() -> dict[str, Any]:
     return _contact_payload(
         contact_id=IMPORT_CONTACT_ID,
-        name="tidas-tools import",
-        short_name="tidas-tools import",
+        name=PLACEHOLDER_IMPORT_ACTOR,
+        short_name=PLACEHOLDER_IMPORT_ACTOR,
     )
 
 
@@ -325,6 +340,7 @@ def _imported_source_dataset(entity: CanonicalEntity) -> dict[str, Any]:
         publication_type=raw.get("publicationType"),
         description=raw.get("description"),
         url=raw.get("url") or raw.get("externalUrl"),
+        source_trace=raw.get("sourceTrace"),
     )
 
 
@@ -338,6 +354,7 @@ def _source_payload(
     publication_type: Any = None,
     description: Any = None,
     url: Any = None,
+    source_trace: Any = None,
 ) -> dict[str, Any]:
     dataset_info = {
         "common:UUID": source_id,
@@ -360,6 +377,9 @@ def _source_payload(
         dataset_info["sourceDescriptionOrComment"] = _ml(str(description).strip())
     if _uri(url):
         dataset_info["referenceToDigitalFile"] = {"@uri": str(url).strip()}
+    common_other = _common_other_trace(source_trace)
+    if common_other:
+        dataset_info["common:other"] = common_other
 
     return {
         "sourceDataSet": {
@@ -384,7 +404,10 @@ def _format_source() -> dict[str, Any]:
 
 def _compliance_source() -> dict[str, Any]:
     return _source_dataset(
-        COMPLIANCE_SOURCE_ID, "Not defined compliance system", "3", "Compliance systems"
+        COMPLIANCE_SOURCE_ID,
+        PLACEHOLDER_COMPLIANCE_NOT_DEFINED,
+        "3",
+        "Compliance systems",
     )
 
 
@@ -493,13 +516,18 @@ def _flow_dataset(
     dataset_info = {
         "common:UUID": entity.internal_id,
         "name": _name_parts(entity.name or "Flow"),
-        "classificationInformation": classification,
     }
+    if _text(entity.raw.get("synonyms")):
+        dataset_info["common:synonyms"] = _ml(str(entity.raw["synonyms"]).strip())
+    dataset_info["classificationInformation"] = classification
     cas_number = _cas_number(entity.raw.get("CASNumber"))
     if cas_number:
         dataset_info["CASNumber"] = cas_number
     if _text(entity.raw.get("sumFormula")):
         dataset_info["sumFormula"] = str(entity.raw["sumFormula"]).strip()
+    common_other = _common_other_trace(entity.raw.get("sourceTrace"))
+    if common_other:
+        dataset_info["common:other"] = common_other
     generated_flow_property = _generated_flow_property_for(entity, generated_units)
     flow_property_id = (
         entity.raw.get("flowPropertyRefId")
@@ -563,7 +591,61 @@ def _process_dataset(entity: CanonicalEntity):
     ]
     reference_flow = _reference_flow_id(exchange_items)
     reference_year = _reference_year(entity.raw.get("referenceYear"))
+    valid_until = _optional_year(entity.raw.get("dataSetValidUntil"))
     location = _location_code(entity.raw.get("location"))
+    data_set_information = {
+        "common:UUID": entity.internal_id,
+        "name": _name_parts(entity.name or "Process"),
+        "classificationInformation": _default_process_classification(),
+        "common:generalComment": _ml(
+            entity.raw.get("description") or PLACEHOLDER_CONVERTED_APPLICATION
+        ),
+    }
+    common_other = _common_other_trace(entity.raw.get("sourceTrace"))
+    if common_other:
+        data_set_information["common:other"] = common_other
+
+    time = {"common:referenceYear": reference_year}
+    if valid_until is not None:
+        time["common:dataSetValidUntil"] = valid_until
+    if _text(entity.raw.get("timeDescription")):
+        time["common:timeRepresentativenessDescription"] = _ml(
+            str(entity.raw["timeDescription"]).strip()
+        )
+
+    location_item = {"@location": location}
+    if _text(entity.raw.get("locationDescription")):
+        location_item["descriptionOfRestrictions"] = _ml(
+            str(entity.raw["locationDescription"]).strip()
+        )
+
+    process_information = {
+        "dataSetInformation": data_set_information,
+        "quantitativeReference": {
+            "@type": "Reference flow(s)",
+            "referenceToReferenceFlow": reference_flow,
+        },
+        "time": time,
+        "geography": {
+            "locationOfOperationSupplyOrProduction": location_item,
+        },
+    }
+    technology = _technology_section(entity)
+    if technology:
+        process_information["technology"] = technology
+
+    modelling_and_validation = {
+        "LCIMethodAndAllocation": {"typeOfDataSet": "Unit process, single operation"}
+    }
+    data_sources = _data_sources_treatment_and_representativeness(entity)
+    if data_sources:
+        modelling_and_validation["dataSourcesTreatmentAndRepresentativeness"] = (
+            data_sources
+        )
+    modelling_and_validation["validation"] = {"review": {"@type": "Not reviewed"}}
+    modelling_and_validation["complianceDeclarations"] = _compliance_declarations(
+        process=True
+    )
     if not exchange_items:
         exchange_items = [
             {
@@ -590,60 +672,14 @@ def _process_dataset(entity: CanonicalEntity):
             "@version": "1.1",
             "@locations": "../ILCDLocations.xml",
             "@xsi:schemaLocation": "http://lca.jrc.it/ILCD/Process ../../schemas/ILCD_ProcessDataSet.xsd",
-            "processInformation": {
-                "dataSetInformation": {
-                    "common:UUID": entity.internal_id,
-                    "name": _name_parts(entity.name or "Process"),
-                    "classificationInformation": {
-                        "common:classification": {
-                            "common:class": [
-                                {
-                                    "@level": "0",
-                                    "@classId": "T",
-                                    "#text": "Other service activities",
-                                },
-                                {
-                                    "@level": "1",
-                                    "@classId": "94",
-                                    "#text": "Activities of membership organizations",
-                                },
-                                {
-                                    "@level": "2",
-                                    "@classId": "949",
-                                    "#text": "Activities of other membership organizations",
-                                },
-                                {
-                                    "@level": "3",
-                                    "@classId": "9499",
-                                    "#text": "Activities of other membership organizations n.e.c.",
-                                },
-                            ]
-                        }
-                    },
-                    "common:generalComment": _ml(
-                        entity.raw.get("description") or "Converted by tidas-tools."
-                    ),
-                },
-                "quantitativeReference": {
-                    "@type": "Reference flow(s)",
-                    "referenceToReferenceFlow": reference_flow,
-                },
-                "time": {"common:referenceYear": reference_year},
-                "geography": {
-                    "locationOfOperationSupplyOrProduction": {"@location": location}
-                },
-            },
-            "modellingAndValidation": {
-                "LCIMethodAndAllocation": {
-                    "typeOfDataSet": "Unit process, single operation"
-                },
-                "validation": {"review": {"@type": "Not reviewed"}},
-                "complianceDeclarations": _compliance_declarations(process=True),
-            },
+            "processInformation": process_information,
+            "modellingAndValidation": modelling_and_validation,
             "administrativeInformation": {
                 "common:commissionerAndGoal": {
                     "common:referenceToCommissioner": _owner_ref(),
-                    "common:intendedApplications": _ml("Converted external LCA data."),
+                    "common:intendedApplications": _ml(
+                        PLACEHOLDER_CONVERTED_APPLICATION
+                    ),
                 },
                 **_admin_info(
                     category="processes",
@@ -656,6 +692,112 @@ def _process_dataset(entity: CanonicalEntity):
     }
 
 
+def _default_process_classification() -> dict[str, Any]:
+    return {
+        "common:classification": {
+            "common:class": [
+                {
+                    "@level": "0",
+                    "@classId": "T",
+                    "#text": "Other service activities",
+                },
+                {
+                    "@level": "1",
+                    "@classId": "94",
+                    "#text": "Activities of membership organizations",
+                },
+                {
+                    "@level": "2",
+                    "@classId": "949",
+                    "#text": "Activities of other membership organizations",
+                },
+                {
+                    "@level": "3",
+                    "@classId": "9499",
+                    "#text": "Activities of other membership organizations n.e.c.",
+                },
+            ]
+        }
+    }
+
+
+def _technology_section(entity: CanonicalEntity) -> dict[str, Any] | None:
+    description = entity.raw.get("technologyDescription")
+    applicability = entity.raw.get("technologicalApplicability")
+    if not _text(description) and not _text(applicability):
+        return None
+    section = {
+        "technologyDescriptionAndIncludedProcesses": _ml(
+            str(description).strip()
+            if _text(description)
+            else PLACEHOLDER_UNSPECIFIED_TEXT
+        )
+    }
+    if _text(applicability):
+        section["technologicalApplicability"] = _ml(str(applicability).strip())
+    return section
+
+
+def _data_sources_treatment_and_representativeness(
+    entity: CanonicalEntity,
+) -> dict[str, Any] | None:
+    raw = entity.raw
+    source_refs = raw.get("sourceRefs") or []
+    relevant_keys = {
+        "productionVolume",
+        "samplingProcedure",
+        "uncertaintyAdjustments",
+        "useAdviceForDataSet",
+        "dataCollectionPeriod",
+    }
+    if not source_refs and not any(_text(raw.get(key)) for key in relevant_keys):
+        return None
+
+    source_ref = source_refs[0] if source_refs else {}
+    source_id = source_ref.get("id") or FORMAT_SOURCE_ID
+    source_name = (
+        source_ref.get("name") or raw.get("sourceLabel") or PLACEHOLDER_DATA_SOURCE
+    )
+    section: dict[str, Any] = {
+        "dataCutOffAndCompletenessPrinciples": _ml(
+            raw.get("dataCutOffAndCompletenessPrinciples") or PLACEHOLDER_DATA_CUTOFF
+        ),
+        "referenceToDataSource": _ref(
+            ref_type="source data set",
+            ref_id=source_id,
+            short_description=str(source_name),
+            category="sources",
+        ),
+        "annualSupplyOrProductionVolume": _annual_supply_or_production_volume(
+            raw.get("productionVolume")
+        ),
+    }
+    if _text(raw.get("samplingProcedure")):
+        section["samplingProcedure"] = _ml(str(raw["samplingProcedure"]).strip())
+    if _text(raw.get("dataCollectionPeriod")):
+        section["dataCollectionPeriod"] = _ml(str(raw["dataCollectionPeriod"]).strip())
+    if _text(raw.get("uncertaintyAdjustments")):
+        section["uncertaintyAdjustments"] = _ml(
+            str(raw["uncertaintyAdjustments"]).strip()
+        )
+    if _text(raw.get("useAdviceForDataSet")):
+        section["useAdviceForDataSet"] = _ml(str(raw["useAdviceForDataSet"]).strip())
+
+    common_other = _common_other_trace(
+        {
+            "format": raw.get("sourceFormat"),
+            "sourceObject": raw.get("sourceLabel"),
+            "sourceCategory": raw.get("sourceCategory"),
+            "sourceSubCategory": raw.get("sourceSubCategory"),
+            "sourceLocalCategory": raw.get("sourceLocalCategory"),
+            "sourceLocalSubCategory": raw.get("sourceLocalSubCategory"),
+        }
+    )
+    if common_other:
+        section["common:other"] = common_other
+    return section
+
+
 def _exchange_item(exchange: dict[str, Any], idx: int) -> dict[str, Any]:
     flow = exchange.get("flow") if isinstance(exchange.get("flow"), dict) else {}
     flow_id = (
@@ -664,6 +806,9 @@ def _exchange_item(exchange: dict[str, Any], idx: int) -> dict[str, Any]:
     flow_name = _extract_name(flow) or exchange.get("flowName") or "Flow"
     amount = _real(exchange.get("amount", 1))
     is_input = bool(exchange.get("isInput", False))
+    derivation_type = _data_derivation_type(exchange.get("dataDerivationTypeStatus"))
+    if derivation_type is None:
+        derivation_type = "Unknown derivation"
     item = {
         "@dataSetInternalID": str(idx),
         "referenceToFlowDataSet": _ref(
@@ -675,16 +820,42 @@ def _exchange_item(exchange: dict[str, Any], idx: int) -> dict[str, Any]:
         "exchangeDirection": "Input" if is_input else "Output",
         "meanAmount": amount,
         "resultingAmount": amount,
-        "dataDerivationTypeStatus": "Unknown derivation",
     }
+    minimum_amount = _optional_real(exchange.get("minimumAmount"))
+    if minimum_amount is not None:
+        item["minimumAmount"] = minimum_amount
+    maximum_amount = _optional_real(exchange.get("maximumAmount"))
+    if maximum_amount is not None:
+        item["maximumAmount"] = maximum_amount
+    uncertainty_type = _uncertainty_distribution_type(
+        exchange.get("uncertaintyDistributionType")
+    )
+    if uncertainty_type:
+        item["uncertaintyDistributionType"] = uncertainty_type
+    relative_std_dev = _percentage(exchange.get("relativeStandardDeviation95In"))
+    if relative_std_dev:
+        item["relativeStandardDeviation95In"] = relative_std_dev
+    item["dataDerivationTypeStatus"] = derivation_type
+
+    comments = []
     if exchange.get("sourceExchangeNumber"):
-        item["generalComment"] = _ml(
+        comments.append(
             f"Source EcoSpold1 exchange number: {exchange['sourceExchangeNumber']}."
         )
     elif exchange.get("sourceExchangeId"):
-        item["generalComment"] = _ml(
+        comments.append(
             f"Source EcoSpold2 exchange id: {exchange['sourceExchangeId']}."
         )
+    if _text(exchange.get("generalComment")):
+        comments.append(str(exchange["generalComment"]).strip())
+    if comments:
+        item["generalComment"] = _ml(" ".join(comments))
+
+    common_other = _common_other_trace(
+        _exchange_trace_payload(exchange),
+    )
+    if common_other:
+        item["common:other"] = common_other
     return item
 
 
@@ -695,6 +866,23 @@ def _reference_flow_id(exchange_items: list[dict[str, Any]]) -> str:
     if exchange_items:
         return str(exchange_items[0].get("@dataSetInternalID") or "1")
     return "1"
+
+
+def _exchange_trace_payload(exchange: dict[str, Any]) -> dict[str, Any] | None:
+    source_trace = exchange.get("sourceTrace")
+    extra = {
+        "activityLinkId": exchange.get("activityLinkId"),
+        "productionVolumeAmount": exchange.get("productionVolumeAmount"),
+        "isCalculatedAmount": exchange.get("isCalculatedAmount"),
+    }
+    if not source_trace and not any(value is not None for value in extra.values()):
+        return None
+    return {
+        "sourceTrace": source_trace,
+        "exchangeMetadata": {
+            key: value for key, value in extra.items() if value is not None
+        },
+    }
 
 
 def _name_parts(name: str) -> dict[str, Any]:
@@ -733,11 +921,15 @@ def _generated_unit_entities(
     result = {}
     for unit_name in unit_names:
         unit_group_id = str(
-            uuid.uuid5(uuid.NAMESPACE_URL, f"tidas-tools/import/unitgroup/{unit_name}")
+            uuid.uuid5(
+                uuid.NAMESPACE_URL,
+                f"{IMPORT_ID_NAMESPACE}/unitgroup/{unit_name}",
+            )
         )
         flow_property_id = str(
             uuid.uuid5(
-                uuid.NAMESPACE_URL, f"tidas-tools/import/flowproperty/{unit_name}"
+                uuid.NAMESPACE_URL,
+                f"{IMPORT_ID_NAMESPACE}/flowproperty/{unit_name}",
             )
         )
         unit_group = CanonicalEntity(
@@ -774,6 +966,16 @@ def _reference_year(value: Any) -> int:
     match = re.search(r"\b(\d{4})\b", text)
     if not match:
         return 2026
+    return int(match.group(1))
+
+
+def _optional_year(value: Any) -> int | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    match = re.search(r"\b(\d{4})\b", text)
+    if not match:
+        return None
     return int(match.group(1))
 
 
@@ -869,6 +1071,101 @@ def _real(value: Any) -> str:
         return f"{float(value):g}"
     except (TypeError, ValueError):
         return "0"
+
+
+def _optional_real(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        return f"{float(value):g}"
+    except (TypeError, ValueError):
+        return None
+
+
+def _percentage(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if numeric < 0 or numeric > 100:
+        return None
+    rounded = round(numeric, 3)
+    return f"{rounded:.3f}".rstrip("0").rstrip(".")
+
+
+def _annual_supply_or_production_volume(value: Any) -> dict[str, str]:
+    text = str(value).strip() if value is not None else ""
+    if not re.fullmatch(r"[+-]?(\d+(\.\d*)?|\.\d+)([Ee][+-]?\d+)?\s+\S.*", text):
+        text = PLACEHOLDER_ANNUAL_VOLUME
+    return _ml(text[:500])
+
+
+def _data_derivation_type(value: Any) -> str | None:
+    text = str(value or "").strip()
+    allowed = {
+        "Measured",
+        "Calculated",
+        "Estimated",
+        "Unknown derivation",
+        "Missing important",
+        "Missing unimportant",
+    }
+    return text if text in allowed else None
+
+
+def _uncertainty_distribution_type(value: Any) -> str | None:
+    text = str(value or "").strip()
+    allowed = {"undefined", "log-normal", "normal", "triangular", "uniform"}
+    return text if text in allowed else None
+
+
+def _common_other_trace(payload: Any) -> dict[str, Any] | None:
+    cleaned = _clean_trace_value(payload)
+    if cleaned in (None, {}, []):
+        return None
+    return {
+        "@xmlns:tidasimport": IMPORT_TRACE_NAMESPACE,
+        "tidasimport:sourceTrace": {
+            "@marker": IMPORT_TRACE_MARKER,
+            "payload": cleaned,
+        },
+    }
+
+
+def _clean_trace_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, list):
+        cleaned_items = [
+            cleaned
+            for item in value
+            if (cleaned := _clean_trace_value(item)) not in (None, {}, [])
+        ]
+        return cleaned_items
+    if isinstance(value, dict):
+        cleaned = {}
+        for key, item in value.items():
+            cleaned_item = _clean_trace_value(item)
+            if cleaned_item in (None, {}, []):
+                continue
+            cleaned[_safe_trace_key(str(key))] = cleaned_item
+        return cleaned
+    return str(value)
+
+
+def _safe_trace_key(key: str) -> str:
+    if key.startswith("@"):
+        return key
+    safe = re.sub(r"[^A-Za-z0-9_.:-]", "_", key)
+    if not safe or not re.match(r"^[A-Za-z_]", safe):
+        safe = f"value_{safe}"
+    if safe.startswith(("common:", "xmlns:")):
+        safe = f"tidasimport_{safe.replace(':', '_')}"
+    return safe
 
 
 def _extract_ref_id(ref: dict[str, Any]) -> str | None:

--- a/tests/test_import_lca_ecospold1.py
+++ b/tests/test_import_lca_ecospold1.py
@@ -50,6 +50,94 @@ def test_ecospold1_minimal_import_can_write_valid_tidas_and_ilcd(tmp_path):
     assert _has_flow_property(output_dir / "tidas", "Amount in kg")
 
 
+def test_ecospold1_import_maps_semantic_fields_and_source_trace(tmp_path):
+    process_uuid = "64e926e8-dd48-3704-b902-daaf546087c4"
+    source = tmp_path / f"process_{process_uuid}.xml"
+    source.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<ecoSpold xmlns="http://www.EcoInvent.org/EcoSpold01">
+  <dataset>
+    <metaInformation>
+      <processInformation>
+        <referenceFunction name="market for enriched steel" generalComment="Reference function note" category="metals" subCategory="steel" localCategory="local metals" localSubCategory="local steel" />
+        <geography location="CH" text="Swiss market boundary" />
+        <technology text="Electric arc furnace route" />
+        <timePeriod startDate="2020-01-01" endDate="2023-12-31" dataValidForEntirePeriod="true">survey period</timePeriod>
+      </processInformation>
+      <modellingAndValidation>
+        <representativeness productionVolume="123 kg" samplingProcedure="supplier survey" uncertaintyAdjustments="pedigree adjusted" extrapolations="use only for Swiss market" />
+      </modellingAndValidation>
+      <sources>
+        <source sourceNumber="10" firstAuthor="A. Author" year="2021" title="Steel source" text="Primary source note" />
+      </sources>
+    </metaInformation>
+    <flowData>
+      <exchange number="1" name="enriched steel" unit="kg" amount="1" outputGroup="0" />
+      <exchange number="2" name="carbon dioxide" CASNumber="124-38-9" formula="CO2" unit="kg" amount="2.5" outputGroup="4" category="air" subCategory="unspecified" minValue="1.2" maxValue="3.4" uncertaintyType="1" standardDeviation95="12.3456" generalComment="measured stack emissions" localName="CO2 local" />
+    </flowData>
+  </dataset>
+</ecoSpold>
+""",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "out"
+    status = main(
+        [
+            "--input",
+            str(source),
+            "--output-dir",
+            str(output_dir),
+            "--target",
+            "both",
+        ]
+    )
+
+    report = json.loads(
+        (output_dir / "conversion-report.json").read_text(encoding="utf-8")
+    )
+    process = _read_process(output_dir / "tidas", process_uuid)
+    process_info = process["processInformation"]
+    data_sources = process["modellingAndValidation"][
+        "dataSourcesTreatmentAndRepresentativeness"
+    ]
+    co2_exchange = _exchange_for_flow(process, "carbon dioxide")
+    co2_flow = _find_flow(output_dir / "tidas", "carbon dioxide")["flowDataSet"][
+        "flowInformation"
+    ]["dataSetInformation"]
+
+    assert status == 0
+    assert report["validation"]["tidas"]["ok"] is True
+    assert report["validation"]["ilcd"]["ok"] is True
+    assert process_info["time"]["common:referenceYear"] == 2020
+    assert process_info["time"]["common:dataSetValidUntil"] == 2023
+    assert (
+        process_info["geography"]["locationOfOperationSupplyOrProduction"]["@location"]
+        == "CH"
+    )
+    assert (
+        process_info["technology"]["technologyDescriptionAndIncludedProcesses"]["#text"]
+        == "Electric arc furnace route"
+    )
+    assert data_sources["annualSupplyOrProductionVolume"]["#text"] == "123 kg"
+    assert data_sources["samplingProcedure"]["#text"] == "supplier survey"
+    assert "source data set" == data_sources["referenceToDataSource"]["@type"]
+    assert (
+        _trace_marker(process_info["dataSetInformation"]["common:other"])
+        == "TIDAS_IMPORT_TRACE_V1"
+    )
+    assert co2_exchange["minimumAmount"] == "1.2"
+    assert co2_exchange["maximumAmount"] == "3.4"
+    assert co2_exchange["uncertaintyDistributionType"] == "log-normal"
+    assert co2_exchange["relativeStandardDeviation95In"] == "12.346"
+    assert "measured stack emissions" in co2_exchange["generalComment"]["#text"]
+    assert _trace_marker(co2_exchange["common:other"]) == "TIDAS_IMPORT_TRACE_V1"
+    assert co2_flow["CASNumber"] == "124-38-9"
+    assert co2_flow["sumFormula"] == "CO2"
+    assert co2_flow["common:synonyms"]["#text"] == "CO2 local"
+    assert _trace_marker(co2_flow["common:other"]) == "TIDAS_IMPORT_TRACE_V1"
+
+
 def test_ecospold1_import_uses_filename_uuid_and_local_exchange_ids(tmp_path):
     process_uuid = "64e926e8-dd48-3704-b902-daaf546087c4"
     source = tmp_path / f"process_{process_uuid}.xml"
@@ -216,6 +304,18 @@ def _flow_ref_for_exchange(process, flow_name):
         if ref["common:shortDescription"]["#text"] == flow_name:
             return ref["@refObjectId"]
     raise AssertionError(f"Exchange not found: {flow_name}")
+
+
+def _exchange_for_flow(process, flow_name):
+    for exchange in process["exchanges"]["exchange"]:
+        ref = exchange["referenceToFlowDataSet"]
+        if ref["common:shortDescription"]["#text"] == flow_name:
+            return exchange
+    raise AssertionError(f"Exchange not found: {flow_name}")
+
+
+def _trace_marker(common_other):
+    return common_other["tidasimport:sourceTrace"]["@marker"]
 
 
 def _has_flow_property(tidas_dir, expected_name):

--- a/tests/test_import_lca_ecospold2.py
+++ b/tests/test_import_lca_ecospold2.py
@@ -94,6 +94,106 @@ def test_ecospold2_minimal_import_can_write_valid_tidas_and_ilcd(tmp_path):
     assert co2["sumFormula"] == "CO2"
 
 
+def test_ecospold2_import_maps_semantic_fields_and_source_trace(tmp_path):
+    process_uuid = "22222222-2222-4222-8222-222222222222"
+    product_id = "11111111-1111-4111-8111-111111111111"
+    source = tmp_path / f"{process_uuid}_{product_id}.spold"
+    source.write_text(
+        f"""<?xml version="1.0" encoding="UTF-8"?>
+<ecoSpold xmlns="http://www.EcoInvent.org/EcoSpold02">
+  <fileAttributes majorRelease="3" minorRelease="12" internalSchemaVersion="2.0" defaultLanguage="en"/>
+  <activityDataset>
+    <activityDescription>
+      <activity id="{process_uuid}" specialActivityType="0">
+        <activityName xml:lang="en">market for enriched product</activityName>
+        <generalComment>
+          <text xml:lang="en" index="1">Activity note</text>
+        </generalComment>
+      </activity>
+      <timePeriod>
+        <startDate>2024-01-01</startDate>
+        <endDate>2025-12-31</endDate>
+        <comment xml:lang="en">Temporal representativeness note</comment>
+      </timePeriod>
+      <geography>
+        <shortname xml:lang="en">CH</shortname>
+        <comment xml:lang="en">Swiss geography note</comment>
+      </geography>
+      <technology>
+        <comment xml:lang="en">Heat pump route</comment>
+      </technology>
+    </activityDescription>
+    <flowData>
+      <intermediateExchange id="{product_id}" amount="1" productionVolumeAmount="42.0" isCalculatedAmount="true" intermediateExchangeId="{product_id}">
+        <name xml:lang="en">enriched product</name>
+        <unitName xml:lang="en">kg</unitName>
+        <comment xml:lang="en">calculated reference product</comment>
+        <outputGroup>0</outputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="33333333-3333-4333-8333-333333333333" amount="0.2" isCalculatedAmount="true" activityLinkId="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa">
+        <name xml:lang="en">linked input</name>
+        <unitName xml:lang="en">kg</unitName>
+        <comment xml:lang="en">linked input comment</comment>
+        <uncertainty>
+          <lognormal meanValue="0.2" variance="0.12"/>
+        </uncertainty>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+    </flowData>
+  </activityDataset>
+</ecoSpold>
+""",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "out"
+    status = main(
+        [
+            "--input",
+            str(source),
+            "--output-dir",
+            str(output_dir),
+            "--target",
+            "both",
+        ]
+    )
+
+    report = json.loads(
+        (output_dir / "conversion-report.json").read_text(encoding="utf-8")
+    )
+    process = _read_only_process(output_dir / "tidas")
+    process_info = process["processInformation"]
+    linked_input = _exchange_for_flow(process, "linked input")
+
+    assert status == 0
+    assert report["validation"]["tidas"]["ok"] is True
+    assert report["validation"]["ilcd"]["ok"] is True
+    assert process_info["time"]["common:referenceYear"] == 2024
+    assert process_info["time"]["common:dataSetValidUntil"] == 2025
+    assert (
+        process_info["time"]["common:timeRepresentativenessDescription"]["#text"]
+        == "2024-01-01 - 2025-12-31; Temporal representativeness note"
+    )
+    assert (
+        process_info["geography"]["locationOfOperationSupplyOrProduction"][
+            "descriptionOfRestrictions"
+        ]["#text"]
+        == "Swiss geography note"
+    )
+    assert (
+        process_info["technology"]["technologyDescriptionAndIncludedProcesses"]["#text"]
+        == "Heat pump route"
+    )
+    assert (
+        _trace_marker(process_info["dataSetInformation"]["common:other"])
+        == "TIDAS_IMPORT_TRACE_V1"
+    )
+    assert linked_input["dataDerivationTypeStatus"] == "Calculated"
+    assert linked_input["uncertaintyDistributionType"] == "log-normal"
+    assert "linked input comment" in linked_input["generalComment"]["#text"]
+    assert _trace_marker(linked_input["common:other"]) == "TIDAS_IMPORT_TRACE_V1"
+
+
 def test_ecospold2_import_uses_filename_uuid_and_merges_generated_flows(tmp_path):
     source_dir = tmp_path / "source"
     source_dir.mkdir()
@@ -318,6 +418,12 @@ def _read_process(tidas_dir, process_id):
     )["processDataSet"]
 
 
+def _read_only_process(tidas_dir):
+    process_paths = list((tidas_dir / "processes").glob("*.json"))
+    assert len(process_paths) == 1
+    return json.loads(process_paths[0].read_text(encoding="utf-8"))["processDataSet"]
+
+
 def _flow_ref_for_exchange(process, flow_name):
     refs = _flow_refs_for_exchanges(process, flow_name)
     if not refs:
@@ -332,6 +438,18 @@ def _flow_refs_for_exchanges(process, flow_name):
         if ref["common:shortDescription"]["#text"] == flow_name:
             refs.append(ref["@refObjectId"])
     return refs
+
+
+def _exchange_for_flow(process, flow_name):
+    for exchange in process["exchanges"]["exchange"]:
+        ref = exchange["referenceToFlowDataSet"]
+        if ref["common:shortDescription"]["#text"] == flow_name:
+            return exchange
+    raise AssertionError(f"Exchange not found: {flow_name}")
+
+
+def _trace_marker(common_other):
+    return common_other["tidasimport:sourceTrace"]["@marker"]
 
 
 def _find_flow(tidas_dir, expected_name):


### PR DESCRIPTION
Closes tiangong-lca/tidas-tools#63

## Summary
- Map additional EcoSpold1 and EcoSpold2 process, flow, source, and exchange fields into official TIDAS locations where schema-compatible.
- Preserve remaining source XML metadata in scanner-friendly common:other trace payloads using TIDAS_IMPORT_TRACE_V1.
- Centralize generated import placeholder markers with TIDAS_IMPORT_PLACEHOLDER prefixes for later cleanup scans.

## Key Decisions
- Keep source trace payloads under a dedicated tidasimport extension namespace so TIDAS JSON and eILCD XML validation both remain compatible.
- Use official ILCD field ordering in the TIDAS writer for enriched fields because JSON schema validation is less strict than XML schema sequence validation.

## Validation
- uv run black --check --target-version py313 src tests
- uv run pytest -q
- EcoSpold1 and EcoSpold2 real-sample imports from temp data both passed TIDAS and ILCD validation with --target both.
- ./scripts/docpact-gate.sh --base origin/main

## Risks / Rollback
- Medium risk: output packages now intentionally carry larger common:other trace payloads to avoid source metadata loss.

## Follow-ups
- Workspace root submodule integration is still required after this tidas-tools PR merges.

## Workspace Integration
- Requires a later lca-workspace pointer bump because tidas-tools is a submodule.