### PR TITLE
Fix v0.0.25 publish manifest paths

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-01"
-lastReviewedCommit: "ddafdef8765c6824ec05cd71312255214faea91f"
+lastReviewedCommit: "39bf8e28dfe1955ad447e6ee90e59a4be4c5863b"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: ddafdef8765c6824ec05cd71312255214faea91f
+lastReviewedCommit: 39bf8e28dfe1955ad447e6ee90e59a4be4c5863b
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,7 +25,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: ddafdef8765c6824ec05cd71312255214faea91f
+lastReviewedCommit: 39bf8e28dfe1955ad447e6ee90e59a4be4c5863b
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: ddafdef8765c6824ec05cd71312255214faea91f
+lastReviewedCommit: 39bf8e28dfe1955ad447e6ee90e59a4be4c5863b
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/src/tidas_tools/import_lca/process_bundles.py
+++ b/src/tidas_tools/import_lca/process_bundles.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from shutil import copy2
 from typing import Any
 
@@ -186,7 +186,7 @@ def _copy_dependencies(
             destination = bundle_tidas_dir / category / source.name
             destination.parent.mkdir(parents=True, exist_ok=True)
             copy2(source, destination)
-            files[category].append(str(Path("tidas") / category / source.name))
+            files[category].append(str(PurePosixPath("tidas") / category / source.name))
     return files
 
 


### PR DESCRIPTION
Closes #84

## Summary
- Writes per-process bundle manifest file entries with POSIX separators so the release test expectations are stable on Windows and POSIX platforms.
- Refreshes docpact review metadata for the release blocker fix.

## Validation
- uv run black --check --target-version py313 src tests
- scripts/docpact validate-config --root . --strict
- scripts/docpact lint --root . --staged --mode enforce
- uv run pytest tests/test_import_lca_openlca_jsonld.py::test_openlca_jsonld_minimal_import_can_write_process_bundles
- uv run pytest

## Risks / Rollback
- The previous v0.0.25 tag workflow failed before PyPI upload; after this merges, v0.0.25 will be re-tagged on the fixed main commit.

## Workspace Integration
- After the publish workflow succeeds, lca-workspace needs a tidas-tools submodule pointer bump.