### PR TITLE
feat: map openLCA JSON-LD lifecycle models

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-21"
-lastReviewedCommit: "0c5ff07c81df294a55801456df0f1a06e7771388"
+lastReviewedAt: "2026-05-22"
+lastReviewedCommit: "dde72d1d0e86fd7bde0483364fa010caf530c3e9"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-21
-lastReviewedCommit: 0c5ff07c81df294a55801456df0f1a06e7771388
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: dde72d1d0e86fd7bde0483364fa010caf530c3e9
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -24,8 +24,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-21
-lastReviewedCommit: 0c5ff07c81df294a55801456df0f1a06e7771388
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: dde72d1d0e86fd7bde0483364fa010caf530c3e9
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-21
-lastReviewedCommit: 0c5ff07c81df294a55801456df0f1a06e7771388
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: dde72d1d0e86fd7bde0483364fa010caf530c3e9
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/src/tidas_tools/import_lca/adapters/openlca_jsonld.py
+++ b/src/tidas_tools/import_lca/adapters/openlca_jsonld.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import re
 from typing import Any, Iterable
 import uuid
 import zipfile
@@ -26,25 +27,25 @@ class OpenLcaJsonLdAdapter(SourceAdapter):
         report: ConversionReport,
     ) -> None:
         count = 0
+        unsupported_items = []
         for label, payload in _iter_json_payloads(Path(source)):
             for item in _iter_items(payload):
                 if not isinstance(item, dict):
                     continue
-                entity = _to_entity(item)
+                entity = _to_entity(item, label)
                 if entity is None:
+                    unsupported_items.append(_unsupported_item(label, item))
                     continue
                 store.add(entity)
                 count += 1
-                report.add_issue(
-                    severity="warning",
-                    code="jsonld_minimal_mapping",
-                    message=(
-                        f"Mapped {entity.entity_type} from openLCA JSON-LD with "
-                        "the current minimal adapter."
-                    ),
-                    source_object=label,
-                    context={"entity_id": entity.internal_id},
-                )
+
+        if unsupported_items:
+            store.add(_auxiliary_source_entity(unsupported_items))
+            count += 1
+
+        lifecycle_model = _provider_graph_lifecycle_model(store, source)
+        if lifecycle_model is not None:
+            store.add(lifecycle_model)
 
         if count == 0:
             report.add_issue(
@@ -52,6 +53,22 @@ class OpenLcaJsonLdAdapter(SourceAdapter):
                 code="no_supported_jsonld_entities",
                 message="No supported openLCA JSON-LD entities were found.",
             )
+            return
+
+        counts = store.counts()
+        report.add_issue(
+            severity="warning",
+            code="jsonld_semantic_mapping_with_trace",
+            message=(
+                "Mapped openLCA JSON-LD entities to TIDAS fields where possible "
+                "and preserved source trace metadata in common:other."
+            ),
+            context={
+                "entity_counts": counts,
+                "unsupported_json_items": len(unsupported_items),
+                "lifecyclemodels": counts.get("lifecyclemodels", 0),
+            },
+        )
 
 
 def _iter_json_payloads(source: Path) -> Iterable[tuple[str, Any]]:
@@ -91,7 +108,7 @@ def _iter_items(payload: Any) -> Iterable[dict[str, Any]]:
             yield payload
 
 
-def _to_entity(item: dict[str, Any]) -> CanonicalEntity | None:
+def _to_entity(item: dict[str, Any], label: str) -> CanonicalEntity | None:
     type_name = _type_name(item.get("@type"))
     entity_type = {
         "actor": "contacts",
@@ -106,12 +123,15 @@ def _to_entity(item: dict[str, Any]) -> CanonicalEntity | None:
 
     entity_id = _entity_id(item, entity_type)
     raw = dict(item)
+    raw["sourceTrace"] = _source_trace(label, _root_trace_payload(item))
     if entity_type == "flowproperties":
         raw.update(_flow_property_refs(item))
     elif entity_type == "flows":
         raw.update(_flow_refs(item))
+        raw.update(_flow_metadata(item))
     elif entity_type == "processes":
-        raw["exchanges"] = _process_exchanges(item)
+        raw.update(_process_metadata(item))
+        raw["exchanges"] = _process_exchanges(item, label)
 
     return CanonicalEntity(
         entity_type=entity_type,
@@ -156,7 +176,65 @@ def _flow_refs(item: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _process_exchanges(item: dict[str, Any]) -> list[dict[str, Any]]:
+def _flow_metadata(item: dict[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    if _text(item.get("refUnit")):
+        metadata["unitName"] = str(item["refUnit"]).strip()
+    formula = item.get("formula")
+    if _looks_like_chemical_formula(formula):
+        metadata["sumFormula"] = str(formula).strip()
+    return metadata
+
+
+def _process_metadata(item: dict[str, Any]) -> dict[str, Any]:
+    documentation = item.get("processDocumentation")
+    if not isinstance(documentation, dict):
+        documentation = {}
+
+    metadata: dict[str, Any] = {
+        "sourceFormat": "openlca-jsonld",
+        "sourceProcessType": item.get("processType"),
+        "sourceDefaultAllocationMethod": item.get("defaultAllocationMethod"),
+        "version": item.get("version"),
+        "lastChange": item.get("lastChange"),
+        "referenceYear": _year_from(documentation.get("validFrom")),
+        "dataSetValidUntil": _year_from(documentation.get("validUntil")),
+        "timeDescription": documentation.get("timeDescription"),
+        "location": _location_code(item.get("location")),
+        "locationDescription": documentation.get("geographyDescription"),
+        "technologyDescription": documentation.get("technologyDescription"),
+        "samplingProcedure": documentation.get("samplingDescription"),
+        "dataCollectionPeriod": documentation.get("dataCollectionDescription"),
+        "dataSelectionAndCombinationPrinciples": documentation.get(
+            "dataSelectionDescription"
+        ),
+        "dataTreatmentAndExtrapolationsPrinciples": documentation.get(
+            "dataTreatmentDescription"
+        ),
+        "dataCutOffAndCompletenessPrinciples": documentation.get(
+            "completenessDescription"
+        ),
+        "uncertaintyAdjustments": documentation.get("uncertaintyAdjustments"),
+        "useAdviceForDataSet": documentation.get("useAdvice"),
+        "intendedApplications": documentation.get("intendedApplication"),
+        "project": documentation.get("projectDescription"),
+        "modellingConstants": documentation.get("modelingConstantsDescription"),
+        "deviationsFromLCIMethodPrinciple": documentation.get(
+            "inventoryMethodDescription"
+        ),
+        "accessRestrictions": documentation.get("restrictionsDescription"),
+        "copyright": documentation.get("isCopyrightProtected"),
+        "creationDate": documentation.get("creationDate"),
+        "dataGeneratorRef": _reference_payload(documentation.get("dataGenerator")),
+        "dataEntryByRef": _reference_payload(documentation.get("dataDocumentor")),
+        "dataSetOwnerRef": _reference_payload(documentation.get("dataSetOwner")),
+        "publicationRef": _reference_payload(documentation.get("publication")),
+        "sourceRefs": _reference_list(documentation.get("sources")),
+    }
+    return {key: value for key, value in metadata.items() if value not in (None, [])}
+
+
+def _process_exchanges(item: dict[str, Any], label: str) -> list[dict[str, Any]]:
     exchanges = item.get("exchanges")
     if not isinstance(exchanges, list):
         return []
@@ -165,17 +243,129 @@ def _process_exchanges(item: dict[str, Any]) -> list[dict[str, Any]]:
         if not isinstance(exchange, dict):
             continue
         flow = exchange.get("flow")
+        unit = exchange.get("unit")
+        flow_property = exchange.get("flowProperty")
+        provider = exchange.get("defaultProvider")
+        uncertainty = exchange.get("uncertainty")
+        exchange_metadata = {
+            "internalId": exchange.get("internalId"),
+            "flow": flow if isinstance(flow, dict) else {},
+            "flowRefId": _ref_id(flow) if isinstance(flow, dict) else None,
+            "flowName": _name(flow) if isinstance(flow, dict) else None,
+            "isInput": bool(exchange.get("isInput", False)),
+            "amount": exchange.get("amount", 1),
+            "amountFormula": exchange.get("amountFormula"),
+            "isQuantitativeReference": bool(
+                exchange.get("isQuantitativeReference", False)
+            ),
+            "isAvoidedProduct": exchange.get("isAvoidedProduct"),
+            "unitId": _ref_id(unit) if isinstance(unit, dict) else None,
+            "unitName": _name(unit) if isinstance(unit, dict) else None,
+            "flowPropertyRefId": (
+                _ref_id(flow_property) if isinstance(flow_property, dict) else None
+            ),
+            "flowPropertyName": (
+                _name(flow_property) if isinstance(flow_property, dict) else None
+            ),
+            "providerRefId": _ref_id(provider) if isinstance(provider, dict) else None,
+            "providerName": _name(provider) if isinstance(provider, dict) else None,
+            "provider": provider if isinstance(provider, dict) else None,
+            "location": _location_code(exchange.get("location")),
+            "dqEntry": exchange.get("dqEntry"),
+            "uncertaintyDistributionType": _uncertainty_distribution_type(uncertainty),
+            "minimumAmount": _uncertainty_bound(uncertainty, "minimum"),
+            "maximumAmount": _uncertainty_bound(uncertainty, "maximum"),
+            "generalComment": exchange.get("description"),
+            "sourceTrace": _source_trace(label, {"exchange": exchange}),
+        }
         result.append(
             {
-                "internalId": exchange.get("internalId"),
-                "flow": flow if isinstance(flow, dict) else {},
-                "flowRefId": _ref_id(flow) if isinstance(flow, dict) else None,
-                "flowName": _name(flow) if isinstance(flow, dict) else None,
-                "isInput": bool(exchange.get("isInput", False)),
-                "amount": exchange.get("amount", 1),
+                key: value
+                for key, value in exchange_metadata.items()
+                if value not in (None, {})
             }
         )
     return result
+
+
+def _provider_graph_lifecycle_model(
+    store: MemoryCanonicalStore, source: str | Path
+) -> CanonicalEntity | None:
+    processes = sorted(
+        store.iter_type("processes"), key=lambda entity: entity.internal_id
+    )
+    process_ids = {entity.internal_id for entity in processes}
+    if len(processes) < 2:
+        return None
+
+    connections = []
+    skipped = []
+    for consumer in processes:
+        for exchange in consumer.raw.get("exchanges") or []:
+            provider_id = exchange.get("providerRefId")
+            if not provider_id:
+                continue
+            if not exchange.get("isInput", False):
+                skipped.append(_provider_skip_payload(consumer, exchange, "non_input"))
+                continue
+            if provider_id not in process_ids:
+                skipped.append(
+                    _provider_skip_payload(consumer, exchange, "missing_provider")
+                )
+                continue
+            flow_id = exchange.get("flowRefId")
+            if not _is_uuid(flow_id):
+                skipped.append(
+                    _provider_skip_payload(consumer, exchange, "missing_flow")
+                )
+                continue
+            connections.append(
+                {
+                    "providerProcessId": provider_id,
+                    "consumerProcessId": consumer.internal_id,
+                    "flowRefId": flow_id,
+                    "flowName": exchange.get("flowName"),
+                    "consumerExchangeInternalId": exchange.get("internalId"),
+                    "amount": exchange.get("amount"),
+                    "location": exchange.get("location"),
+                }
+            )
+
+    if not connections:
+        return None
+
+    reference_process = _reference_process(processes)
+    model_id = str(
+        uuid.uuid5(uuid.NAMESPACE_URL, f"openlca-jsonld/lifecyclemodel/{source}")
+    )
+    return CanonicalEntity(
+        entity_type="lifecyclemodels",
+        internal_id=model_id,
+        name="openLCA JSON-LD provider graph",
+        raw={
+            "description": (
+                "Derived lifecycle model from openLCA JSON-LD exchange "
+                "defaultProvider links."
+            ),
+            "referenceProcessId": reference_process.internal_id,
+            "processRefs": [
+                {
+                    "id": entity.internal_id,
+                    "name": entity.name or "Process",
+                    "processType": entity.raw.get("sourceProcessType"),
+                }
+                for entity in processes
+            ],
+            "connections": connections,
+            "sourceTrace": {
+                "format": "openlca-jsonld",
+                "sourceObject": str(source),
+                "derivedEntity": "provider-graph-lifecyclemodel",
+                "providerConnectionCount": len(connections),
+                "skippedProviderLinks": skipped,
+            },
+        },
+    )
 
 
 def _type_name(value: Any) -> str:
@@ -200,7 +390,9 @@ def _external_id(item: dict[str, Any]) -> str | None:
     return None
 
 
-def _ref_id(ref: dict[str, Any]) -> str | None:
+def _ref_id(ref: dict[str, Any] | None) -> str | None:
+    if not isinstance(ref, dict):
+        return None
     candidate = _external_id(ref)
     if not candidate:
         return None
@@ -217,6 +409,78 @@ def _is_uuid(value: str | None) -> bool:
     except ValueError:
         return False
     return True
+
+
+def _reference_process(processes: list[CanonicalEntity]) -> CanonicalEntity:
+    for entity in processes:
+        if entity.raw.get("sourceProcessType") == "LCI_RESULT":
+            return entity
+    return processes[0]
+
+
+def _unsupported_item(label: str, item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "sourceObject": label,
+        "type": item.get("@type") or item.get("type"),
+        "id": _external_id(item),
+        "payload": item,
+    }
+
+
+def _auxiliary_source_entity(items: list[dict[str, Any]]) -> CanonicalEntity:
+    source_id = str(uuid.uuid5(uuid.NAMESPACE_URL, "openlca-jsonld/auxiliary-metadata"))
+    return CanonicalEntity(
+        entity_type="sources",
+        internal_id=source_id,
+        name="openLCA JSON-LD auxiliary metadata",
+        raw={
+            "shortName": "openLCA JSON-LD auxiliary metadata",
+            "sourceCitation": (
+                "openLCA JSON-LD auxiliary metadata without a direct TIDAS "
+                "root dataset target"
+            ),
+            "description": (
+                "Unsupported or package-level JSON-LD objects preserved for "
+                "traceability."
+            ),
+            "sourceTrace": {
+                "format": "openlca-jsonld",
+                "sourceObject": "auxiliary-jsonld-metadata",
+                "items": items,
+            },
+        },
+    )
+
+
+def _source_trace(label: str, payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "format": "openlca-jsonld",
+        "sourceObject": label,
+        "payload": payload,
+    }
+
+
+def _root_trace_payload(item: dict[str, Any]) -> dict[str, Any]:
+    if _type_name(item.get("@type")) != "process":
+        return {"entity": item}
+    payload = dict(item)
+    if isinstance(payload.get("exchanges"), list):
+        payload["exchanges"] = (
+            "TIDAS_IMPORT_TRACE_EXCHANGES_STORED_ON_EXCHANGE_COMMON_OTHER"
+        )
+    return {"entity": payload}
+
+
+def _provider_skip_payload(
+    process: CanonicalEntity, exchange: dict[str, Any], reason: str
+) -> dict[str, Any]:
+    return {
+        "reason": reason,
+        "consumerProcessId": process.internal_id,
+        "providerProcessId": exchange.get("providerRefId"),
+        "flowRefId": exchange.get("flowRefId"),
+        "exchangeInternalId": exchange.get("internalId"),
+    }
 
 
 def _name(item: Any) -> str | None:
@@ -237,6 +501,26 @@ def _localized(value: Any) -> str | None:
     return None
 
 
+def _reference_payload(item: Any) -> dict[str, str] | None:
+    if not isinstance(item, dict):
+        return None
+    ref_id = _ref_id(item)
+    if not ref_id:
+        return None
+    return {"id": ref_id, "name": _name(item) or ref_id}
+
+
+def _reference_list(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        return []
+    refs = []
+    for item in value:
+        ref = _reference_payload(item)
+        if ref:
+            refs.append(ref)
+    return refs
+
+
 def _category_path(item: dict[str, Any]) -> list[str]:
     category = item.get("category")
     if isinstance(category, str):
@@ -245,3 +529,54 @@ def _category_path(item: dict[str, Any]) -> list[str]:
         name = _name(category)
         return [name] if name else []
     return []
+
+
+def _location_code(value: Any) -> str | None:
+    if isinstance(value, dict):
+        for key in ("code", "name"):
+            text = value.get(key)
+            if _text(text):
+                return str(text).strip()
+    if _text(value):
+        return str(value).strip()
+    return None
+
+
+def _year_from(value: Any) -> int | None:
+    if value is None:
+        return None
+    text = str(value)
+    match = re.search(r"\b(\d{4})\b", text)
+    return int(match.group(1)) if match else None
+
+
+def _uncertainty_distribution_type(value: Any) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    mapping = {
+        "LOG_NORMAL_DISTRIBUTION": "log-normal",
+        "TRIANGLE_DISTRIBUTION": "triangular",
+        "TRIANGULAR_DISTRIBUTION": "triangular",
+        "UNIFORM_DISTRIBUTION": "uniform",
+        "NORMAL_DISTRIBUTION": "normal",
+    }
+    return mapping.get(str(value.get("distributionType") or "").strip().upper())
+
+
+def _uncertainty_bound(value: Any, key: str) -> Any:
+    if isinstance(value, dict):
+        return value.get(key)
+    return None
+
+
+def _looks_like_chemical_formula(value: Any) -> bool:
+    if not _text(value):
+        return False
+    text = str(value).strip()
+    if len(text) > 100 or any(char.isspace() for char in text):
+        return False
+    return bool(re.fullmatch(r"(?:[A-Z][a-z]?\d*(?:[()]\d*)?)+[+-]?", text))
+
+
+def _text(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())

--- a/src/tidas_tools/import_lca/writers/tidas_json.py
+++ b/src/tidas_tools/import_lca/writers/tidas_json.py
@@ -26,6 +26,8 @@ PLACEHOLDER_DATA_CUTOFF = f"{PLACEHOLDER_PREFIX}:DATA_CUTOFF_NOT_AVAILABLE"
 PLACEHOLDER_DATA_SOURCE = f"{PLACEHOLDER_PREFIX}:DATA_SOURCE_NOT_AVAILABLE"
 PLACEHOLDER_ANNUAL_VOLUME = f"0 {PLACEHOLDER_PREFIX}:ANNUAL_VOLUME_NOT_AVAILABLE"
 PLACEHOLDER_CONVERTED_APPLICATION = f"{PLACEHOLDER_PREFIX}:CONVERTED_EXTERNAL_LCA_DATA"
+PLACEHOLDER_YEAR = 9999
+PLACEHOLDER_REVIEW_NOT_AVAILABLE = f"{PLACEHOLDER_PREFIX}:REVIEW_NOT_AVAILABLE"
 IMPORT_CONTACT_ID = str(
     uuid.uuid5(uuid.NAMESPACE_URL, f"{IMPORT_ID_NAMESPACE}/contact")
 )
@@ -120,6 +122,12 @@ def write_tidas_package(store: MemoryCanonicalStore, output_dir: str | Path) -> 
             _process_dataset(entity),
         )
 
+    for entity in store.iter_type("lifecyclemodels"):
+        _write_json(
+            root / "lifecyclemodels" / f"{entity.internal_id}.json",
+            _lifecycle_model_dataset(entity),
+        )
+
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -128,6 +136,19 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
 
 def _ml(text: str, lang: str = "en") -> dict[str, str]:
     return {"@xml:lang": lang, "#text": text or PLACEHOLDER_UNSPECIFIED_TEXT}
+
+
+def _ml_500(text: Any, lang: str = "en") -> dict[str, str]:
+    value = str(text or PLACEHOLDER_UNSPECIFIED_TEXT)
+    return _ml(_truncate(value, 500), lang=lang)
+
+
+def _truncate(text: str, max_length: int) -> str:
+    if len(text) <= max_length:
+        return text
+    if max_length <= 3:
+        return text[:max_length]
+    return text[: max_length - 3].rstrip() + "..."
 
 
 def _now() -> str:
@@ -178,6 +199,20 @@ def _owner_ref() -> dict[str, Any]:
     )
 
 
+def _contact_ref_from_raw(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    ref_id = value.get("id")
+    if not _uuid_text(ref_id):
+        return None
+    return _ref(
+        ref_type="contact data set",
+        ref_id=str(ref_id),
+        short_description=str(value.get("name") or ref_id),
+        category="contacts",
+    )
+
+
 def _permanent_dataset_uri(
     category: str, dataset_id: str, version: str = DEFAULT_VERSION
 ) -> str:
@@ -193,13 +228,20 @@ def _admin_info(
     dataset_id: str,
     version: str = DEFAULT_VERSION,
     process: bool = False,
+    timestamp: Any = None,
+    data_entry_ref: dict[str, Any] | None = None,
+    owner_ref: dict[str, Any] | None = None,
+    copyright_value: Any = None,
+    access_restrictions: Any = None,
 ) -> dict[str, Any]:
     data_entry = {
-        "common:timeStamp": _now(),
+        "common:timeStamp": _date_time(timestamp) or _now(),
         "common:referenceToDataSetFormat": _format_ref(),
     }
     if process:
-        data_entry["common:referenceToPersonOrEntityEnteringTheData"] = _owner_ref()
+        data_entry["common:referenceToPersonOrEntityEnteringTheData"] = (
+            data_entry_ref or _owner_ref()
+        )
 
     publication = {
         "common:dataSetVersion": version,
@@ -210,13 +252,17 @@ def _admin_info(
     if process:
         publication.update(
             {
-                "common:referenceToOwnershipOfDataSet": _owner_ref(),
-                "common:copyright": "false",
+                "common:referenceToOwnershipOfDataSet": owner_ref or _owner_ref(),
+                "common:copyright": _bool_text(copyright_value),
                 "common:licenseType": "Free of charge for all users and uses",
             }
         )
+        if _text(access_restrictions):
+            publication["common:accessRestrictions"] = _ml(
+                str(access_restrictions).strip()
+            )
     else:
-        publication["common:referenceToOwnershipOfDataSet"] = _owner_ref()
+        publication["common:referenceToOwnershipOfDataSet"] = owner_ref or _owner_ref()
 
     return {
         "dataEntryBy": data_entry,
@@ -261,6 +307,7 @@ def _contact_dataset(entity: CanonicalEntity) -> dict[str, Any]:
         website=raw.get("website") or raw.get("url"),
         address=raw.get("address"),
         description=raw.get("description"),
+        source_trace=raw.get("sourceTrace"),
     )
 
 
@@ -274,11 +321,12 @@ def _contact_payload(
     website: Any = None,
     address: Any = None,
     description: Any = None,
+    source_trace: Any = None,
 ) -> dict[str, Any]:
     dataset_info = {
         "common:UUID": contact_id,
-        "common:shortName": _ml(str(short_name)),
-        "common:name": _ml(str(name)),
+        "common:shortName": _ml_500(short_name),
+        "common:name": _ml_500(name),
         "classificationInformation": {
             "common:classification": {
                 "common:class": {
@@ -299,6 +347,9 @@ def _contact_payload(
         dataset_info["contactAddress"] = _ml(str(address).strip())
     if _text(description):
         dataset_info["contactDescriptionOrComment"] = _ml(str(description).strip())
+    common_other = _common_other_trace(source_trace)
+    if common_other:
+        dataset_info["common:other"] = common_other
 
     return {
         "contactDataSet": {
@@ -358,7 +409,7 @@ def _source_payload(
 ) -> dict[str, Any]:
     dataset_info = {
         "common:UUID": source_id,
-        "common:shortName": _ml(str(short_name)),
+        "common:shortName": _ml_500(short_name),
         "classificationInformation": {
             "common:classification": {
                 "common:class": {
@@ -424,6 +475,22 @@ def _unit_group_dataset(entity: CanonicalEntity) -> dict[str, Any]:
                 ),
             }
         )
+    dataset_info = {
+        "common:UUID": entity.internal_id,
+        "common:name": _ml_500(entity.name or "Unit group"),
+        "classificationInformation": {
+            "common:classification": {
+                "common:class": {
+                    "@level": "0",
+                    "@classId": "4",
+                    "#text": "Other unit groups",
+                }
+            }
+        },
+    }
+    common_other = _common_other_trace(entity.raw.get("sourceTrace"))
+    if common_other:
+        dataset_info["common:other"] = common_other
 
     return {
         "unitGroupDataSet": {
@@ -433,19 +500,7 @@ def _unit_group_dataset(entity: CanonicalEntity) -> dict[str, Any]:
             "@version": "1.1",
             "@xsi:schemaLocation": "http://lca.jrc.it/ILCD/UnitGroup ../../schemas/ILCD_UnitGroupDataSet.xsd",
             "unitGroupInformation": {
-                "dataSetInformation": {
-                    "common:UUID": entity.internal_id,
-                    "common:name": _ml(entity.name or "Unit group"),
-                    "classificationInformation": {
-                        "common:classification": {
-                            "common:class": {
-                                "@level": "0",
-                                "@classId": "4",
-                                "#text": "Other unit groups",
-                            }
-                        }
-                    },
-                },
+                "dataSetInformation": dataset_info,
                 "quantitativeReference": {"referenceToReferenceUnit": "1"},
             },
             "modellingAndValidation": {
@@ -466,6 +521,22 @@ def _flow_property_dataset(
     unit_group_name = (
         entity.raw.get("unitGroupName") or default_unit_group.name or "Unit group"
     )
+    dataset_info = {
+        "common:UUID": entity.internal_id,
+        "common:name": _ml_500(entity.name or "Flow property"),
+        "classificationInformation": {
+            "common:classification": {
+                "common:class": {
+                    "@level": "0",
+                    "@classId": "4",
+                    "#text": "Other flow properties",
+                }
+            }
+        },
+    }
+    common_other = _common_other_trace(entity.raw.get("sourceTrace"))
+    if common_other:
+        dataset_info["common:other"] = common_other
     return {
         "flowPropertyDataSet": {
             "@xmlns": "http://lca.jrc.it/ILCD/FlowProperty",
@@ -474,19 +545,7 @@ def _flow_property_dataset(
             "@version": "1.1",
             "@xsi:schemaLocation": "http://lca.jrc.it/ILCD/FlowProperty ../../schemas/ILCD_FlowPropertyDataSet.xsd",
             "flowPropertiesInformation": {
-                "dataSetInformation": {
-                    "common:UUID": entity.internal_id,
-                    "common:name": _ml(entity.name or "Flow property"),
-                    "classificationInformation": {
-                        "common:classification": {
-                            "common:class": {
-                                "@level": "0",
-                                "@classId": "4",
-                                "#text": "Other flow properties",
-                            }
-                        }
-                    },
-                },
+                "dataSetInformation": dataset_info,
                 "quantitativeReference": {
                     "referenceToReferenceUnitGroup": _ref(
                         ref_type="unit group data set",
@@ -586,10 +645,14 @@ def _flow_dataset(
 
 def _process_dataset(entity: CanonicalEntity):
     exchanges = entity.raw.get("exchanges") or []
-    exchange_items = [
-        _exchange_item(exchange, idx) for idx, exchange in enumerate(exchanges, 1)
-    ]
-    reference_flow = _reference_flow_id(exchange_items)
+    exchange_items = []
+    reference_flow = None
+    for idx, exchange in enumerate(exchanges, 1):
+        exchange_items.append(_exchange_item(exchange, idx))
+        if exchange.get("isQuantitativeReference") and reference_flow is None:
+            reference_flow = str(idx)
+    if reference_flow is None:
+        reference_flow = _reference_flow_id(exchange_items)
     reference_year = _reference_year(entity.raw.get("referenceYear"))
     valid_until = _optional_year(entity.raw.get("dataSetValidUntil"))
     location = _location_code(entity.raw.get("location"))
@@ -634,9 +697,7 @@ def _process_dataset(entity: CanonicalEntity):
     if technology:
         process_information["technology"] = technology
 
-    modelling_and_validation = {
-        "LCIMethodAndAllocation": {"typeOfDataSet": "Unit process, single operation"}
-    }
+    modelling_and_validation = {"LCIMethodAndAllocation": _process_lci_method(entity)}
     data_sources = _data_sources_treatment_and_representativeness(entity)
     if data_sources:
         modelling_and_validation["dataSourcesTreatmentAndRepresentativeness"] = (
@@ -664,6 +725,39 @@ def _process_dataset(entity: CanonicalEntity):
         ]
         reference_flow = "1"
 
+    commissioner_and_goal = {
+        "common:referenceToCommissioner": _process_commissioner_ref(entity),
+        "common:intendedApplications": _ml(
+            str(
+                entity.raw.get("intendedApplications")
+                or PLACEHOLDER_CONVERTED_APPLICATION
+            )
+        ),
+    }
+    if _text(entity.raw.get("project")):
+        commissioner_and_goal["common:project"] = _ml_500(
+            str(entity.raw["project"]).strip()
+        )
+    administrative_information = {
+        "common:commissionerAndGoal": commissioner_and_goal,
+        **_admin_info(
+            category="processes",
+            dataset_id=entity.internal_id,
+            version=_dataset_version(entity.raw.get("version")),
+            process=True,
+            timestamp=entity.raw.get("lastChange") or entity.raw.get("creationDate"),
+            data_entry_ref=_contact_ref_from_raw(entity.raw.get("dataEntryByRef")),
+            owner_ref=_contact_ref_from_raw(entity.raw.get("dataSetOwnerRef")),
+            copyright_value=entity.raw.get("copyright"),
+            access_restrictions=entity.raw.get("accessRestrictions"),
+        ),
+    }
+    data_generator_ref = _contact_ref_from_raw(entity.raw.get("dataGeneratorRef"))
+    if data_generator_ref:
+        administrative_information["dataGenerator"] = {
+            "common:referenceToPersonOrEntityGeneratingTheDataSet": data_generator_ref
+        }
+
     return {
         "processDataSet": {
             "@xmlns": "http://lca.jrc.it/ILCD/Process",
@@ -674,6 +768,57 @@ def _process_dataset(entity: CanonicalEntity):
             "@xsi:schemaLocation": "http://lca.jrc.it/ILCD/Process ../../schemas/ILCD_ProcessDataSet.xsd",
             "processInformation": process_information,
             "modellingAndValidation": modelling_and_validation,
+            "administrativeInformation": administrative_information,
+            "exchanges": {"exchange": exchange_items},
+        }
+    }
+
+
+def _lifecycle_model_dataset(entity: CanonicalEntity) -> dict[str, Any]:
+    raw = entity.raw or {}
+    process_instances = _lifecycle_process_instances(entity)
+    reference_instance = _lifecycle_reference_instance(raw, process_instances)
+    dataset_info = {
+        "common:UUID": entity.internal_id,
+        "name": _name_parts(entity.name or "Life cycle model"),
+        "classificationInformation": _default_process_classification(),
+        "common:generalComment": _ml(
+            raw.get("description") or PLACEHOLDER_CONVERTED_APPLICATION
+        ),
+    }
+    common_other = _common_other_trace(raw.get("sourceTrace"))
+    if common_other:
+        dataset_info["common:other"] = common_other
+
+    return {
+        "lifeCycleModelDataSet": {
+            "@xmlns": "http://eplca.jrc.ec.europa.eu/ILCD/LifeCycleModel/2017",
+            "@xmlns:acme": "http://acme.com/custom",
+            "@xmlns:common": "http://lca.jrc.it/ILCD/Common",
+            "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+            "@locations": "../ILCDLocations.xml",
+            "@version": "1.1",
+            "@xsi:schemaLocation": "http://eplca.jrc.ec.europa.eu/ILCD/LifeCycleModel/2017 ../../schemas/ILCD_LifeCycleModelDataSet.xsd",
+            "lifeCycleModelInformation": {
+                "dataSetInformation": dataset_info,
+                "quantitativeReference": {
+                    "referenceToReferenceProcess": reference_instance
+                },
+                "technology": {
+                    "processes": {"processInstance": process_instances},
+                },
+            },
+            "modellingAndValidation": {
+                "validation": {
+                    "review": {
+                        "common:referenceToNameOfReviewerAndInstitution": _owner_ref(),
+                        "common:otherReviewDetails": _ml(
+                            PLACEHOLDER_REVIEW_NOT_AVAILABLE
+                        ),
+                    }
+                },
+                "complianceDeclarations": _compliance_declarations(process=True),
+            },
             "administrativeInformation": {
                 "common:commissionerAndGoal": {
                     "common:referenceToCommissioner": _owner_ref(),
@@ -682,14 +827,109 @@ def _process_dataset(entity: CanonicalEntity):
                     ),
                 },
                 **_admin_info(
-                    category="processes",
+                    category="lifecyclemodels",
                     dataset_id=entity.internal_id,
+                    version=_dataset_version(raw.get("version")),
                     process=True,
                 ),
             },
-            "exchanges": {"exchange": exchange_items},
         }
     }
+
+
+def _lifecycle_process_instances(entity: CanonicalEntity) -> list[dict[str, Any]]:
+    raw = entity.raw or {}
+    refs = [
+        ref
+        for ref in raw.get("processRefs") or []
+        if isinstance(ref, dict) and _uuid_text(ref.get("id"))
+    ]
+    instance_by_process = {
+        str(ref["id"]): str(index) for index, ref in enumerate(refs, start=1)
+    }
+    connections_by_provider: dict[str, dict[str, list[dict[str, Any]]]] = {}
+    for connection in raw.get("connections") or []:
+        if not isinstance(connection, dict):
+            continue
+        provider_id = str(connection.get("providerProcessId") or "")
+        consumer_id = str(connection.get("consumerProcessId") or "")
+        flow_id = str(connection.get("flowRefId") or "")
+        if (
+            provider_id not in instance_by_process
+            or consumer_id not in instance_by_process
+            or not _uuid_text(flow_id)
+        ):
+            continue
+        downstream = {
+            "@id": instance_by_process[consumer_id],
+            "@flowUUID": flow_id,
+        }
+        location = _location_code(connection.get("location"))
+        if connection.get("location") and location != "GLO":
+            downstream["@location"] = location
+        connections_by_provider.setdefault(provider_id, {}).setdefault(
+            flow_id, []
+        ).append(downstream)
+
+    instances = []
+    for ref in refs:
+        process_id = str(ref["id"])
+        instance = {
+            "@dataSetInternalID": instance_by_process[process_id],
+            "@multiplicationFactor": "1",
+            "referenceToProcess": _ref(
+                ref_type="process data set",
+                ref_id=process_id,
+                short_description=str(ref.get("name") or "Process"),
+                category="processes",
+            ),
+        }
+        output_exchanges = []
+        for flow_id, downstream_items in sorted(
+            connections_by_provider.get(process_id, {}).items()
+        ):
+            output_exchanges.append(
+                {
+                    "@flowUUID": flow_id,
+                    "@dominant": "true",
+                    "downstreamProcess": (
+                        downstream_items[0]
+                        if len(downstream_items) == 1
+                        else downstream_items
+                    ),
+                }
+            )
+        if output_exchanges:
+            instance["connections"] = {
+                "outputExchange": (
+                    output_exchanges[0]
+                    if len(output_exchanges) == 1
+                    else output_exchanges
+                )
+            }
+        trace = _common_other_trace(
+            {
+                "sourceProcessType": ref.get("processType"),
+                "sourceProcessId": process_id,
+            }
+        )
+        if trace:
+            instance["common:other"] = trace
+        instances.append(instance)
+    return instances
+
+
+def _lifecycle_reference_instance(
+    raw: dict[str, Any], process_instances: list[dict[str, Any]]
+) -> str:
+    reference_process_id = raw.get("referenceProcessId")
+    process_refs = raw.get("processRefs") or []
+    for index, ref in enumerate(process_refs, start=1):
+        if isinstance(ref, dict) and ref.get("id") == reference_process_id:
+            return str(index)
+    if process_instances:
+        return str(process_instances[0].get("@dataSetInternalID") or "1")
+    return "1"
 
 
 def _default_process_classification() -> dict[str, Any]:
@@ -721,6 +961,60 @@ def _default_process_classification() -> dict[str, Any]:
     }
 
 
+def _process_lci_method(entity: CanonicalEntity) -> dict[str, Any]:
+    raw = entity.raw
+    section: dict[str, Any] = {
+        "typeOfDataSet": _process_type(raw.get("sourceProcessType")),
+    }
+    allocation = _allocation_method(raw.get("sourceDefaultAllocationMethod"))
+    if allocation:
+        section["LCIMethodApproaches"] = allocation
+    if _text(raw.get("deviationsFromLCIMethodPrinciple")):
+        section["deviationsFromLCIMethodPrinciple"] = _ml(
+            str(raw["deviationsFromLCIMethodPrinciple"]).strip()
+        )
+    if _text(raw.get("modellingConstants")):
+        section["modellingConstants"] = _ml(str(raw["modellingConstants"]).strip())
+    common_other = _common_other_trace(
+        {
+            "sourceProcessType": raw.get("sourceProcessType"),
+            "sourceDefaultAllocationMethod": raw.get("sourceDefaultAllocationMethod"),
+        }
+    )
+    if common_other:
+        section["common:other"] = common_other
+    return section
+
+
+def _process_type(value: Any) -> str:
+    text = str(value or "").strip().upper()
+    if text == "LCI_RESULT":
+        return "LCI result"
+    if text == "PARTLY_TERMINATED_SYSTEM":
+        return "Partly terminated system"
+    if text == "AVOIDED_PRODUCT_SYSTEM":
+        return "Avoided product system"
+    return "Unit process, single operation"
+
+
+def _allocation_method(value: Any) -> str | None:
+    text = str(value or "").strip().upper()
+    return {
+        "ECONOMIC_ALLOCATION": "Allocation - market value",
+        "PHYSICAL_ALLOCATION": "Allocation - physical causality",
+        "CAUSAL_ALLOCATION": "Allocation - physical causality",
+        "NO_ALLOCATION": "Not applicable",
+    }.get(text)
+
+
+def _process_commissioner_ref(entity: CanonicalEntity) -> dict[str, Any]:
+    return (
+        _contact_ref_from_raw(entity.raw.get("dataSetOwnerRef"))
+        or _contact_ref_from_raw(entity.raw.get("dataGeneratorRef"))
+        or _owner_ref()
+    )
+
+
 def _technology_section(entity: CanonicalEntity) -> dict[str, Any] | None:
     description = entity.raw.get("technologyDescription")
     applicability = entity.raw.get("technologicalApplicability")
@@ -749,33 +1043,63 @@ def _data_sources_treatment_and_representativeness(
         "uncertaintyAdjustments",
         "useAdviceForDataSet",
         "dataCollectionPeriod",
+        "dataSelectionAndCombinationPrinciples",
+        "dataTreatmentAndExtrapolationsPrinciples",
+        "dataCutOffAndCompletenessPrinciples",
     }
     if not source_refs and not any(_text(raw.get(key)) for key in relevant_keys):
         return None
 
-    source_ref = source_refs[0] if source_refs else {}
-    source_id = source_ref.get("id") or FORMAT_SOURCE_ID
-    source_name = (
-        source_ref.get("name") or raw.get("sourceLabel") or PLACEHOLDER_DATA_SOURCE
-    )
+    source_refs_payload = [
+        _ref(
+            ref_type="source data set",
+            ref_id=source_ref.get("id"),
+            short_description=str(
+                source_ref.get("name")
+                or raw.get("sourceLabel")
+                or PLACEHOLDER_DATA_SOURCE
+            ),
+            category="sources",
+        )
+        for source_ref in source_refs
+        if _uuid_text(source_ref.get("id"))
+    ]
+    if not source_refs_payload:
+        source_refs_payload = [
+            _ref(
+                ref_type="source data set",
+                ref_id=FORMAT_SOURCE_ID,
+                short_description=PLACEHOLDER_DATA_SOURCE,
+                category="sources",
+            )
+        ]
     section: dict[str, Any] = {
         "dataCutOffAndCompletenessPrinciples": _ml(
             raw.get("dataCutOffAndCompletenessPrinciples") or PLACEHOLDER_DATA_CUTOFF
         ),
-        "referenceToDataSource": _ref(
-            ref_type="source data set",
-            ref_id=source_id,
-            short_description=str(source_name),
-            category="sources",
+        "referenceToDataSource": (
+            source_refs_payload[0]
+            if len(source_refs_payload) == 1
+            else source_refs_payload
         ),
         "annualSupplyOrProductionVolume": _annual_supply_or_production_volume(
             raw.get("productionVolume")
         ),
     }
+    if _text(raw.get("dataSelectionAndCombinationPrinciples")):
+        section["dataSelectionAndCombinationPrinciples"] = _ml(
+            str(raw["dataSelectionAndCombinationPrinciples"]).strip()
+        )
+    if _text(raw.get("dataTreatmentAndExtrapolationsPrinciples")):
+        section["dataTreatmentAndExtrapolationsPrinciples"] = _ml(
+            str(raw["dataTreatmentAndExtrapolationsPrinciples"]).strip()
+        )
     if _text(raw.get("samplingProcedure")):
         section["samplingProcedure"] = _ml(str(raw["samplingProcedure"]).strip())
     if _text(raw.get("dataCollectionPeriod")):
-        section["dataCollectionPeriod"] = _ml(str(raw["dataCollectionPeriod"]).strip())
+        section["dataCollectionPeriod"] = _ml_500(
+            str(raw["dataCollectionPeriod"]).strip()
+        )
     if _text(raw.get("uncertaintyAdjustments")):
         section["uncertaintyAdjustments"] = _ml(
             str(raw["uncertaintyAdjustments"]).strip()
@@ -821,6 +1145,9 @@ def _exchange_item(exchange: dict[str, Any], idx: int) -> dict[str, Any]:
         "meanAmount": amount,
         "resultingAmount": amount,
     }
+    location = _location_code(exchange.get("location"))
+    if exchange.get("location") and location != "GLO":
+        item["location"] = location
     minimum_amount = _optional_real(exchange.get("minimumAmount"))
     if minimum_amount is not None:
         item["minimumAmount"] = minimum_amount
@@ -846,10 +1173,12 @@ def _exchange_item(exchange: dict[str, Any], idx: int) -> dict[str, Any]:
         comments.append(
             f"Source EcoSpold2 exchange id: {exchange['sourceExchangeId']}."
         )
+    elif exchange.get("internalId") is not None:
+        comments.append(f"Source exchange internal id: {exchange['internalId']}.")
     if _text(exchange.get("generalComment")):
         comments.append(str(exchange["generalComment"]).strip())
     if comments:
-        item["generalComment"] = _ml(" ".join(comments))
+        item["generalComment"] = _ml_500(" ".join(comments))
 
     common_other = _common_other_trace(
         _exchange_trace_payload(exchange),
@@ -874,6 +1203,17 @@ def _exchange_trace_payload(exchange: dict[str, Any]) -> dict[str, Any] | None:
         "activityLinkId": exchange.get("activityLinkId"),
         "productionVolumeAmount": exchange.get("productionVolumeAmount"),
         "isCalculatedAmount": exchange.get("isCalculatedAmount"),
+        "amountFormula": exchange.get("amountFormula"),
+        "isQuantitativeReference": exchange.get("isQuantitativeReference"),
+        "isAvoidedProduct": exchange.get("isAvoidedProduct"),
+        "unitId": exchange.get("unitId"),
+        "unitName": exchange.get("unitName"),
+        "flowPropertyRefId": exchange.get("flowPropertyRefId"),
+        "flowPropertyName": exchange.get("flowPropertyName"),
+        "providerRefId": exchange.get("providerRefId"),
+        "providerName": exchange.get("providerName"),
+        "provider": exchange.get("provider"),
+        "dqEntry": exchange.get("dqEntry"),
     }
     if not source_trace and not any(value is not None for value in extra.values()):
         return None
@@ -887,9 +1227,9 @@ def _exchange_trace_payload(exchange: dict[str, Any]) -> dict[str, Any] | None:
 
 def _name_parts(name: str) -> dict[str, Any]:
     return {
-        "baseName": _ml(name),
-        "treatmentStandardsRoutes": _ml(""),
-        "mixAndLocationTypes": _ml(""),
+        "baseName": _ml_500(name),
+        "treatmentStandardsRoutes": _ml_500(""),
+        "mixAndLocationTypes": _ml_500(""),
     }
 
 
@@ -961,11 +1301,11 @@ def _generated_flow_property_for(
 
 def _reference_year(value: Any) -> int:
     if value is None:
-        return 2026
+        return PLACEHOLDER_YEAR
     text = str(value).strip()
     match = re.search(r"\b(\d{4})\b", text)
     if not match:
-        return 2026
+        return PLACEHOLDER_YEAR
     return int(match.group(1))
 
 
@@ -977,6 +1317,44 @@ def _optional_year(value: Any) -> int | None:
     if not match:
         return None
     return int(match.group(1))
+
+
+def _dataset_version(value: Any) -> str:
+    if value is None:
+        return DEFAULT_VERSION
+    text = str(value).strip()
+    return text or DEFAULT_VERSION
+
+
+def _date_time(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if "T" not in text:
+        return None
+    if text.endswith("Z"):
+        return text
+    if re.search(r"[+-]\d{2}:\d{2}$", text):
+        return text
+    return None
+
+
+def _bool_text(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    text = str(value or "").strip().casefold()
+    if text in {"true", "1", "yes"}:
+        return "true"
+    return "false"
+
+
+def _uuid_text(value: Any) -> bool:
+    return isinstance(value, str) and bool(
+        re.fullmatch(
+            r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+            value,
+        )
+    )
 
 
 def _cas_number(value: Any) -> str | None:

--- a/tests/test_import_lca_openlca_jsonld.py
+++ b/tests/test_import_lca_openlca_jsonld.py
@@ -9,6 +9,8 @@ UNIT_GROUP_ID = "33333333-3333-4333-8333-333333333333"
 FLOW_PROPERTY_ID = "44444444-4444-4444-8444-444444444444"
 ACTOR_ID = "55555555-5555-4555-8555-555555555555"
 SOURCE_ID = "66666666-6666-4666-8666-666666666666"
+PROVIDER_PROCESS_ID = "77777777-7777-4777-8777-777777777777"
+CONSUMER_PROCESS_ID = "88888888-8888-4888-8888-888888888888"
 
 
 def test_openlca_jsonld_minimal_import_writes_valid_tidas_package(tmp_path):
@@ -44,6 +46,17 @@ def test_openlca_jsonld_minimal_import_writes_valid_tidas_package(tmp_path):
     assert report["summary"]["processes"] == 1
     assert report["summary"]["sources"] == 1
     assert report["validation"]["tidas"]["ok"] is True
+    process_payload = json.loads(
+        (output_dir / "tidas" / "processes" / f"{PROCESS_ID}.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert (
+        process_payload["processDataSet"]["processInformation"]["time"][
+            "common:referenceYear"
+        ]
+        == 9999
+    )
 
 
 def test_openlca_jsonld_minimal_import_can_write_valid_ilcd(tmp_path):
@@ -71,6 +84,65 @@ def test_openlca_jsonld_minimal_import_can_write_valid_ilcd(tmp_path):
     assert report["validation"]["tidas"]["ok"] is True
     assert report["validation"]["ilcd"]["ok"] is True
     assert (output_dir / "ilcd" / "data" / "flows" / f"{FLOW_ID}.xml").is_file()
+
+
+def test_openlca_jsonld_provider_links_create_valid_lifecycle_model(tmp_path):
+    source_dir = write_provider_graph_jsonld_fixture(tmp_path)
+    output_dir = tmp_path / "out"
+
+    status = main(
+        [
+            "--input",
+            str(source_dir),
+            "--output-dir",
+            str(output_dir),
+            "--from-format",
+            "openlca-jsonld",
+        ]
+    )
+
+    report = json.loads(
+        (output_dir / "conversion-report.json").read_text(encoding="utf-8")
+    )
+    lifecycle_files = list((output_dir / "tidas" / "lifecyclemodels").glob("*.json"))
+
+    assert status == 0
+    assert report["summary"]["lifecyclemodels"] == 1
+    assert report["validation"]["tidas"]["ok"] is True
+    assert len(lifecycle_files) == 1
+
+    lifecycle = json.loads(lifecycle_files[0].read_text(encoding="utf-8"))
+    model = lifecycle["lifeCycleModelDataSet"]
+    instances = model["lifeCycleModelInformation"]["technology"]["processes"][
+        "processInstance"
+    ]
+    instance_by_process = {
+        item["referenceToProcess"]["@refObjectId"]: item for item in instances
+    }
+    provider_instance = instance_by_process[PROVIDER_PROCESS_ID]
+    consumer_instance = instance_by_process[CONSUMER_PROCESS_ID]
+    output_exchange = provider_instance["connections"]["outputExchange"]
+    downstream = output_exchange["downstreamProcess"]
+
+    assert output_exchange["@flowUUID"] == FLOW_ID
+    assert downstream["@id"] == consumer_instance["@dataSetInternalID"]
+    assert downstream["@flowUUID"] == FLOW_ID
+    assert (
+        model["lifeCycleModelInformation"]["dataSetInformation"]["common:other"][
+            "tidasimport:sourceTrace"
+        ]["@marker"]
+        == "TIDAS_IMPORT_TRACE_V1"
+    )
+
+    consumer = json.loads(
+        (output_dir / "tidas" / "processes" / f"{CONSUMER_PROCESS_ID}.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    exchange = consumer["processDataSet"]["exchanges"]["exchange"][0]
+    trace = exchange["common:other"]["tidasimport:sourceTrace"]
+    assert trace["@marker"] == "TIDAS_IMPORT_TRACE_V1"
+    assert trace["payload"]["exchangeMetadata"]["providerRefId"] == PROVIDER_PROCESS_ID
 
 
 def write_minimal_jsonld_fixture(tmp_path):
@@ -155,6 +227,95 @@ def write_minimal_jsonld_fixture(tmp_path):
                         "isInput": False,
                         "isQuantitativeReference": True,
                     }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return source_dir
+
+
+def write_provider_graph_jsonld_fixture(tmp_path):
+    source_dir = write_minimal_jsonld_fixture(tmp_path)
+    (source_dir / "provider_process.json").write_text(
+        json.dumps(
+            {
+                "@type": "Process",
+                "@id": PROVIDER_PROCESS_ID,
+                "name": "Steel billet production",
+                "description": "Provider process fixture",
+                "processType": "UNIT_PROCESS",
+                "processDocumentation": {
+                    "validFrom": "2020-01-01",
+                    "validUntil": "2024-12-31",
+                    "technologyDescription": "Electric arc furnace route",
+                    "sources": [
+                        {
+                            "@type": "Source",
+                            "@id": SOURCE_ID,
+                            "name": "Example source",
+                        }
+                    ],
+                    "dataGenerator": {
+                        "@type": "Actor",
+                        "@id": ACTOR_ID,
+                        "name": "Example data author",
+                    },
+                },
+                "exchanges": [
+                    {
+                        "internalId": 1,
+                        "flow": {"@id": FLOW_ID, "name": "Steel product"},
+                        "amount": 1.0,
+                        "isInput": False,
+                        "isQuantitativeReference": True,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (source_dir / "consumer_process.json").write_text(
+        json.dumps(
+            {
+                "@type": "Process",
+                "@id": CONSUMER_PROCESS_ID,
+                "name": "Steel sheet production",
+                "description": "Consumer process fixture",
+                "processType": "UNIT_PROCESS",
+                "defaultAllocationMethod": "PHYSICAL_ALLOCATION",
+                "processDocumentation": {
+                    "validFrom": "2021-01-01",
+                    "geographyDescription": "United States",
+                    "samplingDescription": "Secondary data sample",
+                    "intendedApplication": "Provider graph test fixture",
+                },
+                "exchanges": [
+                    {
+                        "internalId": 1,
+                        "flow": {"@id": FLOW_ID, "name": "Steel product"},
+                        "amount": 2.5,
+                        "isInput": True,
+                        "unit": {"@id": "kg", "name": "kg"},
+                        "defaultProvider": {
+                            "@type": "Process",
+                            "@id": PROVIDER_PROCESS_ID,
+                            "name": "Steel billet production",
+                        },
+                        "uncertainty": {
+                            "@type": "Uncertainty",
+                            "distributionType": "TRIANGLE_DISTRIBUTION",
+                            "minimum": 2.0,
+                            "maximum": 3.0,
+                        },
+                    },
+                    {
+                        "internalId": 2,
+                        "flow": {"@id": FLOW_ID, "name": "Steel product"},
+                        "amount": 1.0,
+                        "isInput": False,
+                        "isQuantitativeReference": True,
+                    },
                 ],
             }
         ),


### PR DESCRIPTION
Closes #65

## Summary
- Expand the openLCA JSON-LD adapter so actors, sources, units, flows, processes, process documentation, and exchange metadata map into formal TIDAS fields where compatible.
- Preserve unmapped JSON-LD source payloads in common:other with the stable TIDAS_IMPORT_TRACE_V1 marker and TIDAS_IMPORT_PLACEHOLDER:* placeholder scheme.
- Derive a TIDAS lifecycle model from resolvable openLCA defaultProvider links so process graph connections are represented as lifecyclemodels.

## Key Decisions
- Model defaultProvider links as lifecycle model connections because they describe provider-consumer relationships across processes rather than process-local descriptive fields.
- Keep full raw trace data under common:other while truncating schema-limited formal multilingual fields to satisfy TIDAS validation.

## Validation
- uv run pytest tests/test_import_lca_openlca_jsonld.py -q
- uv run pytest
- uv run black --check --target-version py313 src tests
- uv run python src/tidas_tools/import_lca/cli.py --input /Users/davidli/projects/workspace/tidas-tools/temp/National_Renewable_Energy_Laboratory-USLCI_Database_Public.zip --output-dir /Users/davidli/projects/workspace/tidas-tools/temp/uslci-jsonld-tidas-eval-20260522002709 --from-format openlca-jsonld --target tidas --validation-jobs 0
- USLCI conversion report: 70 contacts, 558 sources, 4314 flows, 1341 processes, 1 lifecyclemodel, and TIDAS validation with 0 issues.

## Risks / Rollback
- Moderate importer-surface change; existing EcoSpold, SimaPro, XLSX, and validator tests passed in the full pytest run.

## Follow-ups
- Use the common:other import trace markers for future post-processing and semantic-mapping refinements.

## Workspace Integration
- After merge, lca-workspace still needs a deliberate tidas-tools submodule pointer bump before the workspace consumes this snapshot.