### PR TITLE
fix(import_lca): promote USLCI land-transformation flows to Elementary Land use (0.0.36)

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-25"
-lastReviewedCommit: "48cbdbaed5feb33dcc83fea10cc48ec3c70553cb"
+lastReviewedCommit: "8fb8a5acbc0165864e13df5490b1c709ce58460d"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-25
-lastReviewedCommit: 48cbdbaed5feb33dcc83fea10cc48ec3c70553cb
+lastReviewedCommit: "8fb8a5acbc0165864e13df5490b1c709ce58460d"
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-25
-lastReviewedCommit: 48cbdbaed5feb33dcc83fea10cc48ec3c70553cb
+lastReviewedCommit: "8fb8a5acbc0165864e13df5490b1c709ce58460d"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-25
-lastReviewedCommit: 48cbdbaed5feb33dcc83fea10cc48ec3c70553cb
+lastReviewedCommit: "8fb8a5acbc0165864e13df5490b1c709ce58460d"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidas-tools"
-version = "0.0.35"
+version = "0.0.36"
 description = "tidas-tools"
 authors = [
     { name = "Nan LI", email = "linanenv@gmail.com" },

--- a/src/tidas_tools/import_lca/writers/tidas_json.py
+++ b/src/tidas_tools/import_lca/writers/tidas_json.py
@@ -665,6 +665,13 @@ def _flow_dataset(
     generated_units: dict[str, tuple[CanonicalEntity, CanonicalEntity]] | None = None,
 ):
     flow_type = _flow_type(entity.raw.get("flowType"))
+    # Land-use flows (ecoinvent "Occupation,"/"Transformation, from|to ...") are
+    # elementary even when a source mislabels them as PRODUCT_FLOW (e.g. USLCI's
+    # "Ecosystem Services" product category). Promote them so they receive a real
+    # ILCD Land-use category instead of a CPC product stub. The original flowType is
+    # preserved as provenance in the classification sourceTrace.
+    if flow_type == "Product flow" and _is_land_use_flow(entity.raw):
+        flow_type = "Elementary flow"
     classification = _flow_classification(flow_type, entity.raw)
     dataset_info = {
         "common:UUID": entity.internal_id,
@@ -1761,6 +1768,52 @@ def _location_codes() -> frozenset[str]:
     )
 
 
+# ecoinvent/openLCA land-use elementary flows follow a fixed naming convention:
+# "Occupation, <land class>", "Transformation, from <land class>" and
+# "Transformation, to <land class>". Some sources (notably NREL USLCI) mislabel
+# these as PRODUCT_FLOW under an "Ecosystem Services" product category. Detect them
+# by name so they are emitted as elementary flows under the ILCD "Land use" category
+# instead of a meaningless CPC product stub.
+_LAND_OCCUPATION_RE = re.compile(r"^\s*occupation\s*,", re.IGNORECASE)
+_LAND_TRANSFORMATION_RE = re.compile(
+    r"^\s*transformation\s*,\s*(?:from|to)\b", re.IGNORECASE
+)
+
+
+def _land_use_categorization(name: Any) -> list[dict[str, str]] | None:
+    """Return the ILCD "Land use" elementary category for a land-use flow name.
+
+    Maps the ecoinvent land-flow naming convention to the TIDAS elementary category
+    tree (tidas_flows_elementary_category.json): occupation -> "Land occupation"
+    (3.1), transformation -> "Land transformation" (3.2). Returns None for any other
+    name. The "Land use" branch is two levels deep (L0/L1), which the flow schema's
+    positional category array accepts (maxItems 3, no minItems).
+    """
+    text = str(name or "")
+    if _LAND_OCCUPATION_RE.match(text):
+        leaf = ("3.1", "Land occupation")
+    elif _LAND_TRANSFORMATION_RE.match(text):
+        leaf = ("3.2", "Land transformation")
+    else:
+        return None
+    return [
+        {"@level": "0", "@catId": "3", "#text": "Land use"},
+        {"@level": "1", "@catId": leaf[0], "#text": leaf[1]},
+    ]
+
+
+def _is_land_use_flow(raw: dict[str, Any] | None) -> bool:
+    """True when the flow's name marks it as an ecoinvent land-use elementary flow.
+
+    Keyed on raw["name"], which only the openLCA JSON-LD adapter carries; ecoSpold
+    adapters omit it (their land flows are already typed elementary with real
+    compartments), so this never reclassifies ecoSpold/BAFU output.
+    """
+    if not raw:
+        return False
+    return _land_use_categorization(raw.get("name")) is not None
+
+
 def _elementary_categorization(
     raw: dict[str, Any] | None,
 ) -> list[dict[str, str]] | None:
@@ -1771,11 +1824,15 @@ def _elementary_categorization(
     "Elementary flows/emission/air/troposphere/rural"); returns None otherwise so
     the caller keeps the legacy default. ecoSpold single-token compartments
     ("air"/"resource") and non-FEDEFL shapes have no recognizable medium and yield
-    None, so this never changes the ecoSpold/BAFU output. Compartment text/catIds
-    match tidas_flows_elementary_category.json.
+    None, so this never changes the ecoSpold/BAFU output. Land-use flows are matched
+    by name first (see _land_use_categorization). Compartment text/catIds match
+    tidas_flows_elementary_category.json.
     """
     if not raw:
         return None
+    land = _land_use_categorization(raw.get("name"))
+    if land is not None:
+        return land
     raw_path = raw.get("category")
     if not raw_path and isinstance(raw.get("sourceCategoryPath"), list):
         raw_path = "/".join(str(part) for part in raw["sourceCategoryPath"])

--- a/tests/test_import_lca_writer_placeholders.py
+++ b/tests/test_import_lca_writer_placeholders.py
@@ -100,6 +100,54 @@ def test_missing_compartment_falls_back_with_gap():
     assert other["tidasimport:conversionGap"]["status"] == "placeholder-compartment"
 
 
+# --- land-use elementary flows mislabelled as PRODUCT_FLOW (USLCI) ----------
+
+
+def test_land_use_categorization_by_name():
+    occ = W._land_use_categorization("Occupation, arable, non-irrigated")
+    assert occ == [
+        {"@level": "0", "@catId": "3", "#text": "Land use"},
+        {"@level": "1", "@catId": "3.1", "#text": "Land occupation"},
+    ]
+    for name in ("Transformation, from pasture and meadow", "Transformation, to forest"):
+        assert W._land_use_categorization(name) == [
+            {"@level": "0", "@catId": "3", "#text": "Land use"},
+            {"@level": "1", "@catId": "3.2", "#text": "Land transformation"},
+        ]
+    # Non land-use names (products, emissions) are untouched.
+    for name in ("Electricity, at grid", "Carbon dioxide", "transformer, distribution"):
+        assert W._land_use_categorization(name) is None
+
+
+def test_land_use_product_flow_promoted_to_elementary_land_category():
+    # USLCI ships land-transformation flows as PRODUCT_FLOW / "Ecosystem Services".
+    raw = {"name": "Transformation, from pasture and meadow", "flowType": "PRODUCT_FLOW",
+           "category": "Ecosystem Services"}
+    flow_type = W._flow_type(raw["flowType"])
+    if flow_type == "Product flow" and W._is_land_use_flow(raw):
+        flow_type = "Elementary flow"
+    assert flow_type == "Elementary flow"
+    block = W._flow_classification(flow_type, raw)
+    # Land-use category, not a CPC product stub or air-unspecified placeholder.
+    assert "common:classification" not in block
+    cats = block["common:elementaryFlowCategorization"]["common:category"]
+    assert cats == [
+        {"@level": "0", "@catId": "3", "#text": "Land use"},
+        {"@level": "1", "@catId": "3.2", "#text": "Land transformation"},
+    ]
+    # No conversion gap, but original PRODUCT_FLOW preserved as provenance.
+    other = block["common:elementaryFlowCategorization"]["common:other"]
+    assert "tidasimport:conversionGap" not in other
+    assert other["tidasimport:sourceTrace"]["payload"]["sourceFlowType"] == "PRODUCT_FLOW"
+
+
+def test_ecospold_style_raw_without_name_not_reclassified():
+    # ecoSpold/BAFU flow raw carries no "name" key -> never promoted/reclassified.
+    assert W._is_land_use_flow({"flowType": "PRODUCT_FLOW", "category": "land"}) is False
+    assert W._elementary_categorization({"category": "resource/ground"}) is not None
+    assert W._land_use_categorization(None) is None
+
+
 # --- B3: scanner ----------------------------------------------------------
 
 


### PR DESCRIPTION
## What
USLCI's openLCA export labels land-transformation flows as `PRODUCT_FLOW` with category 'Ecosystem Services'. `_flow_dataset` / `_land_use_categorization` now detect these by name and promote them to Elementary **'Land use'** (3.2 transformation / 3.1 occupation), keyed on `raw['name']` so the ecoSpold/BAFU adapters are unaffected.

## Why
Without this, USLCI land flows hit the CPC authoring gate as products and couldn't reuse the canonical elementary land flows — blocking the import. This is the converter half of the USLCI elementary-reuse fix (validated end-to-end by the 1,347/1,358 USLCI import run).

## Tests / gate
- +3 regression tests; full suite **129 passed**.
- docpact gate: **pass** (coverage=ok, freshness=ok); version bumped 0.0.35 → **0.0.36** (CI tags + publishes on merge to main).