### PR TITLE
Add expert mapping CSV for LCA imports

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-22"
-lastReviewedCommit: "8f0df20e748f5dbf23b5e6c7d879ac1924a79839"
+lastReviewedCommit: "4d7e3810162f2e4d0511990c2ada9e668af95a82"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-22
-lastReviewedCommit: 8f0df20e748f5dbf23b5e6c7d879ac1924a79839
+lastReviewedCommit: 4d7e3810162f2e4d0511990c2ada9e668af95a82
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,7 +25,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-22
-lastReviewedCommit: 8f0df20e748f5dbf23b5e6c7d879ac1924a79839
+lastReviewedCommit: 4d7e3810162f2e4d0511990c2ada9e668af95a82
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-22
-lastReviewedCommit: 8f0df20e748f5dbf23b5e6c7d879ac1924a79839
+lastReviewedCommit: 4d7e3810162f2e4d0511990c2ada9e668af95a82
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/src/tidas_tools/import_lca/cli.py
+++ b/src/tidas_tools/import_lca/cli.py
@@ -20,6 +20,7 @@ if __package__:
         detect_format,
     )
     from .errors import AmbiguousFormatError
+    from .mapping_csv import write_mapping_csv
     from .report import ConversionReport
     from .store import MemoryCanonicalStore
     from .writers import write_ilcd_from_tidas, write_tidas_package
@@ -40,6 +41,7 @@ else:
         detect_format,
     )
     from tidas_tools.import_lca.errors import AmbiguousFormatError
+    from tidas_tools.import_lca.mapping_csv import write_mapping_csv
     from tidas_tools.import_lca.report import ConversionReport
     from tidas_tools.import_lca.store import MemoryCanonicalStore
     from tidas_tools.import_lca.writers import (
@@ -269,6 +271,14 @@ def run_import(args: argparse.Namespace) -> int:
             logging.error("Generated ILCD/eILCD package failed validation")
             return 2
 
+    mapping_csv_path = output_dir / "mapping.csv"
+    report.mapping_csv_rows = write_mapping_csv(
+        store,
+        tidas_dir,
+        mapping_csv_path,
+        source_format=detected.format_id,
+    )
+    report.mapping_csv = str(mapping_csv_path)
     report.write_json(report_path)
     logging.info("Import report written to %s", report_path)
     return _status_for_report(report, args.fail_on_warning)

--- a/src/tidas_tools/import_lca/mapping_csv.py
+++ b/src/tidas_tools/import_lca/mapping_csv.py
@@ -1,0 +1,412 @@
+"""Mapping CSV writer for expert review of import results."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from decimal import Decimal
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from .model import CanonicalEntity
+from .store import MemoryCanonicalStore
+
+PLACEHOLDER_PREFIX = "TIDAS_IMPORT_PLACEHOLDER:"
+TRACE_MARKER = "TIDAS_IMPORT_TRACE_V1"
+
+MAPPING_CSV_COLUMNS = [
+    "row_id",
+    "source_format",
+    "source_object",
+    "source_entity_type",
+    "source_entity_id",
+    "source_entity_name",
+    "source_exchange_id",
+    "source_field_path",
+    "source_field_name",
+    "source_value",
+    "target_dataset_type",
+    "target_dataset_id",
+    "target_dataset_name",
+    "target_file",
+    "target_scope",
+    "target_field_path",
+    "target_field_name",
+    "target_value",
+    "mapping_status",
+    "mapping_category",
+    "placeholder_kind",
+    "trace_marker",
+    "needs_review",
+    "reviewer_notes",
+]
+
+ROOT_KEYS = {
+    "contacts": "contactDataSet",
+    "flowproperties": "flowPropertyDataSet",
+    "flows": "flowDataSet",
+    "lifecyclemodels": "lifeCycleModelDataSet",
+    "processes": "processDataSet",
+    "sources": "sourceDataSet",
+    "unitgroups": "unitGroupDataSet",
+}
+
+
+@dataclass(frozen=True)
+class _SourceMatch:
+    path: str
+    value: str
+
+
+def write_mapping_csv(
+    store: MemoryCanonicalStore,
+    tidas_dir: str | Path,
+    output_path: str | Path,
+    *,
+    source_format: str | None = None,
+) -> int:
+    """Write a stable mapping CSV for generated TIDAS JSON datasets."""
+
+    root = Path(tidas_dir)
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    entities = _entities_by_id(store)
+
+    row_count = 0
+    with path.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=MAPPING_CSV_COLUMNS)
+        writer.writeheader()
+        for index, row in enumerate(
+            _mapping_rows(root, entities, source_format=source_format), start=1
+        ):
+            row_count = index
+            writer.writerow(
+                {
+                    column: str(row.get(column, "") or "")
+                    for column in MAPPING_CSV_COLUMNS
+                    if column != "row_id"
+                }
+                | {"row_id": str(index)}
+            )
+    return row_count
+
+
+def _mapping_rows(
+    root: Path,
+    entities: dict[tuple[str, str], CanonicalEntity],
+    *,
+    source_format: str | None,
+) -> Iterable[dict[str, str]]:
+    for dataset_dir in sorted(path for path in root.iterdir() if path.is_dir()):
+        dataset_type = dataset_dir.name
+        root_key = ROOT_KEYS.get(dataset_type)
+        if root_key is None:
+            continue
+        for file_path in sorted(dataset_dir.glob("*.json")):
+            payload = json.loads(file_path.read_text(encoding="utf-8"))
+            dataset = payload.get(root_key)
+            if not isinstance(dataset, dict):
+                continue
+            dataset_id = file_path.stem
+            entity = entities.get((dataset_type, dataset_id))
+            source_index = _source_value_index(entity)
+            source_trace = entity.raw.get("sourceTrace") if entity else {}
+            source_format_value = (
+                _source_format(entity)
+                or source_format
+                or _trace_value(source_trace, "format")
+            )
+            source_object = _trace_value(source_trace, "sourceObject")
+            context = {
+                "source_format": source_format_value,
+                "source_object": source_object,
+                "source_entity_type": dataset_type,
+                "source_entity_id": (
+                    entity.external_id if entity and entity.external_id else dataset_id
+                ),
+                "source_entity_name": entity.name if entity and entity.name else "",
+                "target_dataset_type": dataset_type,
+                "target_dataset_id": dataset_id,
+                "target_dataset_name": _dataset_name(dataset),
+                "target_file": str(file_path.relative_to(root.parent)),
+            }
+            for target_path, value in _flatten(dataset):
+                if _skip_target_path(target_path):
+                    continue
+                value_text = _value_text(value)
+                status = _mapping_status(target_path, value_text, entity)
+                source_match = _source_match(
+                    status=status,
+                    target_path=target_path,
+                    target_value=value_text,
+                    source_index=source_index,
+                )
+                placeholder_kind = _placeholder_kind(value_text)
+                yield {
+                    **context,
+                    "source_exchange_id": _source_exchange_id(entity, target_path),
+                    "source_field_path": source_match.path if source_match else "",
+                    "source_field_name": _field_name(
+                        source_match.path if source_match else ""
+                    ),
+                    "source_value": source_match.value if source_match else "",
+                    "target_scope": _target_scope(target_path),
+                    "target_field_path": target_path,
+                    "target_field_name": _field_name(target_path),
+                    "target_value": value_text,
+                    "mapping_status": status,
+                    "mapping_category": _mapping_category(
+                        target_path, source_match.path if source_match else ""
+                    ),
+                    "placeholder_kind": placeholder_kind,
+                    "trace_marker": TRACE_MARKER if _is_trace_path(target_path) else "",
+                    "needs_review": _needs_review(status, placeholder_kind),
+                    "reviewer_notes": "",
+                }
+
+
+def _entities_by_id(
+    store: MemoryCanonicalStore,
+) -> dict[tuple[str, str], CanonicalEntity]:
+    entities: dict[tuple[str, str], CanonicalEntity] = {}
+    for entity_type in ROOT_KEYS:
+        for entity in store.iter_type(entity_type):
+            entities[(entity_type, entity.internal_id)] = entity
+    return entities
+
+
+def _flatten(value: Any, prefix: str = "") -> Iterable[tuple[str, Any]]:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            path = f"{prefix}.{key}" if prefix else str(key)
+            yield from _flatten(item, path)
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            yield from _flatten(item, f"{prefix}[{index}]")
+        return
+    yield prefix, value
+
+
+def _skip_target_path(path: str) -> bool:
+    parts = path.split(".")
+    return any(
+        part.startswith("@xmlns")
+        or part in {"@xsi:schemaLocation", "@locations", "@version"}
+        for part in parts
+    )
+
+
+def _mapping_status(path: str, value: str, entity: CanonicalEntity | None) -> str:
+    if _placeholder_kind(value):
+        return "placeholder"
+    if _is_trace_path(path):
+        return "trace_only"
+    if entity is None:
+        return "generated"
+    if _is_generated_path(path):
+        return "generated"
+    return "formal"
+
+
+def _source_match(
+    *,
+    status: str,
+    target_path: str,
+    target_value: str,
+    source_index: dict[str, list[_SourceMatch]],
+) -> _SourceMatch | None:
+    if status == "trace_only":
+        return _SourceMatch(
+            path=_trace_source_path(target_path),
+            value=target_value,
+        )
+    if status == "generated":
+        return None
+    matches = source_index.get(target_value)
+    if matches:
+        return matches[0]
+    return None
+
+
+def _source_value_index(
+    entity: CanonicalEntity | None,
+) -> dict[str, list[_SourceMatch]]:
+    if entity is None:
+        return {}
+    index: dict[str, list[_SourceMatch]] = {}
+    for path, value in _flatten(entity.raw):
+        value_text = _value_text(value)
+        if not value_text:
+            continue
+        index.setdefault(value_text, []).append(
+            _SourceMatch(path=path, value=value_text)
+        )
+    for matches in index.values():
+        matches.sort(key=lambda match: (path_priority(match.path), match.path))
+    return index
+
+
+def path_priority(path: str) -> int:
+    if path.startswith("sourceTrace."):
+        return 3
+    if "sourceTrace." in path:
+        return 2
+    if path.startswith("exchanges["):
+        return 1
+    return 0
+
+
+def _trace_source_path(target_path: str) -> str:
+    marker = ".tidasimport:sourceTrace.payload."
+    if marker in target_path:
+        return target_path.split(marker, 1)[1]
+    marker = ".tidasimport:sourceTrace."
+    if marker in target_path:
+        return target_path.split(marker, 1)[1]
+    return target_path
+
+
+def _is_trace_path(path: str) -> bool:
+    return ".common:other.tidasimport:sourceTrace" in f".{path}"
+
+
+def _is_generated_path(path: str) -> bool:
+    generated_markers = (
+        ".administrativeInformation.",
+        ".common:referenceToDataSetFormat.",
+        ".common:permanentDataSetURI",
+        ".common:referenceToComplianceSystem.",
+        ".common:referenceToCommissioner.",
+        ".common:referenceToPersonOrEntity",
+    )
+    return any(marker in f".{path}" for marker in generated_markers)
+
+
+def _target_scope(path: str) -> str:
+    if ".exchanges.exchange[" in path or path.startswith("exchanges.exchange["):
+        return "exchange"
+    if _is_trace_path(path):
+        return "trace"
+    if ".administrativeInformation." in f".{path}":
+        return "administrative"
+    return "dataset"
+
+
+def _mapping_category(target_path: str, source_path: str) -> str:
+    path = f"{target_path}.{source_path}".casefold()
+    categories = (
+        ("provider", "provider_link"),
+        ("activitylinkid", "provider_link"),
+        ("classification", "classification"),
+        ("category", "classification"),
+        ("casnumber", "cas"),
+        ("sumformula", "chemical_identity"),
+        ("location", "geography"),
+        ("geography", "geography"),
+        ("time", "time"),
+        ("referenceyear", "time"),
+        ("validuntil", "time"),
+        ("technology", "technology"),
+        ("review", "review"),
+        ("source", "source"),
+        ("amount", "amount"),
+        ("exchange", "exchange"),
+        ("flow", "flow"),
+        ("name", "name"),
+        ("uuid", "identity"),
+    )
+    for token, category in categories:
+        if token in path:
+            return category
+    return "metadata"
+
+
+def _source_exchange_id(entity: CanonicalEntity | None, target_path: str) -> str:
+    if entity is None:
+        return ""
+    exchange_index = _exchange_index(target_path)
+    if exchange_index is None:
+        return ""
+    exchanges = entity.raw.get("exchanges")
+    if not isinstance(exchanges, list) or exchange_index >= len(exchanges):
+        return str(exchange_index + 1)
+    exchange = exchanges[exchange_index]
+    if not isinstance(exchange, dict):
+        return str(exchange_index + 1)
+    for key in ("sourceExchangeNumber", "sourceExchangeId", "internalId"):
+        if exchange.get(key) is not None:
+            return str(exchange[key])
+    return str(exchange_index + 1)
+
+
+def _exchange_index(path: str) -> int | None:
+    marker = "exchanges.exchange["
+    if marker not in path:
+        return None
+    tail = path.split(marker, 1)[1]
+    index_text = tail.split("]", 1)[0]
+    try:
+        return int(index_text)
+    except ValueError:
+        return None
+
+
+def _needs_review(status: str, placeholder_kind: str) -> str:
+    if status in {"trace_only", "placeholder"} or placeholder_kind:
+        return "TRUE"
+    if status == "generated":
+        return "TRUE"
+    return "FALSE"
+
+
+def _placeholder_kind(value: str) -> str:
+    if PLACEHOLDER_PREFIX not in value:
+        return ""
+    return value.split(PLACEHOLDER_PREFIX, 1)[1].split()[0].strip(".,;:)")
+
+
+def _source_format(entity: CanonicalEntity | None) -> str:
+    if entity is None:
+        return ""
+    source_trace = entity.raw.get("sourceTrace")
+    if isinstance(source_trace, dict) and source_trace.get("format"):
+        return str(source_trace["format"])
+    if entity.raw.get("sourceFormat"):
+        return str(entity.raw["sourceFormat"])
+    return ""
+
+
+def _trace_value(trace: Any, key: str) -> str:
+    if isinstance(trace, dict) and trace.get(key) is not None:
+        return str(trace[key])
+    return ""
+
+
+def _dataset_name(dataset: dict[str, Any]) -> str:
+    for path, value in _flatten(dataset):
+        if path.endswith(".name.baseName.#text") or path.endswith(".shortName.#text"):
+            text = _value_text(value)
+            if text:
+                return text
+    return ""
+
+
+def _field_name(path: str) -> str:
+    if not path:
+        return ""
+    field = path.rsplit(".", 1)[-1]
+    if "]" in field:
+        field = field.rsplit("]", 1)[-1].lstrip(".")
+    return field
+
+
+def _value_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (str, int, float, Decimal)):
+        return str(value)
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)

--- a/src/tidas_tools/import_lca/report.py
+++ b/src/tidas_tools/import_lca/report.py
@@ -41,6 +41,8 @@ class ConversionReport:
     target: str = "tidas"
     tidas_dir: str | None = None
     ilcd_dir: str | None = None
+    mapping_csv: str | None = None
+    mapping_csv_rows: int | None = None
     detection_evidence: list[str] = field(default_factory=list)
     object_counts: dict[str, int] = field(default_factory=dict)
     issues: list[ConversionIssue] = field(default_factory=list)
@@ -101,6 +103,8 @@ class ConversionReport:
                 "requested": self.target,
                 "tidas_dir": self.tidas_dir,
                 "ilcd_dir": self.ilcd_dir,
+                "mapping_csv": self.mapping_csv,
+                "mapping_csv_rows": self.mapping_csv_rows,
             },
             "summary": {
                 **counts,

--- a/tests/test_import_lca_mapping_csv.py
+++ b/tests/test_import_lca_mapping_csv.py
@@ -1,0 +1,222 @@
+import csv
+import json
+
+from tidas_tools.import_lca.cli import main
+from tidas_tools.import_lca.mapping_csv import MAPPING_CSV_COLUMNS
+
+FLOW_ID = "11111111-1111-4111-8111-111111111111"
+PROCESS_ID = "22222222-2222-4222-8222-222222222222"
+
+
+def test_openlca_jsonld_import_writes_expert_mapping_csv(tmp_path):
+    source_dir = tmp_path / "jsonld"
+    source_dir.mkdir()
+    (source_dir / "flow.json").write_text(
+        json.dumps(
+            {
+                "@type": "Flow",
+                "@id": FLOW_ID,
+                "name": "carbon dioxide",
+                "category": "Elementary flows/air",
+                "cas": "124-38-9",
+                "formula": "CO2",
+                "flowType": "ELEMENTARY_FLOW",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (source_dir / "process.json").write_text(
+        json.dumps(
+            {
+                "@type": "Process",
+                "@id": PROCESS_ID,
+                "name": "Example process",
+                "category": "Manufacturing/Test category",
+                "location": "United States of America (the)",
+                "exchanges": [
+                    {
+                        "internalId": 1,
+                        "flow": {"@id": FLOW_ID, "name": "carbon dioxide"},
+                        "amount": "__AMOUNT__",
+                        "isInput": False,
+                        "isQuantitativeReference": True,
+                    }
+                ],
+            }
+        ).replace('"__AMOUNT__"', "0.123456789012345678"),
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "out"
+
+    status = main(
+        [
+            "--input",
+            str(source_dir),
+            "--output-dir",
+            str(output_dir),
+            "--from-format",
+            "openlca-jsonld",
+        ]
+    )
+
+    rows = _mapping_rows(output_dir)
+    report = json.loads(
+        (output_dir / "conversion-report.json").read_text(encoding="utf-8")
+    )
+
+    assert status == 0
+    assert rows
+    assert report["target"]["mapping_csv"] == str(output_dir / "mapping.csv")
+    assert report["target"]["mapping_csv_rows"] == len(rows)
+    assert rows[0].keys() == dict.fromkeys(MAPPING_CSV_COLUMNS).keys()
+    assert _has_row(
+        rows,
+        source_format="openlca-jsonld",
+        target_field_name="CASNumber",
+        target_value="124-38-9",
+        mapping_status="formal",
+        mapping_category="cas",
+    )
+    assert _has_row(
+        rows,
+        target_field_name="meanAmount",
+        target_value="0.123456789012345678",
+        mapping_status="formal",
+        mapping_category="amount",
+    )
+    assert _has_row(
+        rows,
+        mapping_status="trace_only",
+        mapping_category="classification",
+        trace_marker="TIDAS_IMPORT_TRACE_V1",
+    )
+    assert _has_row(rows, mapping_status="placeholder", needs_review="TRUE")
+
+
+def test_ecospold1_import_writes_same_expert_mapping_csv_schema(tmp_path):
+    source = tmp_path / "dataset.xml"
+    source.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<ecoSpold xmlns="http://www.EcoInvent.org/EcoSpold01">
+  <dataset>
+    <metaInformation>
+      <processInformation>
+        <referenceFunction name="market for enriched steel" category="metals" subCategory="steel" />
+        <geography location="CH" text="Swiss market boundary" />
+        <timePeriod startDate="2020-01-01" endDate="2023-12-31" />
+      </processInformation>
+    </metaInformation>
+    <flowData>
+      <exchange number="1" name="enriched steel" unit="kg" amount="1" outputGroup="0" />
+      <exchange number="2" name="carbon dioxide" CASNumber="124-38-9" formula="CO2" unit="kg" amount="2.5000000000000001" outputGroup="4" category="air" subCategory="unspecified" />
+    </flowData>
+  </dataset>
+</ecoSpold>
+""",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "out"
+
+    status = main(["--input", str(source), "--output-dir", str(output_dir)])
+
+    rows = _mapping_rows(output_dir)
+
+    assert status == 0
+    assert rows[0].keys() == dict.fromkeys(MAPPING_CSV_COLUMNS).keys()
+    assert _has_row(
+        rows,
+        source_format="ecospold1",
+        target_field_name="meanAmount",
+        target_value="2.5000000000000001",
+        source_exchange_id="2",
+        mapping_status="formal",
+        mapping_category="amount",
+    )
+    assert _has_row(
+        rows,
+        source_format="ecospold1",
+        mapping_status="trace_only",
+        mapping_category="classification",
+    )
+    assert _has_row(rows, source_format="ecospold1", mapping_status="placeholder")
+
+
+def test_ecospold2_import_writes_same_expert_mapping_csv_schema(tmp_path):
+    source = tmp_path / "activity.spold"
+    source.write_text(
+        f"""<?xml version="1.0" encoding="UTF-8"?>
+<ecoSpold xmlns="http://www.EcoInvent.org/EcoSpold02">
+  <activityDataset>
+    <activityDescription>
+      <activity id="{PROCESS_ID}">
+        <activityName xml:lang="en">market for test product</activityName>
+      </activity>
+      <classification classificationId="activity-class">
+        <classificationSystem xml:lang="en">EcoSpold activity classes</classificationSystem>
+        <classificationValue xml:lang="en">energy systems</classificationValue>
+      </classification>
+      <timePeriod>
+        <startDate>2024-01-01</startDate>
+      </timePeriod>
+      <geography>
+        <shortname xml:lang="en">CH</shortname>
+      </geography>
+    </activityDescription>
+    <flowData>
+      <intermediateExchange id="{FLOW_ID}" amount="1">
+        <name xml:lang="en">test product</name>
+        <unitName xml:lang="en">kg</unitName>
+        <outputGroup>0</outputGroup>
+      </intermediateExchange>
+      <elementaryExchange id="44444444-4444-4444-8444-444444444444" amount="1.5">
+        <name xml:lang="en">carbon dioxide</name>
+        <CASNumber>124-38-9</CASNumber>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment>
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">low population density</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup>
+      </elementaryExchange>
+    </flowData>
+  </activityDataset>
+</ecoSpold>
+""",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "out"
+
+    status = main(["--input", str(source), "--output-dir", str(output_dir)])
+
+    rows = _mapping_rows(output_dir)
+
+    assert status == 0
+    assert rows[0].keys() == dict.fromkeys(MAPPING_CSV_COLUMNS).keys()
+    assert _has_row(
+        rows,
+        source_format="ecospold2",
+        target_field_name="CASNumber",
+        target_value="124-38-9",
+        mapping_status="formal",
+        mapping_category="cas",
+    )
+    assert _has_row(
+        rows,
+        source_format="ecospold2",
+        mapping_status="trace_only",
+        mapping_category="classification",
+    )
+    assert _has_row(rows, source_format="ecospold2", mapping_status="placeholder")
+
+
+def _mapping_rows(output_dir):
+    path = output_dir / "mapping.csv"
+    assert path.is_file()
+    with path.open(newline="", encoding="utf-8") as stream:
+        return list(csv.DictReader(stream))
+
+
+def _has_row(rows, **expected):
+    return any(
+        all(row.get(key) == value for key, value in expected.items()) for row in rows
+    )


### PR DESCRIPTION
Closes #71

## Summary
- Add a shared mapping.csv writer for generated, validated TIDAS import outputs.
- Emit stable expert-review columns across openLCA JSON-LD, EcoSpold1, and EcoSpold2 imports.
- Record formal, trace-only, placeholder, and generated rows so original trace data remains reviewable.

## Key Decisions
- Write mapping.csv only after generated TIDAS output passes validation, and after ILCD validation when requested.
- Stream CSV rows while scanning generated TIDAS JSON packages to avoid holding large review files in memory.

## Validation
- uv run pytest tests/test_import_lca_mapping_csv.py -q
- uv run pytest tests/test_import_lca_openlca_jsonld.py tests/test_import_lca_ecospold1.py tests/test_import_lca_ecospold2.py tests/test_import_lca_mapping_csv.py -q
- uv run pytest
- uv run black --check --target-version py313 src tests
- uv run python src/tidas_tools/import_lca/cli.py --help
- git diff --check --cached
- docpact validate-config --strict and docpact lint --staged --mode enforce

## Risks / Rollback
- mapping.csv can be large for full USLCI-style imports, so the writer streams rows directly to disk.

## Workspace Integration
- Root workspace submodule pointer update is required after this PR merges.