### PR TITLE
Add per-process TIDAS bundle output for imports

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "e3b9aa33fe4d99afb2a9fb74baa17ec8f97655fc"
+lastReviewedAt: "2026-06-01"
+lastReviewedCommit: "754954252a46f8a43b7f815be23a94a664626ef8"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: e3b9aa33fe4d99afb2a9fb74baa17ec8f97655fc
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 754954252a46f8a43b7f815be23a94a664626ef8
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -82,11 +82,19 @@ Source units from EcoSpold, SimaPro CSV, and process XLSX inputs are propagated
 into generated unit groups and flow properties when no explicit reference data
 is available.
 
+Use `--process-bundles` when downstream AI/import workers need to handle each
+TIDAS process independently. The normal `<output_directory>/tidas` package is
+still written unchanged; the importer also writes
+`<output_directory>/process-bundles/<process_uuid>/` folders containing the
+process JSON plus referenced flow, flow property, unit group, contact, and
+source JSON files. `--process-bundles-dir <dir>` overrides the bundle location.
+
 ### (2) Usage Example
 
 ```bash
 tidas-import --input <source_file_or_dir> --output-dir <output_directory> --detect-only
 tidas-import --input <source_file_or_dir> --output-dir <output_directory> --target both --validation-jobs 0
+tidas-import --input <source_file_or_dir> --output-dir <output_directory> --process-bundles
 ```
 
 ---

--- a/README_CN.md
+++ b/README_CN.md
@@ -109,11 +109,18 @@ tidas-convert --input-dir <eILCD数据目录> --output-dir <TIDAS数据输出目
 
 导入的 JSON-LD Actor 和 Source 会写出为 TIDAS contact 与 source。EcoSpold、SimaPro CSV 和 process XLSX 源数据中的单位会在缺少显式 reference data 时生成对应 unit group 与 flow property，减少全部 flow 落到默认 `Mass`/`kg` 的情况。
 
+当下游 AI/导入 worker 需要按 process 并行处理时，可以使用
+`--process-bundles`。标准 `<输出目录>/tidas` 包会保持原样写出；导入器会额外写出
+`<输出目录>/process-bundles/<process_uuid>/` 子目录，其中包含该 process JSON 以及它引用的
+flow、flow property、unit group、contact 和 source JSON 文件。可用
+`--process-bundles-dir <目录>` 覆盖默认 bundle 位置。
+
 ### （二）使用示例
 
 ```bash
 tidas-import --input <源文件或目录> --output-dir <输出目录> --detect-only
 tidas-import --input <源文件或目录> --output-dir <输出目录> --target both --validation-jobs 0
+tidas-import --input <源文件或目录> --output-dir <输出目录> --process-bundles
 ```
 
 ---

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -24,8 +24,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: e3b9aa33fe4d99afb2a9fb74baa17ec8f97655fc
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 754954252a46f8a43b7f815be23a94a664626ef8
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -61,7 +61,7 @@ This repo packages standalone tooling plus the schema, methodology, and styleshe
 
 `convert.py` owns standalone TIDAS and eILCD conversion behavior.
 
-`import_lca/` owns staged external LCA source import behavior for `tidas-import`. The current foundation covers CLI dispatch, format detection, `.zolca` rejection, canonical store scaffolding, TIDAS package layout helpers, ILCD bridging, and conversion reports. Validated adapters currently exist for openLCA JSON-LD, EcoSpold 1, SimaPro CSV, EcoSpold 2, and openLCA process XLSX, with canonical contact/source writing and generated unit group / flow property support for source units.
+`import_lca/` owns staged external LCA source import behavior for `tidas-import`. The current foundation covers CLI dispatch, format detection, `.zolca` rejection, canonical store scaffolding, TIDAS package layout helpers, optional per-process TIDAS dependency bundle output for parallel AI import workers, ILCD bridging, and conversion reports. Validated adapters currently exist for openLCA JSON-LD, EcoSpold 1, SimaPro CSV, EcoSpold 2, and openLCA process XLSX, with canonical contact/source writing and generated unit group / flow property support for source units.
 
 ### Validation
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: e3b9aa33fe4d99afb2a9fb74baa17ec8f97655fc
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 754954252a46f8a43b7f815be23a94a664626ef8
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/src/tidas_tools/import_lca/cli.py
+++ b/src/tidas_tools/import_lca/cli.py
@@ -21,6 +21,7 @@ if __package__:
     )
     from .errors import AmbiguousFormatError
     from .mapping_csv import write_mapping_csv
+    from .process_bundles import write_process_bundles
     from .report import ConversionReport
     from .store import MemoryCanonicalStore
     from .writers import write_ilcd_from_tidas, write_tidas_package
@@ -42,6 +43,7 @@ else:
     )
     from tidas_tools.import_lca.errors import AmbiguousFormatError
     from tidas_tools.import_lca.mapping_csv import write_mapping_csv
+    from tidas_tools.import_lca.process_bundles import write_process_bundles
     from tidas_tools.import_lca.report import ConversionReport
     from tidas_tools.import_lca.store import MemoryCanonicalStore
     from tidas_tools.import_lca.writers import (
@@ -108,6 +110,21 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Number of parallel validation worker processes. "
             "Use 0 to use all CPU cores. Defaults to 1."
+        ),
+    )
+    parser.add_argument(
+        "--process-bundles",
+        action="store_true",
+        help=(
+            "Also write per-process TIDAS dependency bundles under "
+            "<output-dir>/process-bundles."
+        ),
+    )
+    parser.add_argument(
+        "--process-bundles-dir",
+        help=(
+            "Custom directory for per-process TIDAS dependency bundles. "
+            "Implies --process-bundles."
         ),
     )
     parser.add_argument(
@@ -252,6 +269,27 @@ def run_import(args: argparse.Namespace) -> int:
         report.write_json(report_path)
         logging.error("Generated TIDAS package failed validation")
         return 2
+
+    if args.process_bundles or args.process_bundles_dir:
+        process_bundles_dir = (
+            Path(args.process_bundles_dir)
+            if args.process_bundles_dir
+            else output_dir / "process-bundles"
+        )
+        bundle_summary = write_process_bundles(tidas_dir, process_bundles_dir)
+        report.process_bundles_dir = str(process_bundles_dir)
+        report.process_bundle_count = int(bundle_summary["process_count"])
+        unresolved = bundle_summary.get("unresolved_references") or []
+        if unresolved:
+            report.add_issue(
+                severity="warning",
+                code="process_bundle_unresolved_reference",
+                message="Some process bundle references could not be resolved.",
+                context={
+                    "count": len(unresolved),
+                    "examples": unresolved[:10],
+                },
+            )
 
     if args.target in {"ilcd", "both"}:
         ilcd_dir = Path(report.ilcd_dir)

--- a/src/tidas_tools/import_lca/process_bundles.py
+++ b/src/tidas_tools/import_lca/process_bundles.py
@@ -1,0 +1,199 @@
+"""Materialize per-process TIDAS dependency bundles."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from shutil import copy2
+from typing import Any
+
+from .writers import TIDAS_CATEGORIES, ensure_tidas_package_dirs
+
+PROCESS_BUNDLE_CATEGORIES = (
+    "contacts",
+    "sources",
+    "unitgroups",
+    "flowproperties",
+    "flows",
+    "processes",
+)
+
+
+def write_process_bundles(
+    tidas_dir: str | Path, output_dir: str | Path
+) -> dict[str, Any]:
+    """Copy each process and its referenced TIDAS datasets into its own folder."""
+
+    package_root = Path(tidas_dir)
+    bundle_root = Path(output_dir)
+    bundle_root.mkdir(parents=True, exist_ok=True)
+
+    package_index = _index_package(package_root)
+    process_ids = sorted(package_index["processes"])
+    bundles: list[dict[str, Any]] = []
+    unresolved_references: list[dict[str, Any]] = []
+
+    for process_id in process_ids:
+        dependencies, unresolved = _collect_dependencies(process_id, package_index)
+        bundle_dir = bundle_root / process_id
+        tidas_bundle_dir = ensure_tidas_package_dirs(bundle_dir / "tidas")
+        files = _copy_dependencies(package_root, tidas_bundle_dir, dependencies)
+        dependency_counts = {
+            category: len(files.get(category, []))
+            for category in PROCESS_BUNDLE_CATEGORIES
+        }
+        manifest = {
+            "schema_version": 1,
+            "process_id": process_id,
+            "source_tidas_dir": str(package_root),
+            "bundle_tidas_dir": "tidas",
+            "dependency_counts": dependency_counts,
+            "files": files,
+            "unresolved_references": unresolved,
+        }
+        _write_json(bundle_dir / "manifest.json", manifest)
+        bundles.append(
+            {
+                "process_id": process_id,
+                "manifest": f"{process_id}/manifest.json",
+                "tidas_dir": f"{process_id}/tidas",
+                "dependency_counts": dependency_counts,
+            }
+        )
+        unresolved_references.extend(
+            {"process_id": process_id, **item} for item in unresolved
+        )
+
+    index_payload = {
+        "schema_version": 1,
+        "source_tidas_dir": str(package_root),
+        "process_count": len(bundles),
+        "bundles": bundles,
+        "unresolved_references": unresolved_references,
+    }
+    _write_json(bundle_root / "index.json", index_payload)
+    return {
+        "process_count": len(bundles),
+        "output_dir": str(bundle_root),
+        "index_file": str(bundle_root / "index.json"),
+        "bundles": bundles,
+        "unresolved_references": unresolved_references,
+    }
+
+
+def _index_package(tidas_dir: Path) -> dict[str, dict[str, Path]]:
+    index: dict[str, dict[str, Path]] = {}
+    for category in TIDAS_CATEGORIES:
+        category_dir = tidas_dir / category
+        index[category] = {
+            path.stem: path for path in sorted(category_dir.glob("*.json"))
+        }
+    return index
+
+
+def _collect_dependencies(
+    process_id: str, package_index: dict[str, dict[str, Path]]
+) -> tuple[dict[str, set[str]], list[dict[str, Any]]]:
+    dependencies: dict[str, set[str]] = {
+        category: set() for category in PROCESS_BUNDLE_CATEGORIES
+    }
+    unresolved: list[dict[str, Any]] = []
+    visited: set[tuple[str, str]] = set()
+    queue: list[tuple[str, str, str]] = [("processes", process_id, "$")]
+
+    while queue:
+        category, dataset_id, ref_path = queue.pop(0)
+        if category not in dependencies:
+            continue
+        if (category, dataset_id) in visited:
+            continue
+        visited.add((category, dataset_id))
+
+        dataset_path = package_index.get(category, {}).get(dataset_id)
+        if dataset_path is None:
+            unresolved.append(
+                {
+                    "category": category,
+                    "ref_id": dataset_id,
+                    "path": ref_path,
+                }
+            )
+            continue
+
+        dependencies[category].add(dataset_id)
+        payload = _read_json(dataset_path)
+        for reference in _iter_references(payload):
+            ref_category = reference.get("category")
+            ref_id = reference.get("ref_id")
+            if not isinstance(ref_category, str) or not isinstance(ref_id, str):
+                continue
+            if ref_category not in dependencies:
+                continue
+            queue.append((ref_category, ref_id, str(reference["path"])))
+
+    return dependencies, unresolved
+
+
+def _iter_references(payload: Any, path: str = "$"):
+    if isinstance(payload, dict):
+        ref_id = payload.get("@refObjectId")
+        if isinstance(ref_id, str):
+            category = _category_for_reference(payload)
+            if category:
+                yield {
+                    "category": category,
+                    "ref_id": ref_id,
+                    "path": path,
+                }
+        for key, value in payload.items():
+            yield from _iter_references(value, f"{path}.{key}")
+    elif isinstance(payload, list):
+        for index, item in enumerate(payload):
+            yield from _iter_references(item, f"{path}[{index}]")
+
+
+def _category_for_reference(reference: dict[str, Any]) -> str | None:
+    ref_type = str(reference.get("@type") or "").lower()
+    if "flow property" in ref_type:
+        return "flowproperties"
+    if "flow" in ref_type:
+        return "flows"
+    if "unit group" in ref_type:
+        return "unitgroups"
+    if "contact" in ref_type:
+        return "contacts"
+    if "source" in ref_type:
+        return "sources"
+    if "process" in ref_type:
+        return "processes"
+
+    uri = str(reference.get("@uri") or "")
+    uri_parts = {part for part in uri.split("/") if part}
+    for category in PROCESS_BUNDLE_CATEGORIES:
+        if category in uri_parts:
+            return category
+    return None
+
+
+def _copy_dependencies(
+    package_root: Path, bundle_tidas_dir: Path, dependencies: dict[str, set[str]]
+) -> dict[str, list[str]]:
+    files: dict[str, list[str]] = {}
+    for category in PROCESS_BUNDLE_CATEGORIES:
+        files[category] = []
+        for dataset_id in sorted(dependencies[category]):
+            source = package_root / category / f"{dataset_id}.json"
+            destination = bundle_tidas_dir / category / source.name
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            copy2(source, destination)
+            files[category].append(str(Path("tidas") / category / source.name))
+    return files
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")

--- a/src/tidas_tools/import_lca/report.py
+++ b/src/tidas_tools/import_lca/report.py
@@ -41,6 +41,8 @@ class ConversionReport:
     target: str = "tidas"
     tidas_dir: str | None = None
     ilcd_dir: str | None = None
+    process_bundles_dir: str | None = None
+    process_bundle_count: int | None = None
     mapping_csv: str | None = None
     mapping_csv_rows: int | None = None
     detection_evidence: list[str] = field(default_factory=list)
@@ -103,11 +105,14 @@ class ConversionReport:
                 "requested": self.target,
                 "tidas_dir": self.tidas_dir,
                 "ilcd_dir": self.ilcd_dir,
+                "process_bundles_dir": self.process_bundles_dir,
+                "process_bundle_count": self.process_bundle_count,
                 "mapping_csv": self.mapping_csv,
                 "mapping_csv_rows": self.mapping_csv_rows,
             },
             "summary": {
                 **counts,
+                "process_bundles": self.process_bundle_count or 0,
                 "warnings": self.warning_count,
                 "errors": self.error_count,
             },

--- a/tests/test_import_lca_openlca_jsonld.py
+++ b/tests/test_import_lca_openlca_jsonld.py
@@ -92,6 +92,60 @@ def test_openlca_jsonld_minimal_import_writes_valid_tidas_package(tmp_path):
     assert exchange["meanAmount"] == "0.123456789012345678"
 
 
+def test_openlca_jsonld_minimal_import_can_write_process_bundles(tmp_path):
+    source_dir = write_minimal_jsonld_fixture(tmp_path)
+    output_dir = tmp_path / "out"
+
+    status = main(
+        [
+            "--input",
+            str(source_dir),
+            "--output-dir",
+            str(output_dir),
+            "--from-format",
+            "openlca-jsonld",
+            "--process-bundles",
+        ]
+    )
+
+    bundle_dir = output_dir / "process-bundles" / PROCESS_ID
+    manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
+    index = json.loads(
+        (output_dir / "process-bundles" / "index.json").read_text(encoding="utf-8")
+    )
+    report = json.loads(
+        (output_dir / "conversion-report.json").read_text(encoding="utf-8")
+    )
+
+    assert status == 0
+    assert index["process_count"] == 1
+    assert index["bundles"][0]["process_id"] == PROCESS_ID
+    assert manifest["process_id"] == PROCESS_ID
+    assert manifest["unresolved_references"] == []
+    assert f"tidas/processes/{PROCESS_ID}.json" in manifest["files"]["processes"]
+    assert f"tidas/flows/{FLOW_ID}.json" in manifest["files"]["flows"]
+    assert (
+        f"tidas/flowproperties/{FLOW_PROPERTY_ID}.json"
+        in manifest["files"]["flowproperties"]
+    )
+    assert f"tidas/unitgroups/{UNIT_GROUP_ID}.json" in manifest["files"]["unitgroups"]
+    assert f"tidas/sources/{SOURCE_ID}.json" in manifest["files"]["sources"]
+    assert (bundle_dir / "tidas" / "processes" / f"{PROCESS_ID}.json").is_file()
+    assert (bundle_dir / "tidas" / "flows" / f"{FLOW_ID}.json").is_file()
+    assert (
+        bundle_dir / "tidas" / "flowproperties" / f"{FLOW_PROPERTY_ID}.json"
+    ).is_file()
+    assert (bundle_dir / "tidas" / "unitgroups" / f"{UNIT_GROUP_ID}.json").is_file()
+    assert report["target"]["process_bundles_dir"] == str(
+        output_dir / "process-bundles"
+    )
+    assert report["target"]["process_bundle_count"] == 1
+    assert report["summary"]["process_bundles"] == 1
+
+    validation = validate_package_dir(str(bundle_dir / "tidas"))
+    assert validation["ok"] is True
+
+
 def test_openlca_jsonld_minimal_import_can_write_valid_ilcd(tmp_path):
     source_dir = write_minimal_jsonld_fixture(tmp_path)
     output_dir = tmp_path / "out"


### PR DESCRIPTION
Closes #82

## Summary
- Adds optional tidas-import process bundle output without changing the normal full TIDAS package.
- Writes process-bundles/index.json plus per-process manifest.json files and process-scoped TIDAS folders.
- Records process bundle directory/count in the conversion report and documents the CLI flags.

## Key Decisions
- Bundle generation runs only after the generated TIDAS package validates.
- Dependency discovery scans TIDAS JSON @refObjectId references recursively and copies referenced process, flow, flow property, unit group, contact, and source datasets.
- No duplicate-import prevention is implemented here; downstream database/import controls remain responsible for deduplication.

## Validation
- uv run black --check --target-version py313 src tests
- uv run python src/tidas_tools/import_lca/cli.py --help
- uv run pytest tests/test_import_lca_openlca_jsonld.py tests/test_import_lca_cli.py tests/test_import_lca_report.py
- uv run pytest
- scripts/docpact validate-config --root . --strict
- scripts/docpact lint --root . --staged --mode enforce
- git diff --cached --check

## Risks / Rollback
- Per-process bundles intentionally duplicate shared dependencies across process folders so AI/import workers can run independently; database/import layers still own deduplication.

## Follow-ups
- Merge requires later lca-workspace submodule pointer integration before workspace delivery is complete.

## Workspace Integration
- After this PR merges, update the lca-workspace tidas-tools submodule pointer to the merged main commit.