### PR TITLE
Expose runtime ruleset metadata

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-23"
-lastReviewedCommit: "52952f37714e2e4b6a05eee972f403d480663868"
+lastReviewedCommit: "0ab2d6ac9b1ad10332d051c05fd06e312528348b"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-23
-lastReviewedCommit: 52952f37714e2e4b6a05eee972f403d480663868
+lastReviewedCommit: 0ab2d6ac9b1ad10332d051c05fd06e312528348b
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,7 +25,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-23
-lastReviewedCommit: 52952f37714e2e4b6a05eee972f403d480663868
+lastReviewedCommit: 0ab2d6ac9b1ad10332d051c05fd06e312528348b
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -47,6 +47,7 @@ This repo packages standalone tooling plus the schema, methodology, and styleshe
 | `src/tidas_tools/validation_report.py` | structured validation-report rendering |
 | `src/tidas_tools/export.py` | standalone export CLI |
 | `src/tidas_tools/package_versions.py` | version normalization and export package metadata logic |
+| `src/tidas_tools/runtime_rulesets.py` | loader and validator for packaged runtime ruleset metadata |
 | `src/tidas_tools/tidas/**` | packaged TIDAS schemas and methodologies |
 | `src/tidas_tools/eilcd/**` | packaged eILCD schemas and stylesheets |
 | `tests/**` | automated repo tests |
@@ -80,6 +81,11 @@ Important consequences:
 - `tidas-sdk` runtime assets and generated models depend on the packaged assets here
 - schema or methodology changes here usually imply downstream SDK follow-up
 - `tidas` remains the public docs surface, but it is not the executable upstream for tooling behavior
+
+`src/tidas_tools/tidas/methodologies/runtime_rulesets.json` is the packaged
+runtime metadata layer over the methodology YAML assets. It assigns stable rule
+ids, severity, phases, blocker defaults, and source-rule references for CLI and
+Foundry gates without moving gate execution logic into this repository.
 
 ## Release And Dispatch Architecture
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-23
-lastReviewedCommit: 52952f37714e2e4b6a05eee972f403d480663868
+lastReviewedCommit: 0ab2d6ac9b1ad10332d051c05fd06e312528348b
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/src/tidas_tools/runtime_rulesets.py
+++ b/src/tidas_tools/runtime_rulesets.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+METHODOLOGIES_DIR = Path(__file__).resolve().parent / "tidas" / "methodologies"
+RUNTIME_RULESETS_FILE = METHODOLOGIES_DIR / "runtime_rulesets.json"
+
+REQUIRED_RULESET_FIELDS = {"id", "version", "dataset_type", "phase", "rule_ids"}
+REQUIRED_RULE_FIELDS = {
+    "id",
+    "dataset_type",
+    "summary",
+    "severity",
+    "phases",
+    "default_blocker",
+    "field_paths",
+    "source_rule_refs",
+}
+VALID_SEVERITIES = {"info", "warning", "blocker"}
+
+
+def load_runtime_rulesets(path: str | Path | None = None) -> dict[str, Any]:
+    ruleset_path = Path(path) if path is not None else RUNTIME_RULESETS_FILE
+    return json.loads(ruleset_path.read_text(encoding="utf-8"))
+
+
+def validate_runtime_rulesets(metadata: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    rulesets = metadata.get("rulesets", [])
+    rules = metadata.get("rules", [])
+
+    if not isinstance(rulesets, list) or not rulesets:
+        errors.append("rulesets must be a non-empty array")
+    if not isinstance(rules, list) or not rules:
+        errors.append("rules must be a non-empty array")
+        return errors
+
+    rule_ids: set[str] = set()
+    for index, rule in enumerate(rules):
+        missing = sorted(REQUIRED_RULE_FIELDS - set(rule))
+        if missing:
+            errors.append(f"rules[{index}] missing fields: {', '.join(missing)}")
+            continue
+        rule_id = str(rule["id"])
+        if rule_id in rule_ids:
+            errors.append(f"duplicate rule id: {rule_id}")
+        rule_ids.add(rule_id)
+        if rule.get("severity") not in VALID_SEVERITIES:
+            errors.append(f"{rule_id} has invalid severity: {rule.get('severity')}")
+        if not isinstance(rule.get("phases"), list) or not rule["phases"]:
+            errors.append(f"{rule_id} phases must be a non-empty array")
+        if not isinstance(rule.get("field_paths"), list) or not rule["field_paths"]:
+            errors.append(f"{rule_id} field_paths must be a non-empty array")
+        if (
+            not isinstance(rule.get("source_rule_refs"), list)
+            or not rule["source_rule_refs"]
+        ):
+            errors.append(f"{rule_id} source_rule_refs must be a non-empty array")
+
+    ruleset_ids: set[str] = set()
+    for index, ruleset in enumerate(rulesets):
+        missing = sorted(REQUIRED_RULESET_FIELDS - set(ruleset))
+        if missing:
+            errors.append(f"rulesets[{index}] missing fields: {', '.join(missing)}")
+            continue
+        ruleset_id = str(ruleset["id"])
+        if ruleset_id in ruleset_ids:
+            errors.append(f"duplicate ruleset id: {ruleset_id}")
+        ruleset_ids.add(ruleset_id)
+        unknown_ids = sorted(set(ruleset["rule_ids"]) - rule_ids)
+        if unknown_ids:
+            errors.append(
+                f"{ruleset_id} references unknown rule ids: {', '.join(unknown_ids)}"
+            )
+
+    return errors
+
+
+def rules_for_ruleset(
+    metadata: dict[str, Any], ruleset_id: str
+) -> list[dict[str, Any]]:
+    rules_by_id = {rule["id"]: rule for rule in metadata.get("rules", [])}
+    for ruleset in metadata.get("rulesets", []):
+        if ruleset.get("id") == ruleset_id:
+            return [rules_by_id[rule_id] for rule_id in ruleset.get("rule_ids", [])]
+    raise KeyError(f"Unknown ruleset id: {ruleset_id}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Inspect packaged TIDAS runtime rulesets."
+    )
+    parser.add_argument("--ruleset", help="Print only the rules for one ruleset id.")
+    parser.add_argument(
+        "--validate", action="store_true", help="Validate the packaged metadata."
+    )
+    args = parser.parse_args(argv)
+
+    metadata = load_runtime_rulesets()
+    if args.validate:
+        errors = validate_runtime_rulesets(metadata)
+        print(json.dumps({"ok": not errors, "errors": errors}, indent=2))
+        return 1 if errors else 0
+
+    payload: Any = metadata
+    if args.ruleset:
+        payload = {
+            "schema_version": metadata.get("schema_version"),
+            "ruleset": args.ruleset,
+            "rules": rules_for_ruleset(metadata, args.ruleset),
+        }
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tidas_tools/tidas/methodologies/runtime_rulesets.json
+++ b/src/tidas_tools/tidas/methodologies/runtime_rulesets.json
@@ -1,0 +1,378 @@
+{
+  "$schema": "runtime_rulesets.schema.json",
+  "schema_version": 1,
+  "ruleset_version": "2026.05.23",
+  "purpose": "Runtime-friendly metadata for CLI and Foundry gates. This file assigns stable rule ids, severity, phases, blocker defaults, and source references to packaged TIDAS methodology assets.",
+  "source_assets": [
+    {
+      "asset": "tidas_processes.yaml",
+      "kind": "process methodology"
+    },
+    {
+      "asset": "tidas_flows.yaml",
+      "kind": "flow methodology"
+    }
+  ],
+  "rulesets": [
+    {
+      "id": "process-authoring/strict",
+      "version": "1",
+      "dataset_type": "process",
+      "phase": "authoring",
+      "rule_ids": [
+        "tidas.process.name.base-name.align-reference-flow",
+        "tidas.process.name.qualifiers.structured",
+        "tidas.process.quantitative-reference.required",
+        "tidas.process.exchange.amount.required",
+        "tidas.process.evidence.field-bindings.required"
+      ]
+    },
+    {
+      "id": "process-authoring/repair",
+      "version": "1",
+      "dataset_type": "process",
+      "phase": "repair",
+      "rule_ids": [
+        "tidas.process.quantitative-reference.required",
+        "tidas.process.exchange.amount.required",
+        "tidas.process.evidence.field-bindings.required",
+        "tidas.process.version.format"
+      ]
+    },
+    {
+      "id": "process-publish/default",
+      "version": "1",
+      "dataset_type": "process",
+      "phase": "publish",
+      "rule_ids": [
+        "tidas.process.name.base-name.align-reference-flow",
+        "tidas.process.quantitative-reference.required",
+        "tidas.process.exchange.amount.required",
+        "tidas.process.evidence.field-bindings.required",
+        "tidas.process.version.format"
+      ]
+    },
+    {
+      "id": "process-dedup/default",
+      "version": "1",
+      "dataset_type": "process",
+      "phase": "identity",
+      "rule_ids": [
+        "tidas.process.identity.duplicate-fingerprint.block"
+      ]
+    },
+    {
+      "id": "flow-authoring/strict",
+      "version": "1",
+      "dataset_type": "flow",
+      "phase": "authoring",
+      "rule_ids": [
+        "tidas.flow.name.base-name.technical",
+        "tidas.flow.type.required",
+        "tidas.flow.reference-property-unit.required",
+        "tidas.flow.flow-property.mean-value.positive",
+        "tidas.flow.evidence.field-bindings.required"
+      ]
+    },
+    {
+      "id": "flow-publish/default",
+      "version": "1",
+      "dataset_type": "flow",
+      "phase": "publish",
+      "rule_ids": [
+        "tidas.flow.name.base-name.technical",
+        "tidas.flow.type.required",
+        "tidas.flow.reference-property-unit.required",
+        "tidas.flow.classification.elementary.valid",
+        "tidas.flow.flow-property.mean-value.positive",
+        "tidas.flow.evidence.field-bindings.required"
+      ]
+    },
+    {
+      "id": "flow-dedup/default",
+      "version": "1",
+      "dataset_type": "flow",
+      "phase": "identity",
+      "rule_ids": [
+        "tidas.flow.identity.alias-equivalence.review"
+      ]
+    }
+  ],
+  "rules": [
+    {
+      "id": "tidas.process.name.base-name.align-reference-flow",
+      "dataset_type": "process",
+      "summary": "Process baseName should align with the reference flow naming structure and avoid geography or time qualifiers.",
+      "severity": "blocker",
+      "phases": ["build-plan", "materialize", "publish-build", "save-draft", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "processDataSet.processInformation.dataSetInformation.name.baseName"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.processInformation.dataSetInformation.name.baseName.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.process.name.qualifiers.structured",
+      "dataset_type": "process",
+      "summary": "Process name qualifiers should separate treatment, standards, mix/location, and quantitative properties into the dedicated name segments.",
+      "severity": "warning",
+      "phases": ["build-plan", "materialize", "publish-build"],
+      "default_blocker": false,
+      "field_paths": [
+        "processDataSet.processInformation.dataSetInformation.name.treatmentStandardsRoutes",
+        "processDataSet.processInformation.dataSetInformation.name.mixAndLocationTypes",
+        "processDataSet.processInformation.dataSetInformation.name.functionalUnitFlowProperties"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.processInformation.dataSetInformation.name.treatmentStandardsRoutes.<rules>"
+        },
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.processInformation.dataSetInformation.name.mixAndLocationTypes.<rules>"
+        },
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.processInformation.dataSetInformation.name.functionalUnitFlowProperties.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.process.quantitative-reference.required",
+      "dataset_type": "process",
+      "summary": "A process must identify a quantitative reference exchange or reference flow before authoring or publishing.",
+      "severity": "blocker",
+      "phases": ["build-plan", "materialize", "publish-build", "save-draft", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "processDataSet.exchanges.exchange[*].@dataSetInternalID",
+        "processDataSet.exchanges.exchange[*].referenceToFlowDataSet"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.exchanges.exchange.referenceToFlowDataSet.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.process.exchange.amount.required",
+      "dataset_type": "process",
+      "summary": "Each exchange needs meanAmount or resultingAmount evidence before it can be treated as publish-ready.",
+      "severity": "blocker",
+      "phases": ["build-plan", "materialize", "publish-build", "save-draft", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "processDataSet.exchanges.exchange[*].meanAmount",
+        "processDataSet.exchanges.exchange[*].resultingAmount"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.exchanges.exchange.meanAmount.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.process.evidence.field-bindings.required",
+      "dataset_type": "process",
+      "summary": "Process authoring and publish gates require evidence bindings for identity, names, quantitative reference, exchanges, source, geography, time, and technology.",
+      "severity": "blocker",
+      "phases": ["build-plan", "materialize", "publish-build", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "EvidenceManifest.sources",
+        "EvidenceManifest.field_bindings"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.processInformation.technology.technologyDescriptionAndIncludedProcesses.<rules>"
+        },
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.modellingAndValidation.dataSourcesTreatmentAndRepresentativeness.dataCollectionPeriod.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.process.version.format",
+      "dataset_type": "process",
+      "summary": "Process dataset versions must use fixed-width ILCD three-tier numbering and increase when content changes.",
+      "severity": "blocker",
+      "phases": ["save-draft", "publish-build", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "processDataSet.administrativeInformation.publicationAndOwnership.common:dataSetVersion"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.administrativeInformation.publicationAndOwnership.common:dataSetVersion.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.process.identity.duplicate-fingerprint.block",
+      "dataset_type": "process",
+      "summary": "A new process is blocked when reference flow, route, geography, system boundary, and exchange fingerprint are equivalent to an existing candidate.",
+      "severity": "blocker",
+      "phases": ["identity-preflight", "dedup-review"],
+      "default_blocker": true,
+      "field_paths": [
+        "IdentityDecision.decision",
+        "ProcessIdentity.reference_flow",
+        "ProcessIdentity.exchange_fingerprint"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.exchanges.exchange.referenceToFlowDataSet.<rules>"
+        },
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.processInformation.dataSetInformation.name.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.flow.name.base-name.technical",
+      "dataset_type": "flow",
+      "summary": "Flow baseName must use technical terminology and avoid geography, time, or quantitative qualifiers that belong in dedicated fields.",
+      "severity": "blocker",
+      "phases": ["build-plan", "materialize", "publish-build", "save-draft", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "flowDataSet.flowInformation.dataSetInformation.name.baseName"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.flowInformation.dataSetInformation.name.baseName.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.flow.type.required",
+      "dataset_type": "flow",
+      "summary": "Flow datasets must declare Elementary flow, Product flow, or Waste flow consistently with classification and reference property.",
+      "severity": "blocker",
+      "phases": ["build-plan", "materialize", "publish-build", "save-draft", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "flowDataSet.modellingAndValidation.LCIMethod.typeOfDataSet"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.modellingAndValidation.LCIMethod.typeOfDataSet.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.flow.reference-property-unit.required",
+      "dataset_type": "flow",
+      "summary": "Flow authoring must provide a reference flow property and reference unit before schema or publish gates can pass.",
+      "severity": "blocker",
+      "phases": ["build-plan", "materialize", "publish-build", "save-draft", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "flowDataSet.flowProperties.flowProperty[*].referenceToFlowPropertyDataSet",
+        "flowDataSet.flowProperties.flowProperty[*].referenceUnit"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.flowInformation.dataSetInformation.name.flowProperties.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.flow.flow-property.mean-value.positive",
+      "dataset_type": "flow",
+      "summary": "Flow property mean values must be positive real numbers and the quantitative reference property should use 1.0.",
+      "severity": "blocker",
+      "phases": ["materialize", "publish-build", "save-draft", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "flowDataSet.flowProperties.flowProperty[*].meanValue"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.flowProperties.flowProperty.meanValue.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.flow.classification.elementary.valid",
+      "dataset_type": "flow",
+      "summary": "Elementary flow classification must use the controlled category hierarchy with continuous levels and valid category ids.",
+      "severity": "blocker",
+      "phases": ["materialize", "publish-build", "save-draft", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "flowDataSet.flowInformation.dataSetInformation.classificationInformation.common:elementaryFlowCategorization"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.flowInformation.dataSetInformation.classificationInformation.common:elementaryFlowCategorization.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.flow.evidence.field-bindings.required",
+      "dataset_type": "flow",
+      "summary": "Flow authoring and publish gates require evidence bindings for identity, flow type, name, property, unit, classification, and source.",
+      "severity": "blocker",
+      "phases": ["build-plan", "materialize", "publish-build", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "EvidenceManifest.sources",
+        "EvidenceManifest.field_bindings"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.flowInformation.dataSetInformation.name.<rules>"
+        },
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.flowProperties.flowProperty.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.flow.identity.alias-equivalence.review",
+      "dataset_type": "flow",
+      "summary": "Flow identity preflight should reuse or review flows with equivalent type, property, unit, CAS/category, synonyms, and aliases.",
+      "severity": "warning",
+      "phases": ["identity-preflight", "dedup-review"],
+      "default_blocker": false,
+      "field_paths": [
+        "IdentityDecision.decision",
+        "FlowIdentity.flow_type",
+        "FlowIdentity.reference_property",
+        "FlowIdentity.reference_unit",
+        "FlowIdentity.aliases"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.flowInformation.dataSetInformation.name.common:synonyms.<rules>"
+        },
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.flowProperties.flowProperty.<rules>"
+        }
+      ]
+    }
+  ]
+}

--- a/src/tidas_tools/tidas/methodologies/runtime_rulesets.schema.json
+++ b/src/tidas_tools/tidas/methodologies/runtime_rulesets.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tiangong-lca.local/tidas/runtime-rulesets.schema.json",
+  "title": "TIDAS Runtime Ruleset Metadata",
+  "type": "object",
+  "required": ["schema_version", "ruleset_version", "source_assets", "rulesets", "rules"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": { "type": "integer", "minimum": 1 },
+    "ruleset_version": { "type": "string" },
+    "source_assets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["asset", "kind"],
+        "additionalProperties": true,
+        "properties": {
+          "asset": { "type": "string" },
+          "kind": { "type": "string" }
+        }
+      }
+    },
+    "rulesets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "version", "dataset_type", "phase", "rule_ids"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "string" },
+          "version": { "type": "string" },
+          "dataset_type": { "type": "string", "enum": ["process", "flow"] },
+          "phase": { "type": "string" },
+          "rule_ids": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1
+          }
+        }
+      }
+    },
+    "rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "dataset_type",
+          "summary",
+          "severity",
+          "phases",
+          "default_blocker",
+          "field_paths",
+          "source_rule_refs"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "string" },
+          "dataset_type": { "type": "string", "enum": ["process", "flow"] },
+          "summary": { "type": "string" },
+          "severity": { "type": "string", "enum": ["info", "warning", "blocker"] },
+          "phases": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1
+          },
+          "default_blocker": { "type": "boolean" },
+          "field_paths": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1
+          },
+          "source_rule_refs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["asset", "path"],
+              "additionalProperties": true,
+              "properties": {
+                "asset": { "type": "string" },
+                "path": { "type": "string" }
+              }
+            },
+            "minItems": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/test_runtime_rulesets.py
+++ b/tests/test_runtime_rulesets.py
@@ -1,0 +1,78 @@
+import json
+
+from jsonschema import Draft202012Validator
+
+from tidas_tools.runtime_rulesets import (
+    METHODOLOGIES_DIR,
+    load_runtime_rulesets,
+    rules_for_ruleset,
+    validate_runtime_rulesets,
+)
+
+
+def test_runtime_rulesets_validate_against_schema():
+    metadata = load_runtime_rulesets()
+    schema = json.loads(
+        (METHODOLOGIES_DIR / "runtime_rulesets.schema.json").read_text(encoding="utf-8")
+    )
+
+    errors = list(Draft202012Validator(schema).iter_errors(metadata))
+
+    assert errors == []
+    assert validate_runtime_rulesets(metadata) == []
+
+
+def test_runtime_rulesets_cover_required_automated_lca_profiles():
+    metadata = load_runtime_rulesets()
+    rulesets = {ruleset["id"]: ruleset for ruleset in metadata["rulesets"]}
+
+    for ruleset_id in [
+        "process-authoring/strict",
+        "process-authoring/repair",
+        "process-publish/default",
+        "process-dedup/default",
+        "flow-authoring/strict",
+        "flow-publish/default",
+        "flow-dedup/default",
+    ]:
+        assert ruleset_id in rulesets
+        assert rulesets[ruleset_id]["version"] == "1"
+        assert rulesets[ruleset_id]["rule_ids"]
+
+
+def test_runtime_rulesets_include_process_authoring_and_evidence_rules():
+    metadata = load_runtime_rulesets()
+    strict_process_rules = rules_for_ruleset(metadata, "process-authoring/strict")
+    rule_ids = {rule["id"] for rule in strict_process_rules}
+
+    assert "tidas.process.name.base-name.align-reference-flow" in rule_ids
+    assert "tidas.process.quantitative-reference.required" in rule_ids
+    assert "tidas.process.exchange.amount.required" in rule_ids
+    assert "tidas.process.evidence.field-bindings.required" in rule_ids
+    assert all(
+        rule["default_blocker"]
+        for rule in strict_process_rules
+        if rule["severity"] == "blocker"
+    )
+
+
+def test_runtime_rulesets_include_flow_property_and_unit_rules():
+    metadata = load_runtime_rulesets()
+    flow_rules = rules_for_ruleset(metadata, "flow-publish/default")
+    rule_ids = {rule["id"] for rule in flow_rules}
+
+    assert "tidas.flow.type.required" in rule_ids
+    assert "tidas.flow.reference-property-unit.required" in rule_ids
+    assert "tidas.flow.flow-property.mean-value.positive" in rule_ids
+    assert "tidas.flow.evidence.field-bindings.required" in rule_ids
+
+
+def test_runtime_rulesets_reject_unknown_profile():
+    metadata = load_runtime_rulesets()
+
+    try:
+        rules_for_ruleset(metadata, "missing/default")
+    except KeyError as error:
+        assert "missing/default" in str(error)
+    else:
+        raise AssertionError("missing/default should not resolve")


### PR DESCRIPTION
## Summary
- add packaged `runtime_rulesets.json` and schema for TIDAS runtime rule metadata
- add `tidas_tools.runtime_rulesets` loader/validator helpers for CLI/Foundry consumption
- cover process/flow authoring, repair, publish, and dedup profiles with stable rule ids, severity, phases, blocker defaults, field paths, and source rule references
- add tests proving the metadata is schema-valid, parseable, and covers the automated LCA process/flow rules required by workspace#143

Closes #73.
Refs tiangong-lca/workspace#143.

## Validation
- `uv run python src/tidas_tools/runtime_rulesets.py --validate`
- `uv run pytest tests/test_runtime_rulesets.py`
- `uv run pytest`
- `uv run black --check --target-version py313 src tests`
- `scripts/docpact validate-config --root . --strict --format json`
- `scripts/docpact lint --root . --worktree --format json`
- `git diff --check`

## Notes
- Push to canonical `tiangong-lca/tidas-tools` was denied for the current changmillet token, so this PR is opened from the changmillet fork.
- This PR exposes metadata only; CLI gate execution should consume these ids in follow-up CLI work without copying methodology text.
