### PR TITLE
Fix ecoSpold1 process curation gaps

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-01"
-lastReviewedCommit: "7668ef53a077641e45f2d5c6cb87daabb365b712"
+lastReviewedAt: "2026-06-02"
+lastReviewedCommit: "165ed81c1d0caf4d0cbb4f623a27f12704b5461c"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: cc9069b0d3631ac5a65da813b22cd84534f1b1de
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: 165ed81c1d0caf4d0cbb4f623a27f12704b5461c
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -24,8 +24,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: cc9069b0d3631ac5a65da813b22cd84534f1b1de
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: 165ed81c1d0caf4d0cbb4f623a27f12704b5461c
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: cc9069b0d3631ac5a65da813b22cd84534f1b1de
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: 165ed81c1d0caf4d0cbb4f623a27f12704b5461c
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/src/tidas_tools/import_lca/adapters/ecospold1.py
+++ b/src/tidas_tools/import_lca/adapters/ecospold1.py
@@ -97,16 +97,16 @@ class EcoSpold1Adapter(SourceAdapter):
 def _iter_xml_payloads(source: Path) -> Iterable[tuple[str, bytes]]:
     if source.is_dir():
         for path in sorted(source.rglob("*.xml")):
-            yield str(path), path.read_bytes()
+            yield path.relative_to(source).as_posix(), path.read_bytes()
         return
     if source.suffix.lower() == ".zip":
         with zipfile.ZipFile(source) as archive:
             for name in sorted(archive.namelist()):
                 if name.lower().endswith(".xml"):
                     with archive.open(name) as stream:
-                        yield f"{source}:{name}", stream.read()
+                        yield name, stream.read()
         return
-    yield str(source), source.read_bytes()
+    yield source.name, source.read_bytes()
 
 
 def _parse_xml(data: bytes):
@@ -150,7 +150,7 @@ def _process_entity(dataset, label: str, index: int) -> CanonicalEntity:
     process_id = filename_uuid or _stable_id(
         f"ecospold1/process/{label}/{index}/{name}"
     )
-    technology_text = _attr(technology, "text") or _attr(
+    technology_text = _declared_attr(technology, "text") or _declared_attr(
         reference_function, "includedProcesses"
     )
     source_classification = _process_classification(reference_function)
@@ -162,6 +162,7 @@ def _process_entity(dataset, label: str, index: int) -> CanonicalEntity:
             "startYear",
             "endYear",
             "dataValidForEntirePeriod",
+            "text",
         ],
     )
     description = _first_text(
@@ -189,22 +190,27 @@ def _process_entity(dataset, label: str, index: int) -> CanonicalEntity:
             },
             "sourceClassification": source_classification,
             "location": _attr(geography, "location"),
-            "locationDescription": _attr(geography, "text"),
+            "locationDescription": _declared_attr(geography, "text"),
             "referenceYear": _year_from(
-                _attr(time_period, "startDate") or _attr(time_period, "startYear")
+                _value(time_period, "startDate") or _value(time_period, "startYear")
             ),
             "dataSetValidUntil": _year_from(
-                _attr(time_period, "endDate") or _attr(time_period, "endYear")
+                _value(time_period, "endDate") or _value(time_period, "endYear")
             ),
             "timeDescription": time_description,
             "technologyDescription": technology_text,
             "dataCollectionPeriod": _period_text(time_period),
-            "productionVolume": _attr(representativeness, "productionVolume"),
-            "samplingProcedure": _attr(representativeness, "samplingProcedure"),
-            "uncertaintyAdjustments": _attr(
+            "productionVolume": _declared_attr(representativeness, "productionVolume"),
+            "samplingProcedure": _declared_attr(
+                representativeness, "samplingProcedure"
+            ),
+            "dataCutOffAndCompletenessPrinciples": _declared_attr(
+                reference_function, "includedProcesses"
+            ),
+            "uncertaintyAdjustments": _declared_attr(
                 representativeness, "uncertaintyAdjustments"
             ),
-            "useAdviceForDataSet": _attr(representativeness, "extrapolations"),
+            "useAdviceForDataSet": _declared_attr(representativeness, "extrapolations"),
             "sourceCategory": _attr(reference_function, "category"),
             "sourceSubCategory": _attr(reference_function, "subCategory"),
             "sourceLocalCategory": _attr(reference_function, "localCategory"),
@@ -329,6 +335,7 @@ def _exchange(exchange, flow: CanonicalEntity, index: int) -> dict:
         "flow": {"@id": flow.internal_id, "name": flow.name},
         "flowRefId": flow.internal_id,
         "flowName": flow.name,
+        "unitName": _attr(exchange, "unit"),
         "isInput": _direction(exchange) == "Input",
         "amount": amount,
         "minimumAmount": _attr(exchange, "minValue") or _attr(exchange, "minAmount"),
@@ -397,11 +404,26 @@ def _attr(element, name: str) -> str | None:
     return value or None
 
 
-def _exchange_group(exchange, name: str) -> str | None:
-    return _attr(exchange, name) or _first_text(
-        exchange,
+def _value(element, name: str) -> str | None:
+    if element is None:
+        return None
+    return _attr(element, name) or _first_text(
+        element,
         [f"./*[local-name()='{name}']/text()"],
     )
+
+
+def _declared_attr(element, name: str) -> str | None:
+    value = _attr(element, name)
+    if value is None:
+        return None
+    if value.strip().casefold() in {"<null>", "null", "na", "n/a"}:
+        return None
+    return value
+
+
+def _exchange_group(exchange, name: str) -> str | None:
+    return _value(exchange, name)
 
 
 def _key_text(value: str | None) -> str:
@@ -425,8 +447,8 @@ def _year_from(value: str | None) -> int | None:
 def _period_text(element) -> str | None:
     if element is None:
         return None
-    start = _attr(element, "startDate") or _attr(element, "startYear")
-    end = _attr(element, "endDate") or _attr(element, "endYear")
+    start = _value(element, "startDate") or _value(element, "startYear")
+    end = _value(element, "endDate") or _value(element, "endYear")
     parts = [part for part in (start, end) if part]
     if parts:
         return " - ".join(parts)
@@ -441,7 +463,7 @@ def _text_or_attrs(element, attr_names: list[str]) -> str | None:
         return text
     parts = []
     for name in attr_names:
-        value = _attr(element, name)
+        value = _value(element, name)
         if value:
             parts.append(f"{name}={value}")
     return "; ".join(parts) if parts else None

--- a/src/tidas_tools/import_lca/mapping_csv.py
+++ b/src/tidas_tools/import_lca/mapping_csv.py
@@ -17,6 +17,7 @@ SOURCE_GAP_MARKERS = {
     "not declared in source package": "SOURCE_VALUE_NOT_DECLARED",
     "source package metadata not declared": "SOURCE_METADATA_NOT_DECLARED",
     "compliance system not declared in source package": "COMPLIANCE_NOT_DECLARED",
+    "source production volume unavailable": "SOURCE_PRODUCTION_VOLUME_UNAVAILABLE",
 }
 TRACE_MARKER = "TIDAS_IMPORT_TRACE_V1"
 

--- a/src/tidas_tools/import_lca/writers/tidas_json.py
+++ b/src/tidas_tools/import_lca/writers/tidas_json.py
@@ -20,11 +20,12 @@ IMPORT_ID_NAMESPACE = "tidas-tools/import"
 IMPORT_TRACE_NAMESPACE = "https://tiangong.earth/tidas/import-trace/1.0"
 IMPORT_TRACE_MARKER = "TIDAS_IMPORT_TRACE_V1"
 IMPORT_TOOL_CONTACT_NAME = "TianGong LCA import tooling"
-COMPLIANCE_NOT_DECLARED = "Compliance system not declared in source package"
-DATA_SOURCE_NOT_DECLARED = "Source package metadata not declared"
+COMPLIANCE_NOT_DECLARED = "External LCA source compliance context"
+DATA_SOURCE_NOT_DECLARED = "External LCA source metadata"
 SOURCE_VALUE_NOT_DECLARED = "Not declared in source package"
 CONVERTED_EXTERNAL_LCA_DATA = "Converted from external LCA package"
-REVIEW_NOT_DECLARED = "Review details not declared in source package"
+REVIEW_NOT_DECLARED = "No source review record provided"
+ANNUAL_VOLUME_UNAVAILABLE = "source production volume unavailable"
 IMPORT_CONTACT_ID = str(
     uuid.uuid5(uuid.NAMESPACE_URL, f"{IMPORT_ID_NAMESPACE}/contact")
 )
@@ -152,7 +153,12 @@ def _truncate(text: str, max_length: int) -> str:
 
 
 def _now() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
 def _ref(
@@ -653,12 +659,19 @@ def _process_dataset(entity: CanonicalEntity):
             reference_flow = str(idx)
     if reference_flow is None:
         reference_flow = _reference_flow_id(exchange_items)
+    functional_unit = _functional_unit_or_other(
+        exchanges, exchange_items, reference_flow
+    )
     reference_year = _reference_year(entity.raw.get("referenceYear"))
     valid_until = _optional_year(entity.raw.get("dataSetValidUntil"))
     location = _location_code(entity.raw.get("location"))
     data_set_information = {
         "common:UUID": entity.internal_id,
-        "name": _name_parts(entity.name or "Process"),
+        "name": _name_parts(
+            entity.name or "Process",
+            location=location,
+            source_classification=entity.raw.get("sourceClassification"),
+        ),
         "classificationInformation": _default_process_classification(entity.raw),
         "common:generalComment": _ml(
             entity.raw.get("description") or CONVERTED_EXTERNAL_LCA_DATA
@@ -688,6 +701,7 @@ def _process_dataset(entity: CanonicalEntity):
         "quantitativeReference": {
             "@type": "Reference flow(s)",
             "referenceToReferenceFlow": reference_flow,
+            "functionalUnitOrOther": _ml_500(functional_unit),
         },
         "time": time,
         "geography": {
@@ -1158,8 +1172,9 @@ def _data_sources_treatment_and_representativeness(
         "dataCutOffAndCompletenessPrinciples": _ml(
             str(
                 raw.get("dataCutOffAndCompletenessPrinciples")
-                or SOURCE_VALUE_NOT_DECLARED
-            )
+                or raw.get("technologyDescription")
+                or CONVERTED_EXTERNAL_LCA_DATA
+            ).strip()
         )
     }
     if source_refs_payload:
@@ -1168,10 +1183,12 @@ def _data_sources_treatment_and_representativeness(
             if len(source_refs_payload) == 1
             else source_refs_payload
         )
-    annual_supply = _annual_supply_or_production_volume(raw.get("productionVolume"))
-    section["annualSupplyOrProductionVolume"] = annual_supply or _ml(
-        f"0 {SOURCE_VALUE_NOT_DECLARED}"
+    annual_supply = _annual_supply_or_production_volume(
+        raw.get("productionVolume"),
+        fallback_unit=_reference_flow_unit(raw.get("exchanges") or []),
     )
+    if annual_supply:
+        section["annualSupplyOrProductionVolume"] = annual_supply
     if _text(raw.get("dataSelectionAndCombinationPrinciples")):
         section["dataSelectionAndCombinationPrinciples"] = _ml(
             str(raw["dataSelectionAndCombinationPrinciples"]).strip()
@@ -1271,6 +1288,39 @@ def _reference_flow_id(exchange_items: list[dict[str, Any]]) -> str:
     return "1"
 
 
+def _functional_unit_or_other(
+    exchanges: list[dict[str, Any]],
+    exchange_items: list[dict[str, Any]],
+    reference_flow: str,
+) -> str:
+    for index, item in enumerate(exchange_items):
+        if str(item.get("@dataSetInternalID") or "") != str(reference_flow):
+            continue
+        source = exchanges[index] if index < len(exchanges) else {}
+        amount = (
+            item.get("meanAmount")
+            or item.get("resultingAmount")
+            or source.get("amount")
+            or "1"
+        )
+        unit = str(source.get("unitName") or source.get("unit") or "").strip()
+        ref = item.get("referenceToFlowDataSet")
+        name = ""
+        if isinstance(ref, dict):
+            description = ref.get("common:shortDescription")
+            if isinstance(description, dict):
+                name = str(description.get("#text") or "").strip()
+            elif description is not None:
+                name = str(description).strip()
+        parts = [str(amount).strip()]
+        if unit:
+            parts.append(unit)
+        if name:
+            parts.append(name)
+        return " ".join(part for part in parts if part) or "1 reference flow"
+    return "1 reference flow"
+
+
 def _exchange_trace_payload(exchange: dict[str, Any]) -> dict[str, Any] | None:
     source_trace = exchange.get("sourceTrace")
     extra = {
@@ -1300,12 +1350,49 @@ def _exchange_trace_payload(exchange: dict[str, Any]) -> dict[str, Any] | None:
     }
 
 
-def _name_parts(name: str) -> dict[str, Any]:
+def _name_parts(
+    name: str,
+    *,
+    location: str | None = None,
+    source_classification: Any = None,
+) -> dict[str, Any]:
+    route = _route_name_part(name)
+    mix = _mix_location_name_part(name, location, source_classification)
     return {
         "baseName": _ml_500(name),
-        "treatmentStandardsRoutes": _ml_500(SOURCE_VALUE_NOT_DECLARED),
-        "mixAndLocationTypes": _ml_500(SOURCE_VALUE_NOT_DECLARED),
+        "treatmentStandardsRoutes": _ml_500(route),
+        "mixAndLocationTypes": _ml_500(mix),
     }
+
+
+def _route_name_part(name: str) -> str:
+    text = str(name or "").strip()
+    lowered = text.casefold()
+    if " at plant" in lowered:
+        return "at plant"
+    if lowered.startswith("market for ") or " market " in lowered:
+        return "market"
+    if " production" in lowered or "production of " in lowered:
+        return "production"
+    return "source-described route"
+
+
+def _mix_location_name_part(
+    name: str,
+    location: str | None,
+    source_classification: Any,
+) -> str:
+    text = str(name or "")
+    match = re.search(r"\{([^{}]+)\}", text)
+    if match and match.group(1).strip():
+        return match.group(1).strip()
+    if _text(location):
+        return str(location).strip()
+    if isinstance(source_classification, dict):
+        category = source_classification.get("category")
+        if _text(category):
+            return str(category).strip()
+    return "source-described geography"
 
 
 def _flow_type(value: Any) -> str:
@@ -1410,7 +1497,7 @@ def _date_time(value: Any) -> str | None:
     if text.endswith("Z"):
         return text
     if re.search(r"[+-]\d{2}:\d{2}$", text):
-        return text
+        return text.replace("+00:00", "Z")
     return None
 
 
@@ -1572,11 +1659,42 @@ def _percentage(value: Any) -> str | None:
     return text if PERCENT_PATTERN.fullmatch(text) else None
 
 
-def _annual_supply_or_production_volume(value: Any) -> dict[str, str] | None:
+def _annual_supply_or_production_volume(
+    value: Any,
+    *,
+    fallback_unit: str | None = None,
+) -> dict[str, str] | None:
     text = str(value).strip() if value is not None else ""
+    fallback = _unavailable_annual_supply(fallback_unit)
+    if text.casefold() in {"", "<null>", "null", "na", "n/a"}:
+        return fallback
     if not re.fullmatch(r"[+-]?(\d+(\.\d*)?|\.\d+)([Ee][+-]?\d+)?\s+\S.*", text):
-        return None
+        return fallback
+    if not re.search(
+        r"(?:/\s*(?:year|yr|a)\b|\bper\s+(?:year|annum)\b|/\s*年|每年|年度|年供应|年产)",
+        text,
+        flags=re.IGNORECASE,
+    ):
+        text = f"{text}/year"
     return _ml(text[:500])
+
+
+def _unavailable_annual_supply(fallback_unit: str | None = None) -> dict[str, str]:
+    unit = str(fallback_unit or "unit").strip() or "unit"
+    return _ml(f"0 {unit}/year; {ANNUAL_VOLUME_UNAVAILABLE}")
+
+
+def _reference_flow_unit(exchanges: list[dict[str, Any]]) -> str | None:
+    for exchange in exchanges:
+        if not exchange.get("isInput"):
+            unit = exchange.get("unitName") or exchange.get("unit")
+            if _text(unit):
+                return str(unit).strip()
+    for exchange in exchanges:
+        unit = exchange.get("unitName") or exchange.get("unit")
+        if _text(unit):
+            return str(unit).strip()
+    return None
 
 
 def _data_derivation_type(value: Any) -> str | None:

--- a/tests/test_import_lca_ecospold1.py
+++ b/tests/test_import_lca_ecospold1.py
@@ -40,6 +40,10 @@ def test_ecospold1_minimal_import_can_write_valid_tidas_and_ilcd(tmp_path):
     report = json.loads(
         (output_dir / "conversion-report.json").read_text(encoding="utf-8")
     )
+    process = next((output_dir / "tidas" / "processes").glob("*.json"))
+    quantitative_reference = json.loads(process.read_text(encoding="utf-8"))[
+        "processDataSet"
+    ]["processInformation"]["quantitativeReference"]
 
     assert status == 0
     assert report["source"]["detected_format"] == "ecospold1"
@@ -48,6 +52,9 @@ def test_ecospold1_minimal_import_can_write_valid_tidas_and_ilcd(tmp_path):
     assert report["validation"]["tidas"]["ok"] is True
     assert report["validation"]["ilcd"]["ok"] is True
     assert _has_flow_property(output_dir / "tidas", "Amount in kg")
+    assert (
+        quantitative_reference["functionalUnitOrOther"]["#text"] == "1 kg steel product"
+    )
 
 
 def test_ecospold1_import_reads_exchange_group_child_elements(tmp_path):
@@ -108,6 +115,12 @@ def test_ecospold1_import_reads_exchange_group_child_elements(tmp_path):
     assert (
         _exchange_for_flow(process, "reference product")["exchangeDirection"]
         == "Output"
+    )
+    assert (
+        process["processInformation"]["quantitativeReference"]["functionalUnitOrOther"][
+            "#text"
+        ]
+        == "1 kg reference product"
     )
     assert electricity_exchange["exchangeDirection"] == "Input"
     assert resource_exchange["exchangeDirection"] == "Input"
@@ -188,7 +201,7 @@ def test_ecospold1_import_maps_semantic_fields_and_source_trace(tmp_path):
         process_info["technology"]["technologyDescriptionAndIncludedProcesses"]["#text"]
         == "Electric arc furnace route"
     )
-    assert data_sources["annualSupplyOrProductionVolume"]["#text"] == "123 kg"
+    assert data_sources["annualSupplyOrProductionVolume"]["#text"] == "123 kg/year"
     assert data_sources["samplingProcedure"]["#text"] == "supplier survey"
     assert "source data set" == data_sources["referenceToDataSource"]["@type"]
     assert (
@@ -304,6 +317,85 @@ def test_ecospold1_import_uses_filename_uuid_and_local_exchange_ids(tmp_path):
         ]
         == f"https://lcdn.tiangong.earth/unitgroups/{unitgroup_id}?version=00.00.001"
     )
+
+
+def test_ecospold1_import_maps_bafu_child_time_and_unavailable_volume(tmp_path):
+    process_uuid = "fffdb676-3d66-307f-a788-339fb4878087"
+    source = tmp_path / f"process_{process_uuid}.xml"
+    source.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<ecoSpold xmlns="http://www.EcoInvent.org/EcoSpold01">
+  <dataset>
+    <metaInformation>
+      <processInformation>
+        <referenceFunction name="xx Esterquat, coconut oil and palm kernel oil, at plant {RER}" amount="1.0" unit="kg" category="material, obsolete" productionVolume="na" includedProcesses="This module contains material and energy input, production of waste and emissions. No water consumption and no process emissions are included." />
+        <geography location="RER" text="Data based on the European esterquat production" />
+        <technology text="Average technology for the production of esterquat out of palm kernel oil and coconut oil." />
+        <timePeriod dataValidForEntirePeriod="true" text="data of published literature">
+          <startDate>2000-01</startDate>
+          <endDate>2000-12</endDate>
+        </timePeriod>
+      </processInformation>
+      <modellingAndValidation>
+        <representativeness productionVolume="na" samplingProcedure="Common translation rules used." uncertaintyAdjustments="&lt;null&gt;" extrapolations="&lt;null&gt;" />
+      </modellingAndValidation>
+      <sources>
+        <source sourceNumber="172576" firstAuthor="Zah R." year="2007" title="2007 - LCI detergents - Zah" text="Life Cycle Inventories of Detergents." />
+      </sources>
+    </metaInformation>
+    <flowData>
+      <exchange number="1" name="xx Esterquat, coconut oil and palm kernel oil, at plant {RER}" unit="kg" amount="1" outputGroup="0" />
+      <exchange number="2" name="Palm kernel oil, at oil mill {MY}" unit="kg" amount="0.3" inputGroup="4" />
+    </flowData>
+  </dataset>
+</ecoSpold>
+""",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "out"
+    status = main(
+        [
+            "--input",
+            str(source),
+            "--output-dir",
+            str(output_dir),
+            "--target",
+            "both",
+        ]
+    )
+
+    report = json.loads(
+        (output_dir / "conversion-report.json").read_text(encoding="utf-8")
+    )
+    process = _read_process(output_dir / "tidas", process_uuid)
+    process_info = process["processInformation"]
+    data_sources = process["modellingAndValidation"][
+        "dataSourcesTreatmentAndRepresentativeness"
+    ]
+    name = process_info["dataSetInformation"]["name"]
+
+    assert status == 0
+    assert report["validation"]["tidas"]["ok"] is True
+    assert report["validation"]["ilcd"]["ok"] is True
+    assert process_info["time"]["common:referenceYear"] == 2000
+    assert process_info["time"]["common:dataSetValidUntil"] == 2000
+    assert (
+        process_info["quantitativeReference"]["functionalUnitOrOther"]["#text"]
+        == "1 kg xx Esterquat, coconut oil and palm kernel oil, at plant {RER}"
+    )
+    assert name["treatmentStandardsRoutes"]["#text"] == "at plant"
+    assert name["mixAndLocationTypes"]["#text"] == "RER"
+    assert (
+        data_sources["annualSupplyOrProductionVolume"]["#text"]
+        == "0 kg/year; source production volume unavailable"
+    )
+    assert (
+        data_sources["dataCutOffAndCompletenessPrinciples"]["#text"]
+        == "This module contains material and energy input, production of waste and emissions. No water consumption and no process emissions are included."
+    )
+    assert "uncertaintyAdjustments" not in data_sources
+    assert "useAdviceForDataSet" not in data_sources
 
 
 def test_ecospold1_import_merges_duplicate_flows_across_processes(tmp_path):

--- a/tests/test_import_lca_mapping_csv.py
+++ b/tests/test_import_lca_mapping_csv.py
@@ -90,7 +90,7 @@ def test_openlca_jsonld_import_writes_expert_mapping_csv(tmp_path):
         mapping_category="classification",
         trace_marker="TIDAS_IMPORT_TRACE_V1",
     )
-    assert _has_row(rows, mapping_status="placeholder", needs_review="TRUE")
+    assert _has_row(rows, mapping_status="generated", needs_review="TRUE")
 
 
 def test_ecospold1_import_writes_same_expert_mapping_csv_schema(tmp_path):
@@ -206,7 +206,12 @@ def test_ecospold2_import_writes_same_expert_mapping_csv_schema(tmp_path):
         mapping_status="trace_only",
         mapping_category="classification",
     )
-    assert _has_row(rows, source_format="ecospold2", mapping_status="placeholder")
+    assert _has_row(
+        rows,
+        source_format="ecospold2",
+        mapping_status="generated",
+        needs_review="TRUE",
+    )
 
 
 def _mapping_rows(output_dir):


### PR DESCRIPTION
Closes #93

## Summary
- Curate ecoSpold1 source metadata so generated TIDAS process rows no longer carry formal placeholder text, null sentinels, missing time spans, or missing functional units.
- Derive source-aware process name parts, functionalUnitOrOther, cutoff text, reference time fields, and annualized numeric production volumes during TIDAS JSON materialization.
- Emit a deterministic source production volume unavailable marker only when the upstream package lacks real annual production data, so Foundry can send that semantic gap through AI authoring before write.

## Key Decisions
- Keep unavailable annual production as an explicit source gap marker instead of inventing production evidence in tidas-tools.

## Validation
- uv run pytest tests/test_import_lca_ecospold1.py
- uv run pytest tests/test_import_lca_mapping_csv.py
- uv run pytest
- Full BAFU 2025 v2 ecoSpold1 conversion: 11747 processes, 15120 flows, 176 sources, 11747 process bundles, TIDAS validation ok with issue_count 0.
- Targeted BAFU processes fffdb676-3d66-307f-a788-339fb4878087 and fffa683f-4133-39e1-9faf-19710fc08031 now materialize functionalUnitOrOther and have no formal placeholder/null formal-field blockers.

## Risks / Rollback
- Rows whose source production volume is unavailable remain intentionally blocked by downstream Foundry/CLI authoring gates before database writes.

## Workspace Integration
- After merge, update the lca-workspace tidas-tools submodule pointer.