### PR TITLE
Release tidas-tools 0.0.28

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "3bb1f288c799af823d20e528cee48b425cbacbb7"
+lastReviewedAt: "2026-06-05"
+lastReviewedCommit: "87f69da113bd8db7660eb5626c3b6c8561a98c7e"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-02
-lastReviewedCommit: 3bb1f288c799af823d20e528cee48b425cbacbb7
+lastReviewedAt: 2026-06-05
+lastReviewedCommit: 87f69da113bd8db7660eb5626c3b6c8561a98c7e
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -82,19 +82,26 @@ Source units from EcoSpold, SimaPro CSV, and process XLSX inputs are propagated
 into generated unit groups and flow properties when no explicit reference data
 is available.
 
-Use `--process-bundles` when downstream AI/import workers need to handle each
-TIDAS process independently. The normal `<output_directory>/tidas` package is
-still written unchanged; the importer also writes
+When downstream AI/import workers need to handle each TIDAS process
+independently, the importer writes per-process bundles by default. The normal
+`<output_directory>/tidas` package is still written unchanged; the importer
+also writes
 `<output_directory>/process-bundles/<process_uuid>/` folders containing the
 process JSON plus referenced flow, flow property, unit group, contact, and
-source JSON files. `--process-bundles-dir <dir>` overrides the bundle location.
+source JSON files. `--process-bundles-dir <dir>` overrides the bundle location,
+and `--no-process-bundles` disables bundle output.
+
+The expert mapping CSV is disabled by default because large imports can produce
+very large field-level mapping files. Use `--write-mapping-csv` to write
+`<output_directory>/mapping.csv.gz`.
 
 ### (2) Usage Example
 
 ```bash
 tidas-import --input <source_file_or_dir> --output-dir <output_directory> --detect-only
 tidas-import --input <source_file_or_dir> --output-dir <output_directory> --target both --validation-jobs 0
-tidas-import --input <source_file_or_dir> --output-dir <output_directory> --process-bundles
+tidas-import --input <source_file_or_dir> --output-dir <output_directory> --no-process-bundles
+tidas-import --input <source_file_or_dir> --output-dir <output_directory> --write-mapping-csv
 ```
 
 ---

--- a/README_CN.md
+++ b/README_CN.md
@@ -109,18 +109,24 @@ tidas-convert --input-dir <eILCD数据目录> --output-dir <TIDAS数据输出目
 
 导入的 JSON-LD Actor 和 Source 会写出为 TIDAS contact 与 source。EcoSpold、SimaPro CSV 和 process XLSX 源数据中的单位会在缺少显式 reference data 时生成对应 unit group 与 flow property，减少全部 flow 落到默认 `Mass`/`kg` 的情况。
 
-当下游 AI/导入 worker 需要按 process 并行处理时，可以使用
-`--process-bundles`。标准 `<输出目录>/tidas` 包会保持原样写出；导入器会额外写出
+当下游 AI/导入 worker 需要按 process 并行处理时，导入器默认写出
+process bundle。标准 `<输出目录>/tidas` 包会保持原样写出；导入器会额外写出
 `<输出目录>/process-bundles/<process_uuid>/` 子目录，其中包含该 process JSON 以及它引用的
 flow、flow property、unit group、contact 和 source JSON 文件。可用
-`--process-bundles-dir <目录>` 覆盖默认 bundle 位置。
+`--process-bundles-dir <目录>` 覆盖默认 bundle 位置，也可用
+`--no-process-bundles` 关闭 bundle 输出。
+
+专家审查用 mapping CSV 默认关闭，因为大型导入会生成很大的逐字段映射文件。
+需要时可用 `--write-mapping-csv` 写出
+`<输出目录>/mapping.csv.gz`。
 
 ### （二）使用示例
 
 ```bash
 tidas-import --input <源文件或目录> --output-dir <输出目录> --detect-only
 tidas-import --input <源文件或目录> --output-dir <输出目录> --target both --validation-jobs 0
-tidas-import --input <源文件或目录> --output-dir <输出目录> --process-bundles
+tidas-import --input <源文件或目录> --output-dir <输出目录> --no-process-bundles
+tidas-import --input <源文件或目录> --output-dir <输出目录> --write-mapping-csv
 ```
 
 ---

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -61,7 +61,7 @@ This repo packages standalone tooling plus the schema, methodology, and styleshe
 
 `convert.py` owns standalone TIDAS and eILCD conversion behavior.
 
-`import_lca/` owns staged external LCA source import behavior for `tidas-import`. The current foundation covers CLI dispatch, format detection, `.zolca` rejection, canonical store scaffolding, TIDAS package layout helpers, optional per-process TIDAS dependency bundle output for parallel AI import workers, ILCD bridging, and conversion reports. Validated adapters currently exist for openLCA JSON-LD, EcoSpold 1, SimaPro CSV, EcoSpold 2, and openLCA process XLSX, with canonical contact/source writing and generated unit group / flow property support for source units.
+`import_lca/` owns staged external LCA source import behavior for `tidas-import`. The current foundation covers CLI dispatch, format detection, `.zolca` rejection, canonical store scaffolding, TIDAS package layout helpers, default per-process TIDAS dependency bundle output for parallel AI import workers, opt-in gzip-compressed expert mapping CSV output, ILCD bridging, and conversion reports. Validated adapters currently exist for openLCA JSON-LD, EcoSpold 1, SimaPro CSV, EcoSpold 2, and openLCA process XLSX, with canonical contact/source writing and generated unit group / flow property support for source units.
 
 ### Validation
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-02
-lastReviewedCommit: 3bb1f288c799af823d20e528cee48b425cbacbb7
+lastReviewedAt: 2026-06-05
+lastReviewedCommit: 87f69da113bd8db7660eb5626c3b6c8561a98c7e
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidas-tools"
-version = "0.0.27"
+version = "0.0.28"
 description = "tidas-tools"
 authors = [
     { name = "Nan LI", email = "linanenv@gmail.com" },

--- a/src/tidas_tools/import_lca/cli.py
+++ b/src/tidas_tools/import_lca/cli.py
@@ -94,6 +94,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional custom mapping/reference data directory.",
     )
     parser.add_argument(
+        "--write-mapping-csv",
+        action="store_true",
+        help=(
+            "Write gzip-compressed expert mapping CSV to "
+            "<output-dir>/mapping.csv.gz. Disabled by default."
+        ),
+    )
+    parser.add_argument(
         "--language",
         default="en",
         help="Default language for generated multilingual text. Defaults to en.",
@@ -112,19 +120,18 @@ def build_parser() -> argparse.ArgumentParser:
             "Use 0 to use all CPU cores. Defaults to 1."
         ),
     )
+    parser.set_defaults(process_bundles=True)
     parser.add_argument(
-        "--process-bundles",
-        action="store_true",
-        help=(
-            "Also write per-process TIDAS dependency bundles under "
-            "<output-dir>/process-bundles."
-        ),
+        "--no-process-bundles",
+        dest="process_bundles",
+        action="store_false",
+        help="Do not write per-process TIDAS dependency bundles.",
     )
     parser.add_argument(
         "--process-bundles-dir",
         help=(
             "Custom directory for per-process TIDAS dependency bundles. "
-            "Implies --process-bundles."
+            "Bundles are enabled by default."
         ),
     )
     parser.add_argument(
@@ -309,14 +316,15 @@ def run_import(args: argparse.Namespace) -> int:
             logging.error("Generated ILCD/eILCD package failed validation")
             return 2
 
-    mapping_csv_path = output_dir / "mapping.csv"
-    report.mapping_csv_rows = write_mapping_csv(
-        store,
-        tidas_dir,
-        mapping_csv_path,
-        source_format=detected.format_id,
-    )
-    report.mapping_csv = str(mapping_csv_path)
+    if args.write_mapping_csv:
+        mapping_csv_path = output_dir / "mapping.csv.gz"
+        report.mapping_csv_rows = write_mapping_csv(
+            store,
+            tidas_dir,
+            mapping_csv_path,
+            source_format=detected.format_id,
+        )
+        report.mapping_csv = str(mapping_csv_path)
     report.write_json(report_path)
     logging.info("Import report written to %s", report_path)
     return _status_for_report(report, args.fail_on_warning)

--- a/src/tidas_tools/import_lca/mapping_csv.py
+++ b/src/tidas_tools/import_lca/mapping_csv.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 from dataclasses import dataclass
 from decimal import Decimal
+import gzip
 import json
 from pathlib import Path
 from typing import Any, Iterable
@@ -80,7 +81,7 @@ def write_mapping_csv(
     entities = _entities_by_id(store)
 
     row_count = 0
-    with path.open("w", newline="", encoding="utf-8") as stream:
+    with _open_output(path) as stream:
         writer = csv.DictWriter(stream, fieldnames=MAPPING_CSV_COLUMNS)
         writer.writeheader()
         for index, row in enumerate(
@@ -96,6 +97,12 @@ def write_mapping_csv(
                 | {"row_id": str(index)}
             )
     return row_count
+
+
+def _open_output(path: Path):
+    if path.suffix == ".gz":
+        return gzip.open(path, "wt", newline="", encoding="utf-8")
+    return path.open("w", newline="", encoding="utf-8")
 
 
 def _mapping_rows(

--- a/tests/test_import_lca_cli.py
+++ b/tests/test_import_lca_cli.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from tidas_tools.import_lca import cli
 from tidas_tools.import_lca.cli import main
 
@@ -26,6 +28,75 @@ def test_cli_detect_only_writes_report(tmp_path):
     assert status == 0
     assert report["source"]["detected_format"] == "simapro-csv"
     assert report["summary"]["errors"] == 0
+
+
+def test_cli_process_bundles_are_enabled_by_default():
+    args = cli.build_parser().parse_args(
+        [
+            "--input",
+            "source.jsonld",
+            "--output-dir",
+            "out",
+        ]
+    )
+
+    assert args.process_bundles is True
+
+
+def test_cli_can_disable_process_bundles():
+    args = cli.build_parser().parse_args(
+        [
+            "--input",
+            "source.jsonld",
+            "--output-dir",
+            "out",
+            "--no-process-bundles",
+        ]
+    )
+
+    assert args.process_bundles is False
+
+
+def test_cli_mapping_csv_is_disabled_by_default():
+    args = cli.build_parser().parse_args(
+        [
+            "--input",
+            "source.jsonld",
+            "--output-dir",
+            "out",
+        ]
+    )
+
+    assert args.write_mapping_csv is False
+
+
+def test_cli_can_enable_mapping_csv():
+    args = cli.build_parser().parse_args(
+        [
+            "--input",
+            "source.jsonld",
+            "--output-dir",
+            "out",
+            "--write-mapping-csv",
+        ]
+    )
+
+    assert args.write_mapping_csv is True
+
+
+def test_cli_rejects_legacy_process_bundles_flag():
+    with pytest.raises(SystemExit) as exc:
+        cli.build_parser().parse_args(
+            [
+                "--input",
+                "source.jsonld",
+                "--output-dir",
+                "out",
+                "--process-bundles",
+            ]
+        )
+
+    assert exc.value.code == 2
 
 
 def test_cli_rejects_zolca_with_report(tmp_path):

--- a/tests/test_import_lca_mapping_csv.py
+++ b/tests/test_import_lca_mapping_csv.py
@@ -1,4 +1,5 @@
 import csv
+import gzip
 import json
 
 from tidas_tools.import_lca.cli import main
@@ -8,7 +9,7 @@ FLOW_ID = "11111111-1111-4111-8111-111111111111"
 PROCESS_ID = "22222222-2222-4222-8222-222222222222"
 
 
-def test_openlca_jsonld_import_writes_expert_mapping_csv(tmp_path):
+def test_openlca_jsonld_import_writes_expert_mapping_csv_gz(tmp_path):
     source_dir = tmp_path / "jsonld"
     source_dir.mkdir()
     (source_dir / "flow.json").write_text(
@@ -56,6 +57,7 @@ def test_openlca_jsonld_import_writes_expert_mapping_csv(tmp_path):
             str(output_dir),
             "--from-format",
             "openlca-jsonld",
+            "--write-mapping-csv",
         ]
     )
 
@@ -66,7 +68,7 @@ def test_openlca_jsonld_import_writes_expert_mapping_csv(tmp_path):
 
     assert status == 0
     assert rows
-    assert report["target"]["mapping_csv"] == str(output_dir / "mapping.csv")
+    assert report["target"]["mapping_csv"] == str(output_dir / "mapping.csv.gz")
     assert report["target"]["mapping_csv_rows"] == len(rows)
     assert rows[0].keys() == dict.fromkeys(MAPPING_CSV_COLUMNS).keys()
     assert _has_row(
@@ -93,7 +95,7 @@ def test_openlca_jsonld_import_writes_expert_mapping_csv(tmp_path):
     assert _has_row(rows, mapping_status="generated", needs_review="TRUE")
 
 
-def test_ecospold1_import_writes_same_expert_mapping_csv_schema(tmp_path):
+def test_ecospold1_import_writes_same_expert_mapping_csv_gz_schema(tmp_path):
     source = tmp_path / "dataset.xml"
     source.write_text(
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -117,7 +119,15 @@ def test_ecospold1_import_writes_same_expert_mapping_csv_schema(tmp_path):
     )
     output_dir = tmp_path / "out"
 
-    status = main(["--input", str(source), "--output-dir", str(output_dir)])
+    status = main(
+        [
+            "--input",
+            str(source),
+            "--output-dir",
+            str(output_dir),
+            "--write-mapping-csv",
+        ]
+    )
 
     rows = _mapping_rows(output_dir)
 
@@ -141,7 +151,7 @@ def test_ecospold1_import_writes_same_expert_mapping_csv_schema(tmp_path):
     assert _has_row(rows, source_format="ecospold1", mapping_status="placeholder")
 
 
-def test_ecospold2_import_writes_same_expert_mapping_csv_schema(tmp_path):
+def test_ecospold2_import_writes_same_expert_mapping_csv_gz_schema(tmp_path):
     source = tmp_path / "activity.spold"
     source.write_text(
         f"""<?xml version="1.0" encoding="UTF-8"?>
@@ -186,7 +196,15 @@ def test_ecospold2_import_writes_same_expert_mapping_csv_schema(tmp_path):
     )
     output_dir = tmp_path / "out"
 
-    status = main(["--input", str(source), "--output-dir", str(output_dir)])
+    status = main(
+        [
+            "--input",
+            str(source),
+            "--output-dir",
+            str(output_dir),
+            "--write-mapping-csv",
+        ]
+    )
 
     rows = _mapping_rows(output_dir)
 
@@ -215,9 +233,10 @@ def test_ecospold2_import_writes_same_expert_mapping_csv_schema(tmp_path):
 
 
 def _mapping_rows(output_dir):
-    path = output_dir / "mapping.csv"
+    path = output_dir / "mapping.csv.gz"
     assert path.is_file()
-    with path.open(newline="", encoding="utf-8") as stream:
+    assert not (output_dir / "mapping.csv").exists()
+    with gzip.open(path, "rt", newline="", encoding="utf-8") as stream:
         return list(csv.DictReader(stream))
 
 

--- a/tests/test_import_lca_openlca_jsonld.py
+++ b/tests/test_import_lca_openlca_jsonld.py
@@ -47,6 +47,10 @@ def test_openlca_jsonld_minimal_import_writes_valid_tidas_package(tmp_path):
     assert report["summary"]["processes"] == 1
     assert report["summary"]["sources"] == 2
     assert report["validation"]["tidas"]["ok"] is True
+    assert report["target"]["mapping_csv"] is None
+    assert report["target"]["mapping_csv_rows"] is None
+    assert not (output_dir / "mapping.csv").exists()
+    assert not (output_dir / "mapping.csv.gz").exists()
     process_payload = json.loads(
         (output_dir / "tidas" / "processes" / f"{PROCESS_ID}.json").read_text(
             encoding="utf-8"
@@ -92,7 +96,7 @@ def test_openlca_jsonld_minimal_import_writes_valid_tidas_package(tmp_path):
     assert exchange["meanAmount"] == "0.123456789012345678"
 
 
-def test_openlca_jsonld_minimal_import_can_write_process_bundles(tmp_path):
+def test_openlca_jsonld_minimal_import_writes_process_bundles_by_default(tmp_path):
     source_dir = write_minimal_jsonld_fixture(tmp_path)
     output_dir = tmp_path / "out"
 
@@ -104,7 +108,6 @@ def test_openlca_jsonld_minimal_import_can_write_process_bundles(tmp_path):
             str(output_dir),
             "--from-format",
             "openlca-jsonld",
-            "--process-bundles",
         ]
     )
 
@@ -144,6 +147,33 @@ def test_openlca_jsonld_minimal_import_can_write_process_bundles(tmp_path):
 
     validation = validate_package_dir(str(bundle_dir / "tidas"))
     assert validation["ok"] is True
+
+
+def test_openlca_jsonld_minimal_import_can_disable_process_bundles(tmp_path):
+    source_dir = write_minimal_jsonld_fixture(tmp_path)
+    output_dir = tmp_path / "out"
+
+    status = main(
+        [
+            "--input",
+            str(source_dir),
+            "--output-dir",
+            str(output_dir),
+            "--from-format",
+            "openlca-jsonld",
+            "--no-process-bundles",
+        ]
+    )
+
+    report = json.loads(
+        (output_dir / "conversion-report.json").read_text(encoding="utf-8")
+    )
+
+    assert status == 0
+    assert not (output_dir / "process-bundles").exists()
+    assert report["target"]["process_bundles_dir"] is None
+    assert report["target"]["process_bundle_count"] is None
+    assert report["summary"]["process_bundles"] == 0
 
 
 def test_openlca_jsonld_minimal_import_can_write_valid_ilcd(tmp_path):


### PR DESCRIPTION
Closes #97

## Summary
- Bump `tidas-tools` package version from `0.0.27` to `0.0.28`.
- Make `tidas-import` emit per-process bundles by default and use `--no-process-bundles` to disable them.
- Disable expert mapping CSV generation by default; add `--write-mapping-csv` to write compressed `mapping.csv.gz` when needed.
- Update README/README_CN and repo architecture guidance for the import defaults.

## Key Decisions
- Use the existing main-push release workflow; no manual release tag is created in this PR.
- Keep mapping CSV opt-in because large imports can create very large field-level mapping files.
- Keep per-process bundles enabled by default because downstream import workers need process-isolated dependency bundles.

## Validation
- Confirmed PyPI current `tidas-tools` version is `0.0.27`; `0.0.28` is not published yet.
- `uv lock --check`
- `uv run black --check --target-version py313 src tests`
- `uv run python src/tidas_tools/import_lca/cli.py --help`
- `uv run pytest` (`82 passed`)
- `scripts/docpact validate-config --root . --strict --format json`
- `scripts/docpact lint --root . --worktree --format json`
- `scripts/docpact-gate.sh --base HEAD^ --head HEAD`
- pre-push gate: docpact + `uv run pytest` (`82 passed`)
- `uv build`
- `uvx twine check dist/*`

## Risks / Rollback
- Release automation will still check PyPI availability and run the release gate/test matrix before publishing.
- Rollback is a normal follow-up release if the package publishes successfully but behavior needs adjustment.

## Workspace Integration
- After merge/publish, verify `v0.0.28` and update the `lca-workspace` `tidas-tools` submodule pointer when the new tooling snapshot should ship through the workspace.
