### PR TITLE
Release tidas-tools v0.0.25

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-01"
-lastReviewedCommit: "754954252a46f8a43b7f815be23a94a664626ef8"
+lastReviewedCommit: "ddafdef8765c6824ec05cd71312255214faea91f"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 754954252a46f8a43b7f815be23a94a664626ef8
+lastReviewedCommit: ddafdef8765c6824ec05cd71312255214faea91f
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,7 +25,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 754954252a46f8a43b7f815be23a94a664626ef8
+lastReviewedCommit: ddafdef8765c6824ec05cd71312255214faea91f
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 754954252a46f8a43b7f815be23a94a664626ef8
+lastReviewedCommit: ddafdef8765c6824ec05cd71312255214faea91f
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidas-tools"
-version = "0.0.24"
+version = "0.0.25"
 description = "tidas-tools"
 authors = [
     { name = "Nan LI", email = "linanenv@gmail.com" },


### PR DESCRIPTION
Closes #84

## Summary
- Bumps tidas-tools package metadata from 0.0.24 to 0.0.25.
- Refreshes docpact review metadata required for the release version change.

## Key Decisions
- Use the next patch version because v0.0.24 is already tagged/published and main contains new release-worthy changes.

## Validation
- scripts/docpact validate-config --root . --strict
- scripts/docpact lint --root . --staged --mode enforce
- git diff --cached --check
- uv run pytest

## Risks / Rollback
- Low risk: metadata-only release prep; tag publish workflow will run the full release gate and matrix tests before upload.

## Follow-ups
- After merge, push tag v0.0.25 from the merged main commit and monitor Publish to PyPI.

## Workspace Integration
- After merge, lca-workspace needs a tidas-tools submodule pointer bump for release metadata alignment.