### PR TITLE
fix(schema): allow shallow classification paths (remove over-strict cardinality)

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-13"
-lastReviewedCommit: "41264f7bbbeda96c5d50b6fb183800b73356ca7b"
+lastReviewedAt: "2026-06-15"
+lastReviewedCommit: "fb42d72397f00044221e78e119b9701e772155fe"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-13
-lastReviewedCommit: 41264f7bbbeda96c5d50b6fb183800b73356ca7b
+lastReviewedAt: 2026-06-15
+lastReviewedCommit: 800cc444ac59b2539063c356b773cce61369b4a3
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -24,8 +24,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-13
-lastReviewedCommit: 41264f7bbbeda96c5d50b6fb183800b73356ca7b
+lastReviewedAt: 2026-06-15
+lastReviewedCommit: 800cc444ac59b2539063c356b773cce61369b4a3
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-13
-lastReviewedCommit: 41264f7bbbeda96c5d50b6fb183800b73356ca7b
+lastReviewedAt: 2026-06-15
+lastReviewedCommit: 800cc444ac59b2539063c356b773cce61369b4a3
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidas-tools"
-version = "0.0.30"
+version = "0.0.31"
 description = "tidas-tools"
 authors = [
     { name = "Nan LI", email = "linanenv@gmail.com" },

--- a/src/tidas_tools/tidas/schemas/tidas_contacts.json
+++ b/src/tidas_tools/tidas/schemas/tidas_contacts.json
@@ -109,30 +109,8 @@
                                 }
                               ],
                               "uniqueItems": true,
-                              "allOf": [
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "0"
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "1"
-                                      }
-                                    }
-                                  }
-                                }
-                              ]
+                              "maxItems": 2,
+                              "additionalItems": false
                             },
                             {
                               "type": "object",

--- a/src/tidas_tools/tidas/schemas/tidas_flows.json
+++ b/src/tidas_tools/tidas/schemas/tidas_flows.json
@@ -159,41 +159,8 @@
                             }
                           ],
                           "uniqueItems": true,
-                          "allOf": [
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "0"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "1"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "2"
-                                  }
-                                }
-                              }
-                            }
-                          ]
+                          "maxItems": 3,
+                          "additionalItems": false
                         },
                         "common:other": {
                           "$ref": "tidas_data_types.json#/$defs/CommonOther"
@@ -336,63 +303,8 @@
                             }
                           ],
                           "uniqueItems": true,
-                          "allOf": [
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "0"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "1"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "2"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "3"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "4"
-                                  }
-                                }
-                              }
-                            }
-                          ]
+                          "maxItems": 5,
+                          "additionalItems": false
                         },
                         "common:other": {
                           "$ref": "tidas_data_types.json#/$defs/CommonOther"

--- a/src/tidas_tools/tidas/schemas/tidas_lciamethods.json
+++ b/src/tidas_tools/tidas/schemas/tidas_lciamethods.json
@@ -132,41 +132,8 @@
                                 }
                               ],
                               "uniqueItems": true,
-                              "allOf": [
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "0"
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "1"
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "2"
-                                      }
-                                    }
-                                  }
-                                }
-                              ]
+                              "maxItems": 3,
+                              "additionalItems": false
                             }
                           ]
                         },

--- a/src/tidas_tools/tidas/schemas/tidas_lifecyclemodels.json
+++ b/src/tidas_tools/tidas/schemas/tidas_lifecyclemodels.json
@@ -188,52 +188,8 @@
                             }
                           ],
                           "uniqueItems": true,
-                          "allOf": [
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "0"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "1"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "2"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "3"
-                                  }
-                                }
-                              }
-                            }
-                          ]
+                          "maxItems": 4,
+                          "additionalItems": false
                         },
                         "common:other": {
                           "$ref": "tidas_data_types.json#/$defs/CommonOther"

--- a/src/tidas_tools/tidas/schemas/tidas_processes.json
+++ b/src/tidas_tools/tidas/schemas/tidas_processes.json
@@ -196,52 +196,8 @@
                             }
                           ],
                           "uniqueItems": true,
-                          "allOf": [
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "0"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "1"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "2"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "3"
-                                  }
-                                }
-                              }
-                            }
-                          ]
+                          "maxItems": 4,
+                          "additionalItems": false
                         },
                         "common:other": {
                           "$ref": "tidas_data_types.json#/$defs/CommonOther"


### PR DESCRIPTION
## Problem

TIDAS classification arrays force a **full-depth** path, wrongly rejecting legitimately-shallow classifications — e.g. ILCD **"Land use"** (level 0–1) and **"Other elementary flows" / Noise** (level 0) elementary flows, which have no deeper levels in the category scheme.

Root cause: the arrays expressed *"0..N levels, at most one per level"* via JSON-Schema `allOf`/`contains` + `minContains:0` / `maxContains:1`. But every validator in the stack is **draft-07** — `jsonschema@1.5.0` (TS SDK `validatePackageDir`), `Draft7Validator` (tidas-tools `validate.py`), `fastjsonschema`/`jsonschema` (Python SDK) — and **silently ignores `minContains`/`maxContains`**. Bare draft-07 `contains` means "≥1 match required", so the per-level `contains` blocks force the array to contain one item of **every** level.

## Fix

Replace each broken `allOf`/`contains` block with draft-07-native **`maxItems: N` + `additionalItems: false`**. The positional `items` tuple + `uniqueItems` already pin level-by-position. **Strictly loosening** on the count dimension (0..N levels now valid; >N still rejected). Value-level catId/text validation (`dependencies` → category scheme) and the code-level classification-hierarchy ordering check are unchanged.

6 blocks across 5 schemas: `tidas_flows` (×2: elementary `common:category` + product `common:classification`), `tidas_contacts`, `tidas_lciamethods`, `tidas_lifecyclemodels`, `tidas_processes`.

> The generated **Zod** (TS) and **Pydantic** (Python) models never encoded this cardinality (`ts-to-zod` / `datamodel-codegen` can't express `contains`), so **only the JSON schemas change** — regenerating types/Zod/Pydantic produces no diff. This is also why the fix lives entirely in the JSON schemas.

## Verification (all green)

- **tidas-tools**: `uv run pytest` → **89 passed**
- **tidas-sdk**: jest **41 passed**; pytest **37 passed**
- **cli**: `npm test` → **775 passed**
- **305/305** sample BAFU flows valid under the patched schemas (the 13 previously-blocked Land-use/Noise elementary flows now validate); negative tests (over-deep array, invalid catId/text, wrong order) still rejected.
