### PR TITLE
Release tidas-tools 0.0.27

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "165ed81c1d0caf4d0cbb4f623a27f12704b5461c"
+lastReviewedCommit: "3bb1f288c799af823d20e528cee48b425cbacbb7"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 165ed81c1d0caf4d0cbb4f623a27f12704b5461c
+lastReviewedCommit: 3bb1f288c799af823d20e528cee48b425cbacbb7
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,7 +25,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 165ed81c1d0caf4d0cbb4f623a27f12704b5461c
+lastReviewedCommit: 3bb1f288c799af823d20e528cee48b425cbacbb7
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 165ed81c1d0caf4d0cbb4f623a27f12704b5461c
+lastReviewedCommit: 3bb1f288c799af823d20e528cee48b425cbacbb7
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidas-tools"
-version = "0.0.26"
+version = "0.0.27"
 description = "tidas-tools"
 authors = [
     { name = "Nan LI", email = "linanenv@gmail.com" },


### PR DESCRIPTION
Closes #95

## Summary
- Bump tidas-tools package version from 0.0.26 to 0.0.27.
- Include docpact review evidence for the release/runtime governance docs touched by the version bump.

## Key Decisions
- Use the existing main-push release workflow; no manual tag is created in this PR.

## Validation
- uv run pytest tests/test_package_versions.py
- uv run pytest
- docpact lint passed locally and in pre-push.

## Risks / Rollback
- Release automation will still check PyPI availability and run its release gate before publishing.

## Workspace Integration
- After merge, verify v0.0.27 tag/publish workflow and update lca-workspace tidas-tools pointer if main advances.