### PR TITLE
Improve openLCA JSON-LD fidelity mapping

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-22"
-lastReviewedCommit: "8d5023e42f7a19e17e7cd46467611a339cef988e"
+lastReviewedCommit: "8f0df20e748f5dbf23b5e6c7d879ac1924a79839"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-22
-lastReviewedCommit: 8d5023e42f7a19e17e7cd46467611a339cef988e
+lastReviewedCommit: 8f0df20e748f5dbf23b5e6c7d879ac1924a79839
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,7 +25,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-22
-lastReviewedCommit: 8d5023e42f7a19e17e7cd46467611a339cef988e
+lastReviewedCommit: 8f0df20e748f5dbf23b5e6c7d879ac1924a79839
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-22
-lastReviewedCommit: 8d5023e42f7a19e17e7cd46467611a339cef988e
+lastReviewedCommit: 8f0df20e748f5dbf23b5e6c7d879ac1924a79839
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/src/tidas_tools/import_lca/adapters/openlca_jsonld.py
+++ b/src/tidas_tools/import_lca/adapters/openlca_jsonld.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 from pathlib import Path
 import re
 from typing import Any, Iterable
@@ -27,17 +28,21 @@ class OpenLcaJsonLdAdapter(SourceAdapter):
         report: ConversionReport,
     ) -> None:
         count = 0
+        entries = [
+            (label, item)
+            for label, payload in _iter_json_payloads(Path(source))
+            for item in _iter_items(payload)
+            if isinstance(item, dict)
+        ]
+        location_index = _location_index(entries)
         unsupported_items = []
-        for label, payload in _iter_json_payloads(Path(source)):
-            for item in _iter_items(payload):
-                if not isinstance(item, dict):
-                    continue
-                entity = _to_entity(item, label)
-                if entity is None:
-                    unsupported_items.append(_unsupported_item(label, item))
-                    continue
-                store.add(entity)
-                count += 1
+        for label, item in entries:
+            entity = _to_entity(item, label, location_index)
+            if entity is None:
+                unsupported_items.append(_unsupported_item(label, item))
+                continue
+            store.add(entity)
+            count += 1
 
         if unsupported_items:
             store.add(_auxiliary_source_entity(unsupported_items))
@@ -95,7 +100,7 @@ def _iter_json_payloads(source: Path) -> Iterable[tuple[str, Any]]:
 
 
 def _read_json_bytes(data: bytes) -> Any:
-    return json.loads(data.decode("utf-8-sig"))
+    return json.loads(data.decode("utf-8-sig"), parse_float=Decimal)
 
 
 def _iter_items(payload: Any) -> Iterable[dict[str, Any]]:
@@ -108,7 +113,9 @@ def _iter_items(payload: Any) -> Iterable[dict[str, Any]]:
             yield payload
 
 
-def _to_entity(item: dict[str, Any], label: str) -> CanonicalEntity | None:
+def _to_entity(
+    item: dict[str, Any], label: str, location_index: dict[str, dict[str, Any]]
+) -> CanonicalEntity | None:
     type_name = _type_name(item.get("@type"))
     entity_type = {
         "actor": "contacts",
@@ -130,8 +137,8 @@ def _to_entity(item: dict[str, Any], label: str) -> CanonicalEntity | None:
         raw.update(_flow_refs(item))
         raw.update(_flow_metadata(item))
     elif entity_type == "processes":
-        raw.update(_process_metadata(item))
-        raw["exchanges"] = _process_exchanges(item, label)
+        raw.update(_process_metadata(item, location_index))
+        raw["exchanges"] = _process_exchanges(item, label, location_index)
 
     return CanonicalEntity(
         entity_type=entity_type,
@@ -178,29 +185,41 @@ def _flow_refs(item: dict[str, Any]) -> dict[str, Any]:
 
 def _flow_metadata(item: dict[str, Any]) -> dict[str, Any]:
     metadata: dict[str, Any] = {}
+    category_path = _category_path(item)
+    if category_path:
+        metadata["sourceCategoryPath"] = category_path
     if _text(item.get("refUnit")):
         metadata["unitName"] = str(item["refUnit"]).strip()
+    cas_number = item.get("CASNumber") or item.get("cas")
+    if _text(cas_number):
+        metadata["CASNumber"] = str(cas_number).strip()
     formula = item.get("formula")
     if _looks_like_chemical_formula(formula):
         metadata["sumFormula"] = str(formula).strip()
     return metadata
 
 
-def _process_metadata(item: dict[str, Any]) -> dict[str, Any]:
+def _process_metadata(
+    item: dict[str, Any], location_index: dict[str, dict[str, Any]]
+) -> dict[str, Any]:
     documentation = item.get("processDocumentation")
     if not isinstance(documentation, dict):
         documentation = {}
 
+    location = _location_metadata(item.get("location"), location_index)
+    category_path = _category_path(item)
     metadata: dict[str, Any] = {
         "sourceFormat": "openlca-jsonld",
         "sourceProcessType": item.get("processType"),
         "sourceDefaultAllocationMethod": item.get("defaultAllocationMethod"),
+        "sourceCategoryPath": category_path,
         "version": item.get("version"),
         "lastChange": item.get("lastChange"),
         "referenceYear": _year_from(documentation.get("validFrom")),
         "dataSetValidUntil": _year_from(documentation.get("validUntil")),
         "timeDescription": documentation.get("timeDescription"),
-        "location": _location_code(item.get("location")),
+        "location": location.get("code"),
+        "sourceLocation": location,
         "locationDescription": documentation.get("geographyDescription"),
         "technologyDescription": documentation.get("technologyDescription"),
         "samplingProcedure": documentation.get("samplingDescription"),
@@ -230,11 +249,14 @@ def _process_metadata(item: dict[str, Any]) -> dict[str, Any]:
         "dataSetOwnerRef": _reference_payload(documentation.get("dataSetOwner")),
         "publicationRef": _reference_payload(documentation.get("publication")),
         "sourceRefs": _reference_list(documentation.get("sources")),
+        "sourceReviews": _review_list(documentation.get("reviews")),
     }
     return {key: value for key, value in metadata.items() if value not in (None, [])}
 
 
-def _process_exchanges(item: dict[str, Any], label: str) -> list[dict[str, Any]]:
+def _process_exchanges(
+    item: dict[str, Any], label: str, location_index: dict[str, dict[str, Any]]
+) -> list[dict[str, Any]]:
     exchanges = item.get("exchanges")
     if not isinstance(exchanges, list):
         return []
@@ -247,6 +269,7 @@ def _process_exchanges(item: dict[str, Any], label: str) -> list[dict[str, Any]]
         flow_property = exchange.get("flowProperty")
         provider = exchange.get("defaultProvider")
         uncertainty = exchange.get("uncertainty")
+        location = _location_metadata(exchange.get("location"), location_index)
         exchange_metadata = {
             "internalId": exchange.get("internalId"),
             "flow": flow if isinstance(flow, dict) else {},
@@ -270,7 +293,8 @@ def _process_exchanges(item: dict[str, Any], label: str) -> list[dict[str, Any]]
             "providerRefId": _ref_id(provider) if isinstance(provider, dict) else None,
             "providerName": _name(provider) if isinstance(provider, dict) else None,
             "provider": provider if isinstance(provider, dict) else None,
-            "location": _location_code(exchange.get("location")),
+            "location": location.get("code"),
+            "sourceLocation": location,
             "dqEntry": exchange.get("dqEntry"),
             "uncertaintyDistributionType": _uncertainty_distribution_type(uncertainty),
             "minimumAmount": _uncertainty_bound(uncertainty, "minimum"),
@@ -344,8 +368,8 @@ def _provider_graph_lifecycle_model(
         name="openLCA JSON-LD provider graph",
         raw={
             "description": (
-                "Derived lifecycle model from openLCA JSON-LD exchange "
-                "defaultProvider links."
+                "Candidate lifecycle model derived from openLCA JSON-LD "
+                "exchange defaultProvider hints."
             ),
             "referenceProcessId": reference_process.internal_id,
             "processRefs": [
@@ -360,12 +384,115 @@ def _provider_graph_lifecycle_model(
             "sourceTrace": {
                 "format": "openlca-jsonld",
                 "sourceObject": str(source),
-                "derivedEntity": "provider-graph-lifecyclemodel",
+                "derivedEntity": "default-provider-candidate-lifecyclemodel",
+                "linkingSemantics": {
+                    "sourceField": "Exchange.defaultProvider",
+                    "rule": "Only link resolvable default providers on input exchanges.",
+                    "caveat": (
+                        "openLCA defaultProvider is an exchange-level default "
+                        "hint. It is not the same as ProductSystem.processLinks "
+                        "unless a product system was explicitly built with the "
+                        "same linking rule."
+                    ),
+                },
                 "providerConnectionCount": len(connections),
                 "skippedProviderLinks": skipped,
             },
         },
     )
+
+
+def _location_index(
+    entries: list[tuple[str, dict[str, Any]]],
+) -> dict[str, dict[str, Any]]:
+    by_id: dict[str, dict[str, Any]] = {}
+    by_name: dict[str, dict[str, Any]] = {}
+    for label, item in entries:
+        if _type_name(item.get("@type")) != "location":
+            continue
+        payload = _location_payload(item, label)
+        loc_id = payload.get("id")
+        name = payload.get("name")
+        if loc_id:
+            by_id[str(loc_id)] = payload
+        if name:
+            by_name[_norm_location_name(str(name))] = payload
+    return {"by_id": by_id, "by_name": by_name}
+
+
+def _location_payload(item: dict[str, Any], label: str | None = None) -> dict[str, Any]:
+    payload = {
+        "id": _external_id(item),
+        "name": _name(item),
+        "code": item.get("code"),
+        "category": item.get("category"),
+        "latitude": item.get("latitude"),
+        "longitude": item.get("longitude"),
+    }
+    if label:
+        payload["sourceObject"] = label
+    return {key: value for key, value in payload.items() if value not in (None, "")}
+
+
+def _location_metadata(
+    value: Any, location_index: dict[str, dict[str, Any]]
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        if not _text(value):
+            return {}
+        name = str(value).strip()
+        return {
+            key: val
+            for key, val in {
+                "name": name,
+                "code": _location_code_from_name(name),
+                "sourceValue": name,
+            }.items()
+            if val
+        }
+
+    ref_id = _external_id(value)
+    name = _name(value)
+    resolved = None
+    if ref_id:
+        resolved = location_index.get("by_id", {}).get(str(ref_id))
+    if resolved is None and name:
+        resolved = location_index.get("by_name", {}).get(_norm_location_name(name))
+    code = (
+        value.get("code")
+        or (resolved or {}).get("code")
+        or (_location_code_from_name(name) if name else None)
+    )
+    payload = {
+        "id": ref_id,
+        "name": name,
+        "code": code,
+        "category": value.get("category") or (resolved or {}).get("category"),
+        "resolvedLocation": resolved,
+        "sourceRef": value,
+    }
+    return {key: val for key, val in payload.items() if val not in (None, {}, "")}
+
+
+def _location_code_from_name(value: str) -> str | None:
+    aliases = {
+        "global": "GLO",
+        "row": "GLO",
+        "rest of world": "GLO",
+        "northern america": "RNA",
+        "north america": "RNA",
+        "europe": "RER",
+        "united states": "US",
+        "united states of america": "US",
+        "united states of america (the)": "US",
+        "china": "CN",
+        "canada": "CA",
+    }
+    return aliases.get(_norm_location_name(value))
+
+
+def _norm_location_name(value: str) -> str:
+    return " ".join(value.casefold().strip().split())
 
 
 def _type_name(value: Any) -> str:
@@ -378,7 +505,10 @@ def _entity_id(item: dict[str, Any], entity_type: str) -> str:
     candidate = _external_id(item)
     if _is_uuid(candidate):
         return candidate
-    seed = f"openlca-jsonld/{entity_type}/{candidate or _name(item) or json.dumps(item, sort_keys=True)}"
+    seed = (
+        f"openlca-jsonld/{entity_type}/"
+        f"{candidate or _name(item) or json.dumps(item, sort_keys=True, default=str)}"
+    )
     return str(uuid.uuid5(uuid.NAMESPACE_URL, seed))
 
 
@@ -519,6 +649,29 @@ def _reference_list(value: Any) -> list[dict[str, str]]:
         if ref:
             refs.append(ref)
     return refs
+
+
+def _review_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    reviews = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        report = _reference_payload(item.get("report"))
+        reviews.append(
+            {
+                key: entry
+                for key, entry in {
+                    "reviewType": item.get("reviewType"),
+                    "details": item.get("details"),
+                    "reportRef": report,
+                    "sourceReview": item,
+                }.items()
+                if entry not in (None, {})
+            }
+        )
+    return reviews
 
 
 def _category_path(item: dict[str, Any]) -> list[str]:

--- a/src/tidas_tools/import_lca/writers/tidas_json.py
+++ b/src/tidas_tools/import_lca/writers/tidas_json.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from decimal import Decimal
 from functools import lru_cache
 import json
 from pathlib import Path
@@ -573,7 +574,7 @@ def _flow_dataset(
     generated_units: dict[str, tuple[CanonicalEntity, CanonicalEntity]] | None = None,
 ):
     flow_type = _flow_type(entity.raw.get("flowType"))
-    classification = _flow_classification(flow_type)
+    classification = _flow_classification(flow_type, entity.raw)
     dataset_info = {
         "common:UUID": entity.internal_id,
         "name": _name_parts(entity.name or "Flow"),
@@ -661,7 +662,7 @@ def _process_dataset(entity: CanonicalEntity):
     data_set_information = {
         "common:UUID": entity.internal_id,
         "name": _name_parts(entity.name or "Process"),
-        "classificationInformation": _default_process_classification(),
+        "classificationInformation": _default_process_classification(entity.raw),
         "common:generalComment": _ml(
             entity.raw.get("description") or PLACEHOLDER_CONVERTED_APPLICATION
         ),
@@ -683,6 +684,14 @@ def _process_dataset(entity: CanonicalEntity):
         location_item["descriptionOfRestrictions"] = _ml(
             str(entity.raw["locationDescription"]).strip()
         )
+    location_trace = _common_other_trace(
+        {
+            "sourceLocation": entity.raw.get("sourceLocation"),
+            "mappedLocation": location,
+        }
+    )
+    if location_trace:
+        location_item["common:other"] = location_trace
 
     process_information = {
         "dataSetInformation": data_set_information,
@@ -705,7 +714,7 @@ def _process_dataset(entity: CanonicalEntity):
         modelling_and_validation["dataSourcesTreatmentAndRepresentativeness"] = (
             data_sources
         )
-    modelling_and_validation["validation"] = {"review": {"@type": "Not reviewed"}}
+    modelling_and_validation["validation"] = {"review": _review_item(entity)}
     modelling_and_validation["complianceDeclarations"] = _compliance_declarations(
         process=True
     )
@@ -934,8 +943,10 @@ def _lifecycle_reference_instance(
     return "1"
 
 
-def _default_process_classification() -> dict[str, Any]:
-    return {
+def _default_process_classification(
+    raw: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    classification = {
         "common:classification": {
             "common:class": [
                 {
@@ -961,6 +972,10 @@ def _default_process_classification() -> dict[str, Any]:
             ]
         }
     }
+    trace = _classification_trace(raw)
+    if trace:
+        classification["common:classification"]["common:other"] = trace
+    return classification
 
 
 def _process_lci_method(entity: CanonicalEntity) -> dict[str, Any]:
@@ -1014,6 +1029,105 @@ def _process_commissioner_ref(entity: CanonicalEntity) -> dict[str, Any]:
         _contact_ref_from_raw(entity.raw.get("dataSetOwnerRef"))
         or _contact_ref_from_raw(entity.raw.get("dataGeneratorRef"))
         or _owner_ref()
+    )
+
+
+def _review_item(entity: CanonicalEntity) -> dict[str, Any]:
+    reviews = [
+        review
+        for review in entity.raw.get("sourceReviews") or []
+        if isinstance(review, dict)
+    ]
+    if not reviews:
+        return {"@type": "Not reviewed"}
+
+    primary = reviews[0]
+    review_type = _review_type(primary.get("reviewType"))
+    if review_type is None:
+        return {
+            "@type": "Not reviewed",
+            "common:other": _common_other_trace(
+                {
+                    "sourceReviews": reviews,
+                    "mappingNote": (
+                        "Source review records exist, but reviewType could not "
+                        "be mapped to a TIDAS review enum without inference."
+                    ),
+                }
+            ),
+        }
+
+    report_ref = (
+        _source_ref_from_raw(primary.get("reportRef"))
+        or _source_ref_from_raw(entity.raw.get("publicationRef"))
+        or _ref(
+            ref_type="source data set",
+            ref_id=FORMAT_SOURCE_ID,
+            short_description=PLACEHOLDER_DATA_SOURCE,
+            category="sources",
+        )
+    )
+    details = str(primary.get("details") or PLACEHOLDER_REVIEW_NOT_AVAILABLE).strip()
+    item = {
+        "@type": review_type,
+        "common:scope": {
+            "@name": "Documentation",
+            "common:method": {"@name": "Documentation"},
+        },
+        "common:reviewDetails": _ml(details),
+        "common:referenceToNameOfReviewerAndInstitution": _process_commissioner_ref(
+            entity
+        ),
+        "common:referenceToCompleteReviewReport": report_ref,
+    }
+    other = _common_other_trace(
+        {
+            "sourceReviews": reviews,
+            "mappingNote": (
+                "openLCA JSON-LD review records were mapped by rule. Review "
+                "scope/method defaults to Documentation because openLCA review "
+                "details do not use the ILCD scope/method controlled lists."
+            ),
+        }
+    )
+    if other:
+        item["common:other"] = other
+    return item
+
+
+def _review_type(value: Any) -> str | None:
+    text = str(value or "").strip()
+    allowed = {
+        "Dependent internal review",
+        "Independent internal review",
+        "Independent external review",
+        "Accredited third party review",
+        "Independent review panel",
+    }
+    if text in allowed:
+        return text
+    normalized = text.casefold()
+    if "accredited" in normalized and "third" in normalized:
+        return "Accredited third party review"
+    if "panel" in normalized:
+        return "Independent review panel"
+    if "external" in normalized:
+        return "Independent external review"
+    if "internal" in normalized and "independent" in normalized:
+        return "Independent internal review"
+    if "internal" in normalized and "dependent" in normalized:
+        return "Dependent internal review"
+    return None
+
+
+def _source_ref_from_raw(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict) or not _uuid_text(value.get("id")):
+        return None
+    return _ref(
+        ref_type="source data set",
+        ref_id=value["id"],
+        short_description=str(value.get("name") or PLACEHOLDER_DATA_SOURCE),
+        category="sources",
     )
 
 
@@ -1216,6 +1330,7 @@ def _exchange_trace_payload(exchange: dict[str, Any]) -> dict[str, Any] | None:
         "providerName": exchange.get("providerName"),
         "provider": exchange.get("provider"),
         "dqEntry": exchange.get("dqEntry"),
+        "sourceLocation": exchange.get("sourceLocation"),
     }
     if not source_trace and not any(value is not None for value in extra.values()):
         return None
@@ -1363,7 +1478,14 @@ def _cas_number(value: Any) -> str | None:
     if value is None:
         return None
     text = str(value).strip()
-    return text if re.fullmatch(r"[0-9]{2,7}-[0-9]{2}-[0-9]", text) else None
+    if not re.fullmatch(r"[0-9]{2,7}-[0-9]{2}-[0-9]", text):
+        return None
+    body, check_digit = text.rsplit("-", 1)
+    digits = body.replace("-", "")
+    checksum = sum(
+        int(digit) * weight for weight, digit in enumerate(reversed(digits), start=1)
+    )
+    return text if checksum % 10 == int(check_digit) else None
 
 
 def _location_code(value: Any) -> str:
@@ -1398,9 +1520,12 @@ def _location_codes() -> frozenset[str]:
     )
 
 
-def _flow_classification(flow_type: str) -> dict[str, Any]:
+def _flow_classification(
+    flow_type: str, raw: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    trace = _classification_trace(raw)
     if flow_type == "Elementary flow":
-        return {
+        classification = {
             "common:elementaryFlowCategorization": {
                 "common:category": [
                     {"@level": "0", "@catId": "1", "#text": "Emissions"},
@@ -1413,7 +1538,12 @@ def _flow_classification(flow_type: str) -> dict[str, Any]:
                 ]
             }
         }
-    return {
+        if trace:
+            classification["common:elementaryFlowCategorization"][
+                "common:other"
+            ] = trace
+        return classification
+    classification = {
         "common:classification": {
             "common:class": [
                 {
@@ -1444,6 +1574,21 @@ def _flow_classification(flow_type: str) -> dict[str, Any]:
             ]
         }
     }
+    if trace:
+        classification["common:classification"]["common:other"] = trace
+    return classification
+
+
+def _classification_trace(raw: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not raw:
+        return None
+    payload = {
+        "sourceCategoryPath": raw.get("sourceCategoryPath"),
+        "sourceCategory": raw.get("category"),
+        "sourceFlowType": raw.get("flowType"),
+        "sourceProcessType": raw.get("sourceProcessType"),
+    }
+    return _common_other_trace(payload)
 
 
 def _real(value: Any) -> str:
@@ -1511,20 +1656,22 @@ def _common_other_trace(payload: Any) -> dict[str, Any] | None:
 def _clean_trace_value(value: Any) -> Any:
     if value is None:
         return None
+    if isinstance(value, Decimal):
+        return {
+            "@type": "TIDAS_IMPORT_DECIMAL",
+            "#text": str(value),
+        }
     if isinstance(value, (str, int, float, bool)):
         return value
     if isinstance(value, list):
-        cleaned_items = [
-            cleaned
-            for item in value
-            if (cleaned := _clean_trace_value(item)) not in (None, {}, [])
-        ]
-        return cleaned_items
+        if not value:
+            return {"@marker": "TIDAS_IMPORT_EMPTY_ARRAY"}
+        return [_clean_trace_value(item) for item in value]
     if isinstance(value, dict):
         cleaned = {}
         for key, item in value.items():
             cleaned_item = _clean_trace_value(item)
-            if cleaned_item in (None, {}, []):
+            if cleaned_item is None:
                 continue
             cleaned[_safe_trace_key(str(key))] = cleaned_item
         return cleaned

--- a/tests/test_import_lca_openlca_jsonld.py
+++ b/tests/test_import_lca_openlca_jsonld.py
@@ -11,6 +11,7 @@ ACTOR_ID = "55555555-5555-4555-8555-555555555555"
 SOURCE_ID = "66666666-6666-4666-8666-666666666666"
 PROVIDER_PROCESS_ID = "77777777-7777-4777-8777-777777777777"
 CONSUMER_PROCESS_ID = "88888888-8888-4888-8888-888888888888"
+LOCATION_ID = "99999999-9999-4999-8999-999999999999"
 
 
 def test_openlca_jsonld_minimal_import_writes_valid_tidas_package(tmp_path):
@@ -44,7 +45,7 @@ def test_openlca_jsonld_minimal_import_writes_valid_tidas_package(tmp_path):
     assert report["summary"]["contacts"] == 1
     assert report["summary"]["flows"] == 1
     assert report["summary"]["processes"] == 1
-    assert report["summary"]["sources"] == 1
+    assert report["summary"]["sources"] == 2
     assert report["validation"]["tidas"]["ok"] is True
     process_payload = json.loads(
         (output_dir / "tidas" / "processes" / f"{PROCESS_ID}.json").read_text(
@@ -57,6 +58,38 @@ def test_openlca_jsonld_minimal_import_writes_valid_tidas_package(tmp_path):
         ]
         == 9999
     )
+    process = process_payload["processDataSet"]
+    assert (
+        process["processInformation"]["geography"][
+            "locationOfOperationSupplyOrProduction"
+        ]["@location"]
+        == "US"
+    )
+    review = process["modellingAndValidation"]["validation"]["review"]
+    assert review["@type"] == "Independent external review"
+    assert review["common:referenceToCompleteReviewReport"]["@refObjectId"] == SOURCE_ID
+    classification_trace = process["processInformation"]["dataSetInformation"][
+        "classificationInformation"
+    ]["common:classification"]["common:other"]["tidasimport:sourceTrace"]
+    assert classification_trace["@marker"] == "TIDAS_IMPORT_TRACE_V1"
+    assert classification_trace["payload"]["sourceCategoryPath"] == [
+        "31-33: Manufacturing",
+        "3311: Iron and Steel Mills and Ferroalloy Manufacturing",
+    ]
+
+    flow_payload = json.loads(
+        (output_dir / "tidas" / "flows" / f"{FLOW_ID}.json").read_text(encoding="utf-8")
+    )
+    flow_info = flow_payload["flowDataSet"]["flowInformation"]["dataSetInformation"]
+    assert flow_info["CASNumber"] == "7439-89-6"
+    assert flow_info["classificationInformation"]["common:classification"][
+        "common:other"
+    ]["tidasimport:sourceTrace"]["payload"]["sourceCategoryPath"] == [
+        "Technosphere flows",
+        "Metals",
+    ]
+    exchange = process["exchanges"]["exchange"][0]
+    assert exchange["meanAmount"] == "0.123456789012345678"
 
 
 def test_openlca_jsonld_minimal_import_can_write_valid_ilcd(tmp_path):
@@ -195,12 +228,26 @@ def write_minimal_jsonld_fixture(tmp_path):
         ),
         encoding="utf-8",
     )
+    (source_dir / "location.json").write_text(
+        json.dumps(
+            {
+                "@type": "Location",
+                "@id": LOCATION_ID,
+                "name": "United States of America (the)",
+                "code": "US",
+                "category": "Country",
+            }
+        ),
+        encoding="utf-8",
+    )
     (source_dir / "flow.json").write_text(
         json.dumps(
             {
                 "@type": "Flow",
                 "@id": FLOW_ID,
                 "name": "Steel product",
+                "category": "Technosphere flows/Metals",
+                "cas": "7439-89-6",
                 "flowType": "PRODUCT_FLOW",
                 "flowProperties": [
                     {
@@ -212,24 +259,42 @@ def write_minimal_jsonld_fixture(tmp_path):
         ),
         encoding="utf-8",
     )
-    (source_dir / "process.json").write_text(
-        json.dumps(
+    process_payload = {
+        "@type": "Process",
+        "@id": PROCESS_ID,
+        "name": "Steel production",
+        "category": "31-33: Manufacturing/3311: Iron and Steel Mills and Ferroalloy Manufacturing",
+        "description": "Minimal process fixture",
+        "location": {
+            "@type": "Location",
+            "@id": LOCATION_ID,
+            "name": "United States of America (the)",
+        },
+        "processDocumentation": {
+            "reviews": [
+                {
+                    "reviewType": "Independent external review",
+                    "details": "Fixture review details",
+                    "report": {
+                        "@type": "Source",
+                        "@id": SOURCE_ID,
+                        "name": "Example source",
+                    },
+                }
+            ]
+        },
+        "exchanges": [
             {
-                "@type": "Process",
-                "@id": PROCESS_ID,
-                "name": "Steel production",
-                "description": "Minimal process fixture",
-                "exchanges": [
-                    {
-                        "internalId": 1,
-                        "flow": {"@id": FLOW_ID, "name": "Steel product"},
-                        "amount": 1.0,
-                        "isInput": False,
-                        "isQuantitativeReference": True,
-                    }
-                ],
+                "internalId": 1,
+                "flow": {"@id": FLOW_ID, "name": "Steel product"},
+                "amount": "__AMOUNT__",
+                "isInput": False,
+                "isQuantitativeReference": True,
             }
-        ),
+        ],
+    }
+    (source_dir / "process.json").write_text(
+        json.dumps(process_payload).replace('"__AMOUNT__"', "0.123456789012345678"),
         encoding="utf-8",
     )
     return source_dir


### PR DESCRIPTION
Closes #67

## Summary
- map openLCA JSON-LD geography, CAS, and review data into formal TIDAS fields where rules are safe
- preserve classification, unmapped source metadata, invalid CAS values, exchange locations, and Decimal source amounts in `common:other` trace
- emit `Exchange.defaultProvider` links as a candidate lifecycle model with explicit linking semantics instead of treating them as product-system `processLinks`

## Validation
- `uv run pytest`
- `uv run black --check --target-version py313 src tests`
- `uv run python src/tidas_tools/convert.py --help`
- `uv run python src/tidas_tools/import_lca/cli.py --help`
- `/Users/davidli/projects/workspace/scripts/docpact validate-config --root /tmp/tidas-tools-issue67 --strict`
- `/Users/davidli/projects/workspace/scripts/docpact lint --root /tmp/tidas-tools-issue67 --staged --mode enforce --format json`
- USLCI full conversion: `/Users/davidli/projects/workspace/tidas-tools/temp/uslci-jsonld-fidelity-20260522144555/conversion-report.json`; TIDAS validation issue_count=0/error_count=0

## Fidelity checks on USLCI
- process geography: 976 source process locations traced; formal location distribution includes US 677, RNA 184, CA 6, CN 6, RER 3, CD 3, MY 1, GLO fallback 461
- classification: 1341/1341 process category paths and 4314/4314 flow category paths preserved in trace
- CAS: 2394 valid source CAS values mapped formally; 467 invalid/non-CAS source values preserved trace-only
- reviews: 852 source review records preserved in trace; recognized TIDAS review enums mapped formally
- amounts: 77986/77986 exchange amounts match source Decimal text exactly, including 17906 values with more than 15 significant digits
- provider graph: 3875 resolvable input `defaultProvider` hints emitted as lifecycle-model downstream edges; 599 skipped links traced with reasons (`missing_provider`, `non_input`)

## Follow-up
- Workspace submodule integration is still required after this PR merges.
