### PR TITLE
fix: parse EcoSpold1 child exchange groups

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-22"
-lastReviewedCommit: "4d7e3810162f2e4d0511990c2ada9e668af95a82"
+lastReviewedAt: "2026-05-23"
+lastReviewedCommit: "52952f37714e2e4b6a05eee972f403d480663868"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 4d7e3810162f2e4d0511990c2ada9e668af95a82
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 52952f37714e2e4b6a05eee972f403d480663868
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -24,8 +24,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 4d7e3810162f2e4d0511990c2ada9e668af95a82
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 52952f37714e2e4b6a05eee972f403d480663868
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 4d7e3810162f2e4d0511990c2ada9e668af95a82
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 52952f37714e2e4b6a05eee972f403d480663868
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/src/tidas_tools/import_lca/adapters/ecospold1.py
+++ b/src/tidas_tools/import_lca/adapters/ecospold1.py
@@ -348,13 +348,14 @@ def _exchange(exchange, flow: CanonicalEntity, index: int) -> dict:
 
 
 def _direction(exchange) -> str:
-    if _attr(exchange, "inputGroup"):
+    if _exchange_group(exchange, "inputGroup"):
         return "Input"
     return "Output"
 
 
 def _flow_type(exchange) -> str:
-    output_group = _attr(exchange, "outputGroup")
+    input_group = _exchange_group(exchange, "inputGroup")
+    output_group = _exchange_group(exchange, "outputGroup")
     if output_group == "0":
         return "PRODUCT_FLOW"
     category = " ".join(
@@ -364,7 +365,7 @@ def _flow_type(exchange) -> str:
     )
     if any(token in category for token in ("air", "water", "soil", "resource")):
         return "ELEMENTARY_FLOW"
-    if _attr(exchange, "inputGroup") in {"4", "5"} or output_group in {"4", "5"}:
+    if input_group == "4" or output_group in {"4", "5"}:
         return "ELEMENTARY_FLOW"
     return "PRODUCT_FLOW"
 
@@ -394,6 +395,13 @@ def _attr(element, name: str) -> str | None:
         return None
     value = value.strip()
     return value or None
+
+
+def _exchange_group(exchange, name: str) -> str | None:
+    return _attr(exchange, name) or _first_text(
+        exchange,
+        [f"./*[local-name()='{name}']/text()"],
+    )
 
 
 def _key_text(value: str | None) -> str:
@@ -480,8 +488,8 @@ def _exchange_classification(exchange) -> dict[str, str]:
             "subCategory": _attr(exchange, "subCategory"),
             "localCategory": _attr(exchange, "localCategory"),
             "localSubCategory": _attr(exchange, "localSubCategory"),
-            "inputGroup": _attr(exchange, "inputGroup"),
-            "outputGroup": _attr(exchange, "outputGroup"),
+            "inputGroup": _exchange_group(exchange, "inputGroup"),
+            "outputGroup": _exchange_group(exchange, "outputGroup"),
         }.items()
         if value
     }

--- a/tests/test_import_lca_ecospold1.py
+++ b/tests/test_import_lca_ecospold1.py
@@ -50,6 +50,75 @@ def test_ecospold1_minimal_import_can_write_valid_tidas_and_ilcd(tmp_path):
     assert _has_flow_property(output_dir / "tidas", "Amount in kg")
 
 
+def test_ecospold1_import_reads_exchange_group_child_elements(tmp_path):
+    process_uuid = "64e926e8-dd48-3704-b902-daaf546087c4"
+    source = tmp_path / f"process_{process_uuid}.xml"
+    source.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<ecoSpold xmlns="http://www.EcoInvent.org/EcoSpold01">
+  <dataset>
+    <metaInformation>
+      <processInformation>
+        <referenceFunction name="BAFU-style child group fixture" />
+      </processInformation>
+    </metaInformation>
+    <flowData>
+      <exchange number="1" name="reference product" unit="kg" amount="1">
+        <outputGroup>0</outputGroup>
+      </exchange>
+      <exchange number="2" name="electricity input" unit="kWh" meanValue="2" category="electricity" subCategory="supply mix">
+        <inputGroup>5</inputGroup>
+      </exchange>
+      <exchange number="3" name="ore resource" unit="kg" meanValue="3" category="resources" subCategory="in ground">
+        <inputGroup>4</inputGroup>
+      </exchange>
+      <exchange number="4" name="stack emission" unit="kg" meanValue="4" category="emissions to air" subCategory="unspecified">
+        <outputGroup>4</outputGroup>
+      </exchange>
+    </flowData>
+  </dataset>
+</ecoSpold>
+""",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "out"
+    status = main(
+        [
+            "--input",
+            str(source),
+            "--output-dir",
+            str(output_dir),
+            "--target",
+            "both",
+        ]
+    )
+
+    report = json.loads(
+        (output_dir / "conversion-report.json").read_text(encoding="utf-8")
+    )
+    process = _read_process(output_dir / "tidas", process_uuid)
+    electricity_exchange = _exchange_for_flow(process, "electricity input")
+    resource_exchange = _exchange_for_flow(process, "ore resource")
+    emission_exchange = _exchange_for_flow(process, "stack emission")
+
+    assert status == 0
+    assert report["validation"]["tidas"]["ok"] is True
+    assert report["validation"]["ilcd"]["ok"] is True
+    assert (
+        _exchange_for_flow(process, "reference product")["exchangeDirection"]
+        == "Output"
+    )
+    assert electricity_exchange["exchangeDirection"] == "Input"
+    assert resource_exchange["exchangeDirection"] == "Input"
+    assert emission_exchange["exchangeDirection"] == "Output"
+    assert _flow_type(output_dir / "tidas", "electricity input") == "Product flow"
+    assert _flow_type(output_dir / "tidas", "ore resource") == "Elementary flow"
+    assert _flow_type(output_dir / "tidas", "stack emission") == "Elementary flow"
+    exchange_trace = _trace_payload(electricity_exchange["common:other"])["sourceTrace"]
+    assert exchange_trace["sourceClassification"]["inputGroup"] == "5"
+
+
 def test_ecospold1_import_maps_semantic_fields_and_source_trace(tmp_path):
     process_uuid = "64e926e8-dd48-3704-b902-daaf546087c4"
     source = tmp_path / f"process_{process_uuid}.xml"
@@ -360,3 +429,9 @@ def _find_flow(tidas_dir, expected_name):
         if name == expected_name:
             return data
     raise AssertionError(f"Flow not found: {expected_name}")
+
+
+def _flow_type(tidas_dir, expected_name):
+    return _find_flow(tidas_dir, expected_name)["flowDataSet"][
+        "modellingAndValidation"
+    ]["LCIMethod"]["typeOfDataSet"]


### PR DESCRIPTION
Closes #74

## Summary
- Teach the EcoSpold1 adapter to read inputGroup/outputGroup from child elements as well as attributes.
- This fixes BAFU-style imports where technosphere inputs were preserved only in trace but emitted as exchangeDirection Output.
- @linancn please review the EcoSpold1 mapping behavior change.

## Key Decisions
- Use one _exchange_group helper for direction, source classification, and flow type so attribute and child-element EcoSpold1 variants stay consistent.
- Keep inputGroup 5 as a product/technosphere input; inputGroup 4 and outputGroup 4/5 remain elementary-flow cases.

## Validation
- uv sync --dev
- uv run pytest
- uv run black --check --target-version py313 src tests
- uv run pytest tests/test_import_lca_ecospold1.py
- uv run python src/tidas_tools/import_lca/cli.py --help
- uv run python src/tidas_tools/convert.py --help

## Risks / Rollback
- Existing converted BAFU temp output must be regenerated; this PR changes importer behavior but does not rewrite prior artifacts.

## Follow-ups
- After merge, regenerate the BAFU TIDAS package and rerun the process-flow inventory.

## Workspace Integration
- Requires a later lca-workspace submodule pointer bump after the tidas-tools PR merges.