### PR TITLE
chore: automate tidas-tools releases

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-01"
-lastReviewedCommit: "cc9069b0d3631ac5a65da813b22cd84534f1b1de"
+lastReviewedCommit: "7668ef53a077641e45f2d5c6cb87daabb365b712"
 
 catalog:
   repos:

--- a/.github/workflows/python-package-deploy.yml
+++ b/.github/workflows/python-package-deploy.yml
@@ -1,18 +1,181 @@
 name: Publish to PyPI
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Existing v* tag to release with the current workflow definition.
+        required: true
+        type: string
   push:
+    branches:
+      - main
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
+concurrency:
+  group: tidas-tools-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
+  release-context:
+    name: Release Context
+    runs-on: ubuntu-latest
+    outputs:
+      release_base: ${{ steps.release.outputs.release_base }}
+      release_head: ${{ steps.release.outputs.release_head }}
+      should_release: ${{ steps.release.outputs.should_release }}
+      tag_created: ${{ steps.release.outputs.tag_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release target
+        id: release
+        env:
+          PUSH_BEFORE_SHA: ${{ github.event.before || '' }}
+          REQUESTED_TAG_NAME: ${{ github.event.inputs.tag_name || '' }}
+        run: |
+          set -euo pipefail
+
+          git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+          git fetch --force origin '+refs/tags/*:refs/tags/*'
+
+          if [ "${GITHUB_REPOSITORY}" != "tiangong-lca/tidas-tools" ]; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "tag_created=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping release outside canonical repository: ${GITHUB_REPOSITORY}."
+            exit 0
+          fi
+
+          read_project_version() {
+            git show "${1}:pyproject.toml" | python3 -c 'import sys, tomllib; print(tomllib.load(sys.stdin.buffer)["project"]["version"])'
+          }
+
+          tag_created=false
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            tag_name="${REQUESTED_TAG_NAME}"
+            if [ -z "${tag_name}" ] || [[ "${tag_name}" != v* ]]; then
+              echo "::error::workflow_dispatch tag_name must be an existing v* tag."
+              exit 1
+            fi
+
+            if ! release_head="$(git rev-list -n 1 "${tag_name}" 2>/dev/null)"; then
+              echo "::error::Release tag ${tag_name} does not exist."
+              exit 1
+            fi
+
+            package_version="$(read_project_version "${release_head}")"
+            expected_tag="v${package_version}"
+            if [ "${tag_name}" != "${expected_tag}" ]; then
+              echo "::error::Release tag ${tag_name} does not match pyproject.toml version ${package_version} at ${release_head}."
+              exit 1
+            fi
+
+            echo "::notice::Releasing existing ${tag_name} at ${release_head} with the current workflow definition."
+          elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            tag_name="${GITHUB_REF_NAME}"
+            release_head="$(git rev-list -n 1 "${tag_name}")"
+            package_version="$(read_project_version "${release_head}")"
+            expected_tag="v${package_version}"
+            if [ "${tag_name}" != "${expected_tag}" ]; then
+              echo "::error::Release tag ${tag_name} does not match pyproject.toml version ${package_version} at ${release_head}."
+              exit 1
+            fi
+          else
+            release_head="${GITHUB_SHA}"
+            package_version="$(read_project_version "${release_head}")"
+            tag_name="v${package_version}"
+            version_changed=false
+
+            if [ -n "${PUSH_BEFORE_SHA}" ] && [ "${PUSH_BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]; then
+              if git cat-file -e "${PUSH_BEFORE_SHA}:pyproject.toml" 2>/dev/null; then
+                previous_version="$(read_project_version "${PUSH_BEFORE_SHA}")"
+                if [ "${previous_version}" != "${package_version}" ]; then
+                  version_changed=true
+                fi
+              fi
+            fi
+
+            existing_tag_sha="$(git ls-remote --tags origin "refs/tags/${tag_name}" | awk '{print $1}')"
+            if [ -n "${existing_tag_sha}" ]; then
+              git fetch --force origin "refs/tags/${tag_name}:refs/tags/${tag_name}"
+              existing_tag_commit="$(git rev-list -n 1 "${tag_name}")"
+              if [ "${existing_tag_commit}" != "${release_head}" ]; then
+                if [ "${version_changed}" = "false" ]; then
+                  echo "should_release=false" >> "$GITHUB_OUTPUT"
+                  echo "tag_created=false" >> "$GITHUB_OUTPUT"
+                  echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+                  echo "release_head=${release_head}" >> "$GITHUB_OUTPUT"
+                  echo "::notice::${tag_name} already points to ${existing_tag_commit}; pyproject.toml version was unchanged in this main push, so this is not a new release."
+                  exit 0
+                fi
+
+                echo "::error::${tag_name} already points to ${existing_tag_commit}, not current main commit ${release_head}. Bump pyproject.toml before releasing another main commit."
+                exit 1
+              fi
+              echo "::notice::${tag_name} already exists on current main commit ${release_head}; continuing release."
+            else
+              if [ "${version_changed}" != "true" ]; then
+                echo "should_release=false" >> "$GITHUB_OUTPUT"
+                echo "tag_created=false" >> "$GITHUB_OUTPUT"
+                echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+                echo "release_head=${release_head}" >> "$GITHUB_OUTPUT"
+                echo "::notice::pyproject.toml version did not change in this main push; skipping release."
+                exit 0
+              fi
+
+              git tag "${tag_name}" "${release_head}"
+              git push origin "refs/tags/${tag_name}"
+              tag_created=true
+              echo "::notice::Created ${tag_name} on ${release_head}."
+            fi
+          fi
+
+          if ! git merge-base --is-ancestor "${release_head}" origin/main; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "tag_created=${tag_created}" >> "$GITHUB_OUTPUT"
+            echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+            echo "release_head=${release_head}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Release target ${tag_name} points to ${release_head}, which is not on origin/main. Skipping PyPI publish."
+            exit 0
+          fi
+
+          release_base="$(git rev-parse "${release_head}^")"
+
+          echo "release_base=${release_base}" >> "$GITHUB_OUTPUT"
+          echo "release_head=${release_head}" >> "$GITHUB_OUTPUT"
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+          echo "tag_created=${tag_created}" >> "$GITHUB_OUTPUT"
+          echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Release context"
+            echo "- tag: \`${tag_name}\`"
+            echo "- head: \`${release_head}\`"
+            echo "- base: \`${release_base}\`"
+            echo "- package version: \`${package_version}\`"
+            echo "- tag created: \`${tag_created}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   release-gate:
     name: Release Gate
+    needs: release-context
+    if: needs.release-context.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ needs.release-context.outputs.release_head }}
           fetch-depth: 0
 
       - name: Fetch main
@@ -27,13 +190,47 @@ jobs:
       - name: Run docpact release gate
         run: |
           set -euo pipefail
-          release_head="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
-          release_base="$(git rev-parse "${release_head}^")"
+          release_head="${{ needs.release-context.outputs.release_head }}"
+          release_base="${{ needs.release-context.outputs.release_base }}"
           scripts/docpact-gate.sh --base "$release_base" --head "$release_head"
+
+      - name: Check PyPI version availability
+        run: |
+          python3 - <<'PY'
+          import json
+          import sys
+          import tomllib
+          import urllib.error
+          import urllib.request
+          from pathlib import Path
+
+          project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]
+          name = project["name"]
+          version = project["version"]
+          url = f"https://pypi.org/pypi/{name}/json"
+
+          try:
+              with urllib.request.urlopen(url, timeout=15) as response:
+                  payload = json.load(response)
+          except urllib.error.HTTPError as error:
+              if error.code == 404:
+                  payload = {"releases": {}}
+              else:
+                  raise
+
+          releases = payload.get("releases", {})
+          if version in releases:
+              sys.exit(f"error: {name} version {version} already exists on PyPI.")
+
+          print(f"Validated {name} version {version} is not yet published to PyPI.")
+          PY
 
   test:
     name: test (${{ matrix.os }} / ${{ matrix.arch }})
-    needs: release-gate
+    needs:
+      - release-context
+      - release-gate
+    if: needs.release-context.outputs.should_release == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -50,6 +247,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-context.outputs.release_head }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -66,11 +265,16 @@ jobs:
         run: uv run pytest
 
   build-and-publish:
-    needs: test
+    needs:
+      - release-context
+      - test
+    if: needs.release-context.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-context.outputs.release_head }}
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,8 @@ Keep these entry-level facts in `AGENTS.md`. Use `README.md`, `README_CN.md`, an
   - `uv run python src/tidas_tools/validate.py --help`
   - `uv run python src/tidas_tools/export.py --help`
 - release tag pattern: `v<version>`
+- canonical `main` branch pushes whose `pyproject.toml` project version changed create the matching `v<version>` tag when missing, run the release gate, test on the release matrix, and publish to PyPI in the same workflow run
+- manual `v*` tag pushes and `workflow_dispatch` runs for an existing `v*` tag whose target commit is already on `main` remain supported for recovery/backfill releases
 
 ## Ownership Boundaries
 
@@ -166,4 +168,4 @@ Install the versioned local hook once per checkout:
 ./scripts/install-git-hooks.sh
 ```
 
-The `pre-push` hook runs `scripts/docpact-gate.sh`, which delegates CLI lookup to `scripts/docpact` and performs strict config validation plus enforced lint before the push leaves the machine. It then runs `uv run pytest` as the local test gate. The wrapper checks `DOCPACT_BIN`, Cargo install locations, Homebrew install locations, and then `PATH`, so local agent shells should not fail only because bare `docpact` is unavailable. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts. The GitHub `CI` workflow is manual-dispatch only; tag publish still runs pytest before publishing.
+The `pre-push` hook runs `scripts/docpact-gate.sh`, which delegates CLI lookup to `scripts/docpact` and performs strict config validation plus enforced lint before the push leaves the machine. It then runs `uv run pytest` as the local test gate. The wrapper checks `DOCPACT_BIN`, Cargo install locations, Homebrew install locations, and then `PATH`, so local agent shells should not fail only because bare `docpact` is unavailable. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts. The GitHub `CI` workflow is manual-dispatch only; the publish workflow creates release tags from `main` version bumps and still runs pytest before publishing.

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -52,7 +52,7 @@ This repo packages standalone tooling plus the schema, methodology, and styleshe
 | `src/tidas_tools/eilcd/**` | packaged eILCD schemas and stylesheets |
 | `tests/**` | automated repo tests |
 | `.github/workflows/dispatch-tidas-sdk-sync.yml` | downstream SDK refresh dispatch contract |
-| `.github/workflows/python-package-deploy.yml` | tag-driven PyPI publish workflow with a release test gate |
+| `.github/workflows/python-package-deploy.yml` | `main` version-bump and tag-driven PyPI publish workflow with a release test gate |
 | `.github/workflows/ci.yml` | manual-dispatch remote reproduction of local tests |
 
 ## Current Tool Families
@@ -90,7 +90,8 @@ Foundry gates without moving gate execution logic into this repository.
 
 ## Release And Dispatch Architecture
 
-- tag `v<version>` publishes `tidas-tools`
+- `main` pushes whose `pyproject.toml` project version changes create the matching `v<version>` tag and publish `tidas-tools`
+- manual `v<version>` tag pushes and workflow-dispatch runs for existing release tags remain recovery/backfill paths
 - changes under packaged schema and methodology paths can dispatch downstream SDK refresh workflows
 
 This dispatch path is part of the repo architecture, not just a convenience automation.

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -46,7 +46,7 @@ uv run pytest
 
 Use narrower manual probes only when the task touches one CLI surface and full tests would add no extra signal.
 
-The local `pre-push` hook runs docpact first and then `uv run pytest`. The GitHub `CI` workflow is manual-dispatch only, so ordinary branch pushes do not run standalone remote tests. Tag-driven PyPI publish still runs pytest before publishing.
+The local `pre-push` hook runs docpact first and then `uv run pytest`. The GitHub `CI` workflow is manual-dispatch only, so ordinary branch pushes do not run standalone remote tests. The PyPI publish workflow runs from `main` version bumps or explicit release tags and still runs pytest before publishing.
 
 ## Validation Matrix
 


### PR DESCRIPTION
Closes #91

## Summary
- Add a release-context job so main pushes that change pyproject.toml project.version create the matching v* tag and publish through the existing PyPI flow.
- Keep tag push and workflow_dispatch paths for recovery/backfill releases.

## Key Decisions
- Only create tags for version changes on main; unchanged main pushes skip release.
- Require release targets to be ancestors of origin/main before publishing.

## Validation
- git diff --check
- scripts/docpact validate-config --root . --strict
- scripts/docpact lint --root . --merge-base origin/main --mode enforce --format json
- Ruby YAML parse for .github/workflows/python-package-deploy.yml
- Python tomllib pyproject version read returned 0.0.26

## Risks / Rollback
- Low operational risk: publishing still runs through the existing release gate and PyPI availability check.

## Follow-ups
- Monitor the first version-bump release run after merge.

## Workspace Integration
- Requires later lca-workspace submodule pointer update after merge/release eligibility.