### PR TITLE
Fix docpact gate review feedback

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "94efb2ed631b7a1ec9ed5587e3ea848e99dd288b"
+lastReviewedCommit: "9e02d7d3973005be0a2bcd1a6667635aabfce926"
 
 catalog:
   repos:

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "9e02d7d3973005be0a2bcd1a6667635aabfce926"
+lastReviewedCommit: "e3b9aa33fe4d99afb2a9fb74baa17ec8f97655fc"
 
 catalog:
   repos:

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "c2e29d906ec537541e0f32b23f053d7a763812c2"
+lastReviewedCommit: "94efb2ed631b7a1ec9ed5587e3ea848e99dd288b"
 
 catalog:
   repos:

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -31,4 +31,6 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run local docpact gate
-        run: scripts/docpact-gate.sh --base "${{ inputs.base_ref }}"
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+        run: scripts/docpact-gate.sh --base "$BASE_REF"

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -2,6 +2,11 @@ name: ai-doc-lint
 
 on:
   workflow_dispatch:
+    inputs:
+      base_ref:
+        description: Base ref for the manual docpact comparison.
+        required: false
+        default: origin/main
 
 permissions:
   contents: read
@@ -16,8 +21,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch main
-        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+      - name: Fetch branches
+        run: git fetch --force origin '+refs/heads/*:refs/remotes/origin/*'
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -26,4 +31,4 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run local docpact gate
-        run: scripts/docpact-gate.sh --base origin/main
+        run: scripts/docpact-gate.sh --base "${{ inputs.base_ref }}"

--- a/.github/workflows/python-package-deploy.yml
+++ b/.github/workflows/python-package-deploy.yml
@@ -25,7 +25,11 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run docpact release gate
-        run: scripts/docpact-gate.sh --base origin/main
+        run: |
+          set -euo pipefail
+          release_head="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
+          release_base="$(git rev-parse "${release_head}^")"
+          scripts/docpact-gate.sh --base "$release_base" --head "$release_head"
 
   test:
     name: test (${{ matrix.os }} / ${{ matrix.arch }})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 94efb2ed631b7a1ec9ed5587e3ea848e99dd288b
+lastReviewedCommit: 9e02d7d3973005be0a2bcd1a6667635aabfce926
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: 0ab2d6ac9b1ad10332d051c05fd06e312528348b
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 94efb2ed631b7a1ec9ed5587e3ea848e99dd288b
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 9e02d7d3973005be0a2bcd1a6667635aabfce926
+lastReviewedCommit: e3b9aa33fe4d99afb2a9fb74baa17ec8f97655fc
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,7 +25,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 94efb2ed631b7a1ec9ed5587e3ea848e99dd288b
+lastReviewedCommit: 9e02d7d3973005be0a2bcd1a6667635aabfce926
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,7 +25,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: c2e29d906ec537541e0f32b23f053d7a763812c2
+lastReviewedCommit: 94efb2ed631b7a1ec9ed5587e3ea848e99dd288b
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,7 +25,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 9e02d7d3973005be0a2bcd1a6667635aabfce926
+lastReviewedCommit: e3b9aa33fe4d99afb2a9fb74baa17ec8f97655fc
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 94efb2ed631b7a1ec9ed5587e3ea848e99dd288b
+lastReviewedCommit: 9e02d7d3973005be0a2bcd1a6667635aabfce926
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 9e02d7d3973005be0a2bcd1a6667635aabfce926
+lastReviewedCommit: e3b9aa33fe4d99afb2a9fb74baa17ec8f97655fc
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: c2e29d906ec537541e0f32b23f053d7a763812c2
+lastReviewedCommit: 94efb2ed631b7a1ec9ed5587e3ea848e99dd288b
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
## Summary
- address Codex review feedback from the ai-doc local-gate rollout
- make manual ai-doc/docpact fallback workflows accept an explicit base_ref and fetch remote branches
- make release tag docpact gates compare the tag commit against its parent instead of a base that can collapse to the tag commit
- refresh governance review evidence for the touched workflow guidance docs

## Validation
- YAML workflow parse passed from the workspace root
- local docpact/ai-doc gate passed for this branch

Refs tiangong-lca/workspace#183