### PR TITLE
feat: preserve EcoSpold source fidelity

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-22"
-lastReviewedCommit: "dde72d1d0e86fd7bde0483364fa010caf530c3e9"
+lastReviewedCommit: "8d5023e42f7a19e17e7cd46467611a339cef988e"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-22
-lastReviewedCommit: dde72d1d0e86fd7bde0483364fa010caf530c3e9
+lastReviewedCommit: 8d5023e42f7a19e17e7cd46467611a339cef988e
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,7 +25,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-22
-lastReviewedCommit: dde72d1d0e86fd7bde0483364fa010caf530c3e9
+lastReviewedCommit: 8d5023e42f7a19e17e7cd46467611a339cef988e
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-22
-lastReviewedCommit: dde72d1d0e86fd7bde0483364fa010caf530c3e9
+lastReviewedCommit: 8d5023e42f7a19e17e7cd46467611a339cef988e
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/src/tidas_tools/import_lca/adapters/ecospold1.py
+++ b/src/tidas_tools/import_lca/adapters/ecospold1.py
@@ -153,6 +153,7 @@ def _process_entity(dataset, label: str, index: int) -> CanonicalEntity:
     technology_text = _attr(technology, "text") or _attr(
         reference_function, "includedProcesses"
     )
+    source_classification = _process_classification(reference_function)
     time_description = _text_or_attrs(
         time_period,
         [
@@ -183,8 +184,10 @@ def _process_entity(dataset, label: str, index: int) -> CanonicalEntity:
             "sourceTrace": {
                 "format": "ecospold1",
                 "sourceObject": label,
+                "sourceClassification": source_classification,
                 "dataset": element_trace(dataset, exclude_child_names={"flowData"}),
             },
+            "sourceClassification": source_classification,
             "location": _attr(geography, "location"),
             "locationDescription": _attr(geography, "text"),
             "referenceYear": _year_from(
@@ -262,15 +265,18 @@ def _flow_entity(exchange, index: int, key: FlowKey) -> CanonicalEntity:
     category = _attr(exchange, "category")
     subcategory = _attr(exchange, "subCategory")
     flow_id = _stable_id(_flow_key_seed(key))
+    source_classification = _exchange_classification(exchange)
     raw = {
         "flowType": _flow_type(exchange),
         "unitName": _attr(exchange, "unit"),
         "CASNumber": _attr(exchange, "CASNumber"),
         "sumFormula": _attr(exchange, "formula"),
         "synonyms": _attr(exchange, "localName"),
+        "sourceClassification": source_classification,
         "sourceTrace": {
             "format": "ecospold1",
             "sourceObject": "exchange",
+            "sourceClassification": source_classification,
             "exchange": element_trace(exchange),
         },
     }
@@ -316,6 +322,7 @@ def _exchange(exchange, flow: CanonicalEntity, index: int) -> dict:
         or "0"
     )
     source_number = _attr(exchange, "number")
+    source_classification = _exchange_classification(exchange)
     return {
         "internalId": index,
         "sourceExchangeNumber": source_number,
@@ -334,6 +341,7 @@ def _exchange(exchange, flow: CanonicalEntity, index: int) -> dict:
         "sourceTrace": {
             "format": "ecospold1",
             "sourceObject": "exchange",
+            "sourceClassification": source_classification,
             "exchange": element_trace(exchange),
         },
     }
@@ -449,6 +457,34 @@ def _uncertainty_type(value: str | None) -> str | None:
         "uniform": "uniform",
     }
     return mapping.get(text)
+
+
+def _process_classification(reference_function) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in {
+            "category": _attr(reference_function, "category"),
+            "subCategory": _attr(reference_function, "subCategory"),
+            "localCategory": _attr(reference_function, "localCategory"),
+            "localSubCategory": _attr(reference_function, "localSubCategory"),
+        }.items()
+        if value
+    }
+
+
+def _exchange_classification(exchange) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in {
+            "category": _attr(exchange, "category"),
+            "subCategory": _attr(exchange, "subCategory"),
+            "localCategory": _attr(exchange, "localCategory"),
+            "localSubCategory": _attr(exchange, "localSubCategory"),
+            "inputGroup": _attr(exchange, "inputGroup"),
+            "outputGroup": _attr(exchange, "outputGroup"),
+        }.items()
+        if value
+    }
 
 
 def _stable_id(seed: str) -> str:

--- a/src/tidas_tools/import_lca/adapters/ecospold2.py
+++ b/src/tidas_tools/import_lca/adapters/ecospold2.py
@@ -36,6 +36,7 @@ class EcoSpold2Adapter(SourceAdapter):
     ) -> None:
         count = 0
         flow_cache: dict[str, CanonicalEntity] = {}
+        used_process_ids: set[str] = set()
         for label, data in _iter_xml_payloads(Path(source)):
             root = _parse_xml(data)
             if root is None:
@@ -47,7 +48,8 @@ class EcoSpold2Adapter(SourceAdapter):
                 )
                 continue
             for index, dataset in enumerate(_datasets(root), start=1):
-                process = _process_entity(dataset, label, index, root)
+                process = _process_entity(dataset, label, index, root, used_process_ids)
+                used_process_ids.add(process.internal_id)
                 exchanges = []
                 for exchange_index, element in enumerate(
                     _exchange_elements(dataset), 1
@@ -122,7 +124,9 @@ def _exchange_elements(dataset) -> list:
     )
 
 
-def _process_entity(dataset, label: str, index: int, root) -> CanonicalEntity:
+def _process_entity(
+    dataset, label: str, index: int, root, used_process_ids: set[str]
+) -> CanonicalEntity:
     activity = _first_element(dataset, ".//*[local-name()='activity']")
     name = _first_text(
         dataset,
@@ -136,12 +140,13 @@ def _process_entity(dataset, label: str, index: int, root) -> CanonicalEntity:
     activity_id = _attr(activity, "id") if activity is not None else None
     activity_uuid = _uuid_value(activity_id)
     filename_uuids = _uuids_from_label(label)
-    process_id = _process_id(
+    process_id, process_id_candidates, process_id_source = _process_id(
         label=label,
         index=index,
         name=name,
         activity_uuid=activity_uuid,
         filename_uuids=filename_uuids,
+        used_process_ids=used_process_ids,
     )
     description = _first_text(
         dataset,
@@ -166,6 +171,15 @@ def _process_entity(dataset, label: str, index: int, root) -> CanonicalEntity:
     if technology is None:
         technology = _first_element(dataset, ".//*[local-name()='technology']")
     file_attributes = _first_element(root, ".//*[local-name()='fileAttributes']")
+    source_identifiers = {
+        "activityId": activity_id,
+        "activityUUID": activity_uuid,
+        "filenameUUIDs": filename_uuids,
+        "processIdCandidates": process_id_candidates,
+        "selectedProcessId": process_id,
+        "selectedProcessIdSource": process_id_source,
+    }
+    source_classification = _process_classification(dataset)
     return CanonicalEntity(
         entity_type="processes",
         internal_id=process_id,
@@ -196,11 +210,15 @@ def _process_entity(dataset, label: str, index: int, root) -> CanonicalEntity:
             "technologicalApplicability": description,
             "sourceActivityId": activity_id,
             "sourceFileUUIDs": filename_uuids,
+            "sourceUUIDs": source_identifiers,
+            "sourceClassification": source_classification,
             "sourceFormat": "ecospold2",
             "sourceLabel": label,
             "sourceTrace": {
                 "format": "ecospold2",
                 "sourceObject": label,
+                "sourceIdentifiers": source_identifiers,
+                "sourceClassification": source_classification,
                 "rootAttributes": element_trace(
                     root,
                     exclude_child_names={"activityDataset", "childActivityDataset"},
@@ -229,13 +247,19 @@ def _cached_flow_entity(
 
 
 def _flow_entity(element, index: int, flow_id: str) -> CanonicalEntity:
+    source_identifiers = _exchange_identifiers(element)
+    source_classification = _exchange_classification(element)
     raw = {
         "flowType": _flow_type(element),
         "unitName": _unit_name(element),
         "unitId": _attr(element, "unitId"),
+        "sourceIdentifiers": source_identifiers,
+        "sourceClassification": source_classification,
         "sourceTrace": {
             "format": "ecospold2",
             "sourceObject": "exchange",
+            "sourceIdentifiers": source_identifiers,
+            "sourceClassification": source_classification,
             "exchange": element_trace(element),
         },
     }
@@ -308,16 +332,24 @@ def _process_id(
     name: str,
     activity_uuid: str | None,
     filename_uuids: list[str],
-) -> str:
-    if len(filename_uuids) == 1:
-        return filename_uuids[0]
-    if len(filename_uuids) > 1:
-        return _stable_id(f"ecospold2/process/file/{Path(label).stem}")
-    return activity_uuid or _stable_id(f"ecospold2/process/{label}/{index}/{name}")
+    used_process_ids: set[str],
+) -> tuple[str, list[str], str]:
+    candidates = _unique_uuid_candidates([activity_uuid, *filename_uuids])
+    for candidate in candidates:
+        if candidate not in used_process_ids:
+            return candidate, candidates, "source-uuid"
+    fallback = _stable_id(f"ecospold2/process/{label}/{index}/{name}")
+    suffix = 1
+    while fallback in used_process_ids:
+        suffix += 1
+        fallback = _stable_id(f"ecospold2/process/{label}/{index}/{name}/{suffix}")
+    return fallback, candidates, "generated-from-source-context"
 
 
 def _exchange(element, flow: CanonicalEntity, index: int) -> dict[str, Any]:
     amount = _attr(element, "amount") or "0"
+    source_identifiers = _exchange_identifiers(element)
+    source_classification = _exchange_classification(element)
     return {
         "internalId": index,
         "sourceExchangeId": _source_exchange_id(element),
@@ -331,6 +363,10 @@ def _exchange(element, flow: CanonicalEntity, index: int) -> dict[str, Any]:
         "isCalculatedAmount": _attr(element, "isCalculatedAmount"),
         "dataDerivationTypeStatus": _data_derivation_type(element),
         "uncertaintyDistributionType": _uncertainty_distribution_type(element),
+        "unitId": _attr(element, "unitId"),
+        "unitName": _unit_name(element),
+        "sourceIdentifiers": source_identifiers,
+        "sourceClassification": source_classification,
         "generalComment": _first_text(
             element,
             [
@@ -341,6 +377,8 @@ def _exchange(element, flow: CanonicalEntity, index: int) -> dict[str, Any]:
         "sourceTrace": {
             "format": "ecospold2",
             "sourceObject": "exchange",
+            "sourceIdentifiers": source_identifiers,
+            "sourceClassification": source_classification,
             "exchange": element_trace(element),
         },
     }
@@ -589,6 +627,81 @@ def _all_texts(element, expressions: list[str]) -> list[str]:
     return texts
 
 
+def _process_classification(dataset) -> list[dict[str, Any]]:
+    return [
+        _classification_payload(classification)
+        for classification in dataset.xpath(
+            ".//*[local-name()='activityDescription']//*[local-name()='classification']"
+        )
+    ]
+
+
+def _exchange_classification(element) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    classifications = [
+        _classification_payload(classification)
+        for classification in element.xpath("./*[local-name()='classification']")
+    ]
+    if classifications:
+        payload["classifications"] = classifications
+    compartment = _first_text(
+        element,
+        [
+            "./*[local-name()='compartment']/*[local-name()='compartment']/text()",
+            "./*[local-name()='compartment']/@compartment",
+        ],
+    )
+    subcompartment = _first_text(
+        element,
+        [
+            "./*[local-name()='compartment']/*[local-name()='subcompartment']/text()",
+            "./*[local-name()='compartment']/@subcompartment",
+        ],
+    )
+    if compartment:
+        payload["compartment"] = compartment
+    if subcompartment:
+        payload["subcompartment"] = subcompartment
+    input_group = _first_text(element, ["./*[local-name()='inputGroup']/text()"])
+    output_group = _first_text(element, ["./*[local-name()='outputGroup']/text()"])
+    if input_group:
+        payload["inputGroup"] = input_group
+    if output_group:
+        payload["outputGroup"] = output_group
+    return payload
+
+
+def _classification_payload(element) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in {
+            "classificationId": _attr(element, "classificationId"),
+            "classificationContextId": _attr(element, "classificationContextId"),
+            "classificationSystem": _all_texts(
+                element, ["./*[local-name()='classificationSystem']/text()"]
+            ),
+            "classificationValue": _all_texts(
+                element, ["./*[local-name()='classificationValue']/text()"]
+            ),
+        }.items()
+        if value
+    }
+
+
+def _exchange_identifiers(element) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in {
+            "id": _attr(element, "id"),
+            "intermediateExchangeId": _attr(element, "intermediateExchangeId"),
+            "elementaryExchangeId": _attr(element, "elementaryExchangeId"),
+            "activityLinkId": _attr(element, "activityLinkId"),
+            "unitId": _attr(element, "unitId"),
+        }.items()
+        if value
+    }
+
+
 def _attr(element, name: str) -> str | None:
     if element is None:
         return None
@@ -616,6 +729,17 @@ def _uuid_value(value: str | None) -> str | None:
         return str(uuid.UUID(str(value)))
     except ValueError:
         return None
+
+
+def _unique_uuid_candidates(values: list[str | None]) -> list[str]:
+    candidates = []
+    seen = set()
+    for value in values:
+        candidate = _uuid_value(value)
+        if candidate and candidate not in seen:
+            candidates.append(candidate)
+            seen.add(candidate)
+    return candidates
 
 
 def _stable_id(seed: str) -> str:

--- a/src/tidas_tools/import_lca/adapters/xml_trace.py
+++ b/src/tidas_tools/import_lca/adapters/xml_trace.py
@@ -59,5 +59,5 @@ def _attributes(element) -> list[dict[str, str]]:
 def _clean_text(value: str | None) -> str | None:
     if value is None:
         return None
-    text = " ".join(value.split())
+    text = value.strip()
     return text or None

--- a/src/tidas_tools/import_lca/writers/tidas_json.py
+++ b/src/tidas_tools/import_lca/writers/tidas_json.py
@@ -52,6 +52,8 @@ PERMANENT_URI_PATHS = {
     "processes": "datasetdetail/process.xhtml",
     "sources": "datasetdetail/source.xhtml",
 }
+REAL_PATTERN = re.compile(r"[+-]?(\d+(\.\d*)?|\.\d+)([Ee][+-]?\d+)?$")
+PERCENT_PATTERN = re.compile(r"100(\.0{1,3})?|([0-9]|[1-9][0-9])(\.\d{1,3})?")
 
 
 def write_tidas_package(store: MemoryCanonicalStore, output_dir: str | Path) -> None:
@@ -1445,32 +1447,26 @@ def _flow_classification(flow_type: str) -> dict[str, Any]:
 
 
 def _real(value: Any) -> str:
-    try:
-        return f"{float(value):g}"
-    except (TypeError, ValueError):
-        return "0"
+    text = _real_text(value)
+    return text if text is not None else "0"
 
 
 def _optional_real(value: Any) -> str | None:
+    return _real_text(value)
+
+
+def _real_text(value: Any) -> str | None:
     if value is None:
         return None
-    try:
-        return f"{float(value):g}"
-    except (TypeError, ValueError):
-        return None
+    text = str(value).strip()
+    return text if REAL_PATTERN.fullmatch(text) else None
 
 
 def _percentage(value: Any) -> str | None:
     if value is None:
         return None
-    try:
-        numeric = float(value)
-    except (TypeError, ValueError):
-        return None
-    if numeric < 0 or numeric > 100:
-        return None
-    rounded = round(numeric, 3)
-    return f"{rounded:.3f}".rstrip("0").rstrip(".")
+    text = str(value).strip()
+    return text if PERCENT_PATTERN.fullmatch(text) else None
 
 
 def _annual_supply_or_production_volume(value: Any) -> dict[str, str]:

--- a/tests/test_import_lca_ecospold1.py
+++ b/tests/test_import_lca_ecospold1.py
@@ -73,7 +73,7 @@ def test_ecospold1_import_maps_semantic_fields_and_source_trace(tmp_path):
     </metaInformation>
     <flowData>
       <exchange number="1" name="enriched steel" unit="kg" amount="1" outputGroup="0" />
-      <exchange number="2" name="carbon dioxide" CASNumber="124-38-9" formula="CO2" unit="kg" amount="2.5" outputGroup="4" category="air" subCategory="unspecified" minValue="1.2" maxValue="3.4" uncertaintyType="1" standardDeviation95="12.3456" generalComment="measured stack emissions" localName="CO2 local" />
+      <exchange number="2" name="carbon dioxide" CASNumber="124-38-9" formula="CO2" unit="kg" amount="2.5000000000000001" outputGroup="4" category="air" subCategory="unspecified" localCategory="local air" localSubCategory="local stack" minValue="1.2" maxValue="3.4" uncertaintyType="1" standardDeviation95="12.3456" generalComment="measured stack emissions" localName="CO2 local" />
     </flowData>
   </dataset>
 </ecoSpold>
@@ -126,16 +126,27 @@ def test_ecospold1_import_maps_semantic_fields_and_source_trace(tmp_path):
         _trace_marker(process_info["dataSetInformation"]["common:other"])
         == "TIDAS_IMPORT_TRACE_V1"
     )
+    process_trace = _trace_payload(process_info["dataSetInformation"]["common:other"])
+    assert process_trace["sourceClassification"]["category"] == "metals"
+    assert process_trace["sourceClassification"]["localCategory"] == "local metals"
+    assert co2_exchange["meanAmount"] == "2.5000000000000001"
     assert co2_exchange["minimumAmount"] == "1.2"
     assert co2_exchange["maximumAmount"] == "3.4"
     assert co2_exchange["uncertaintyDistributionType"] == "log-normal"
-    assert co2_exchange["relativeStandardDeviation95In"] == "12.346"
+    assert "relativeStandardDeviation95In" not in co2_exchange
     assert "measured stack emissions" in co2_exchange["generalComment"]["#text"]
     assert _trace_marker(co2_exchange["common:other"]) == "TIDAS_IMPORT_TRACE_V1"
+    exchange_trace = _trace_payload(co2_exchange["common:other"])["sourceTrace"]
+    assert exchange_trace["sourceClassification"]["localCategory"] == "local air"
+    assert (
+        _trace_attribute(exchange_trace["exchange"], "standardDeviation95") == "12.3456"
+    )
     assert co2_flow["CASNumber"] == "124-38-9"
     assert co2_flow["sumFormula"] == "CO2"
     assert co2_flow["common:synonyms"]["#text"] == "CO2 local"
     assert _trace_marker(co2_flow["common:other"]) == "TIDAS_IMPORT_TRACE_V1"
+    flow_trace = _trace_payload(co2_flow["common:other"])
+    assert flow_trace["sourceClassification"]["subCategory"] == "unspecified"
 
 
 def test_ecospold1_import_uses_filename_uuid_and_local_exchange_ids(tmp_path):
@@ -316,6 +327,17 @@ def _exchange_for_flow(process, flow_name):
 
 def _trace_marker(common_other):
     return common_other["tidasimport:sourceTrace"]["@marker"]
+
+
+def _trace_payload(common_other):
+    return common_other["tidasimport:sourceTrace"]["payload"]
+
+
+def _trace_attribute(trace, name):
+    for attribute in trace.get("attributes", []):
+        if attribute["name"] == name:
+            return attribute["value"]
+    raise AssertionError(f"Trace attribute not found: {name}")
 
 
 def _has_flow_property(tidas_dir, expected_name):

--- a/tests/test_import_lca_ecospold2.py
+++ b/tests/test_import_lca_ecospold2.py
@@ -110,6 +110,10 @@ def test_ecospold2_import_maps_semantic_fields_and_source_trace(tmp_path):
           <text xml:lang="en" index="1">Activity note</text>
         </generalComment>
       </activity>
+      <classification classificationId="activity-class">
+        <classificationSystem xml:lang="en">EcoSpold activity classes</classificationSystem>
+        <classificationValue xml:lang="en">energy systems</classificationValue>
+      </classification>
       <timePeriod>
         <startDate>2024-01-01</startDate>
         <endDate>2025-12-31</endDate>
@@ -127,12 +131,20 @@ def test_ecospold2_import_maps_semantic_fields_and_source_trace(tmp_path):
       <intermediateExchange id="{product_id}" amount="1" productionVolumeAmount="42.0" isCalculatedAmount="true" intermediateExchangeId="{product_id}">
         <name xml:lang="en">enriched product</name>
         <unitName xml:lang="en">kg</unitName>
+        <classification classificationId="product-class">
+          <classificationSystem xml:lang="en">EcoSpold product classes</classificationSystem>
+          <classificationValue xml:lang="en">reference product class</classificationValue>
+        </classification>
         <comment xml:lang="en">calculated reference product</comment>
         <outputGroup>0</outputGroup>
       </intermediateExchange>
-      <intermediateExchange id="33333333-3333-4333-8333-333333333333" amount="0.2" isCalculatedAmount="true" activityLinkId="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa">
+      <intermediateExchange id="33333333-3333-4333-8333-333333333333" amount="0.20000000000000001" isCalculatedAmount="true" activityLinkId="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa">
         <name xml:lang="en">linked input</name>
         <unitName xml:lang="en">kg</unitName>
+        <classification classificationId="input-class">
+          <classificationSystem xml:lang="en">EcoSpold input classes</classificationSystem>
+          <classificationValue xml:lang="en">linked input class</classificationValue>
+        </classification>
         <comment xml:lang="en">linked input comment</comment>
         <uncertainty>
           <lognormal meanValue="0.2" variance="0.12"/>
@@ -164,10 +176,14 @@ def test_ecospold2_import_maps_semantic_fields_and_source_trace(tmp_path):
     process = _read_only_process(output_dir / "tidas")
     process_info = process["processInformation"]
     linked_input = _exchange_for_flow(process, "linked input")
+    linked_input_flow = _find_flow(output_dir / "tidas", "linked input")["flowDataSet"][
+        "flowInformation"
+    ]["dataSetInformation"]
 
     assert status == 0
     assert report["validation"]["tidas"]["ok"] is True
     assert report["validation"]["ilcd"]["ok"] is True
+    assert process_info["dataSetInformation"]["common:UUID"] == process_uuid
     assert process_info["time"]["common:referenceYear"] == 2024
     assert process_info["time"]["common:dataSetValidUntil"] == 2025
     assert (
@@ -188,10 +204,32 @@ def test_ecospold2_import_maps_semantic_fields_and_source_trace(tmp_path):
         _trace_marker(process_info["dataSetInformation"]["common:other"])
         == "TIDAS_IMPORT_TRACE_V1"
     )
+    process_trace = _trace_payload(process_info["dataSetInformation"]["common:other"])
+    assert process_trace["sourceIdentifiers"]["activityUUID"] == process_uuid
+    assert process_trace["sourceIdentifiers"]["selectedProcessId"] == process_uuid
+    assert process_trace["sourceClassification"][0]["classificationValue"] == [
+        "energy systems"
+    ]
+    assert linked_input["meanAmount"] == "0.20000000000000001"
     assert linked_input["dataDerivationTypeStatus"] == "Calculated"
     assert linked_input["uncertaintyDistributionType"] == "log-normal"
     assert "linked input comment" in linked_input["generalComment"]["#text"]
     assert _trace_marker(linked_input["common:other"]) == "TIDAS_IMPORT_TRACE_V1"
+    exchange_trace = _trace_payload(linked_input["common:other"])["sourceTrace"]
+    assert (
+        exchange_trace["sourceIdentifiers"]["activityLinkId"]
+        == "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    )
+    assert exchange_trace["sourceClassification"]["classifications"][0][
+        "classificationValue"
+    ] == ["linked input class"]
+    linked_flow_trace = _trace_payload(linked_input_flow["common:other"])
+    assert (
+        linked_flow_trace["sourceClassification"]["classifications"][0][
+            "classificationId"
+        ]
+        == "input-class"
+    )
 
 
 def test_ecospold2_import_uses_filename_uuid_and_merges_generated_flows(tmp_path):
@@ -450,6 +488,10 @@ def _exchange_for_flow(process, flow_name):
 
 def _trace_marker(common_other):
     return common_other["tidasimport:sourceTrace"]["@marker"]
+
+
+def _trace_payload(common_other):
+    return common_other["tidasimport:sourceTrace"]["payload"]
 
 
 def _find_flow(tidas_dir, expected_name):


### PR DESCRIPTION
Closes #68

## Summary
- Preserves schema-valid EcoSpold numeric strings in formal Real fields instead of float-rounding them.
- Adds scanner-friendly classification and identifier trace payloads for EcoSpold1 and EcoSpold2 process, flow, and exchange outputs.
- Improves EcoSpold2 process UUID selection by preferring original source UUID candidates while avoiding collisions and recording all candidates in trace.

## Key Decisions
- Rule-based conversion remains deterministic; values that cannot fit optional schema fields are left out of formal fields and retained in TIDAS_IMPORT_TRACE_V1 common:other payloads.

## Validation
- uv run pytest tests/test_import_lca_ecospold1.py tests/test_import_lca_ecospold2.py -q
- uv run black --target-version py313 src tests
- uv run pytest -q
- Sampled 10 EcoSpold1 and 10 EcoSpold2 real files with --target both; TIDAS and ILCD validation passed.
- Checked 302 sampled EcoSpold2 exchange meanAmount values exactly match source amount strings.

## Risks / Rollback
- Formal optional percentage fields are now omitted when the source lexical value cannot satisfy the ILCD/TIDAS percentage schema; the original value remains in trace.

## Workspace Integration
- Requires lca-workspace submodule pointer bump after merge.