### PR TITLE
fix: recover the 0.0.42 Windows release

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -2,6 +2,7 @@ version: 1
 layout: repo
 lastReviewedAt: "2026-06-30"
 lastReviewedCommit: "9b5030e6862d5aff7776794823c88b7812441233"
+# Review note, 2026-07-17: Issue #112 keeps UTF-8 schema reads, LF release-report writes, Windows-portable fixtures, and the 0.0.42 recovery release inside the existing validation, release-packaging, test, and release routes. No ownership, schema, dependency, dispatch, tag-pattern, or workspace-integration rule changes are required.
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,8 @@ related:
 
 `tidas-tools` owns standalone TIDAS and eILCD conversion, validation, export behavior, and the packaged schema and methodology assets consumed by downstream SDK refreshes. Start here when the task may change how TIDAS data is validated, converted, exported, or versioned as tooling.
 
+Review note, 2026-07-17: Issue #112 makes packaged schema reads explicitly UTF-8 and release JSON writes explicitly LF, adds Windows regression proof, and publishes the recovery as 0.0.42. Conversion/profile semantics, packaged assets, dependencies, release automation, immutable tag rules, and workspace-integration requirements are unchanged.
+
 ## Documentation Roles
 
 | Document | Owns | Does not own |

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -38,6 +38,8 @@ related:
 
 This repo packages standalone tooling plus the schema, methodology, and stylesheet assets those tools execute against.
 
+Review note, 2026-07-17: Issue #112 remains inside the existing validation and release-packaging modules. Explicit UTF-8 reads and LF writes make the same packaged assets and report structures byte-stable on Windows; no tool family, asset source, downstream dispatch path, or release architecture changes.
+
 ## Stable Path Map
 
 | Path group | Role |

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -38,6 +38,8 @@ related:
 
 ## Default Baseline
 
+Review note, 2026-07-17: Issue #112 keeps the existing proof contract and makes its four-platform release matrix authoritative for UTF-8 schema/index parity and LF release bytes. The 0.0.42 recovery still requires schema lock, Black, full pytest, release CLI help, Docpact, the complete publish matrix, and PyPI verification.
+
 Unless the change is doc-only, the default local baseline is:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidas-tools"
-version = "0.0.41"
+version = "0.0.42"
 description = "tidas-tools"
 authors = [
     { name = "Nan LI", email = "linanenv@gmail.com" },

--- a/src/tidas_tools/release.py
+++ b/src/tidas_tools/release.py
@@ -98,6 +98,7 @@ def _write_json(file_path: Path, value: Any) -> None:
     file_path.write_text(
         json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
         encoding="utf-8",
+        newline="\n",
     )
 
 

--- a/src/tidas_tools/validate.py
+++ b/src/tidas_tools/validate.py
@@ -811,7 +811,7 @@ def retrieve_schema(uri):
         try:
             schema_name = uri.replace("\\", "/").rstrip("/").split("/")[-1]
             schema_path = pkg_resources.files(schemas) / schema_name
-            with open(schema_path, "r") as f:
+            with open(schema_path, "r", encoding="utf-8") as f:
                 schema_data = json.load(f)
                 # Create a proper resource object
                 return DRAFT7.create_resource(schema_data)
@@ -952,7 +952,7 @@ def _collect_tidas_file_issues(
     validator: TidasSchemaValidator,
 ) -> list[ValidationIssue]:
     try:
-        with open(full_path, "r") as json_file:
+        with open(full_path, "r", encoding="utf-8") as json_file:
             json_item = json.load(json_file)
     except Exception as e:
         return [

--- a/src/tidas_tools/validate.py
+++ b/src/tidas_tools/validate.py
@@ -56,7 +56,7 @@ SUPPORTED_CATEGORIES = [
 @lru_cache
 def tidas_language_codes() -> frozenset[str]:
     schema_file_path = pkg_resources.files(schemas) / "tidas_data_types.json"
-    with schema_file_path.open() as schema_file:
+    with schema_file_path.open(encoding="utf-8") as schema_file:
         root_schema = json.load(schema_file)
     values = root_schema["$defs"]["Languages"]["enum"]
     return frozenset(str(value) for value in values)
@@ -825,7 +825,7 @@ def retrieve_schema(uri):
 @lru_cache(maxsize=None)
 def _load_tidas_schema(schema_filename: str) -> dict:
     schema_file_path = pkg_resources.files(schemas) / schema_filename
-    with schema_file_path.open() as schema_file:
+    with schema_file_path.open(encoding="utf-8") as schema_file:
         return json.load(schema_file)
 
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -14,6 +14,7 @@ from tidas_tools.release import (
     convert_tidas_to_ilcd,
     deterministic_zip,
     load_dataset_index,
+    main as release_main,
     resolve_profile_closure,
     semantic_roundtrip_report,
 )
@@ -39,7 +40,7 @@ def _write_dataset(root, relative_path, document, dataset_type, role, dataset_id
     file_path = root / relative_path
     file_path.parent.mkdir(parents=True, exist_ok=True)
     body = json.dumps(document, ensure_ascii=False, indent=2) + "\n"
-    file_path.write_text(body, encoding="utf-8")
+    file_path.write_text(body, encoding="utf-8", newline="\n")
     return {
         "datasetType": dataset_type,
         "role": role,
@@ -155,6 +156,7 @@ def release_tree(tmp_path):
         )
         + "\n",
         encoding="utf-8",
+        newline="\n",
     )
     return root, index_path
 
@@ -216,6 +218,32 @@ def test_profile_closure_and_four_packages_are_self_contained_and_deterministic(
         )
 
 
+def test_release_report_uses_utf8_lf_bytes(tmp_path, capsys):
+    root, index_path = release_tree(tmp_path)
+    report_path = tmp_path / "closure-report.json"
+
+    exit_code = release_main(
+        [
+            "validate-closure",
+            "--input-dir",
+            str(root),
+            "--dataset-index",
+            str(index_path),
+            "--profile",
+            UNIT_PROFILE,
+            "--report",
+            str(report_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["status"] == "passed"
+    report_bytes = report_path.read_bytes()
+    assert report_bytes.endswith(b"\n")
+    assert b"\r\n" not in report_bytes
+    assert json.loads(report_bytes.decode("utf-8"))["status"] == "passed"
+
+
 def _child_names(element):
     return [child.tag.rsplit("}", 1)[-1] for child in element]
 
@@ -270,6 +298,7 @@ def test_conversion_restores_nested_ilcd_schema_order_from_canonical_json(tmp_pa
             sort_keys=True,
         ),
         encoding="utf-8",
+        newline="\n",
     )
     model_path = root / f"lifecyclemodels/{MODEL_ID}_{VERSION}.json"
     model_path.parent.mkdir(parents=True)
@@ -295,6 +324,7 @@ def test_conversion_restores_nested_ilcd_schema_order_from_canonical_json(tmp_pa
             sort_keys=True,
         ),
         encoding="utf-8",
+        newline="\n",
     )
     lcia_path = root / f"lciamethods/{METHOD_ID}_{VERSION}.json"
     lcia_path.parent.mkdir(parents=True)
@@ -331,6 +361,7 @@ def test_conversion_restores_nested_ilcd_schema_order_from_canonical_json(tmp_pa
             sort_keys=True,
         ),
         encoding="utf-8",
+        newline="\n",
     )
 
     ilcd_dir = tmp_path / "ilcd"
@@ -415,18 +446,20 @@ def test_conversion_restores_nested_ilcd_schema_order_from_canonical_json(tmp_pa
 def test_closure_fails_closed_for_missing_or_inexact_references(tmp_path):
     root, index_path = release_tree(tmp_path)
     unit_path = root / f"processes/{UNIT_ID}_{VERSION}.json"
-    document = json.loads(unit_path.read_text())
+    document = json.loads(unit_path.read_text(encoding="utf-8"))
     reference = document["processDataSet"]["exchanges"]["exchange"][
         "referenceToFlowDataSet"
     ]
     reference.pop("@version")
     body = json.dumps(document, indent=2) + "\n"
-    unit_path.write_text(body)
+    unit_path.write_text(body, encoding="utf-8", newline="\n")
 
-    index = json.loads(index_path.read_text())
+    index = json.loads(index_path.read_text(encoding="utf-8"))
     unit_entry = next(item for item in index["datasets"] if item["uuid"] == UNIT_ID)
     unit_entry["sha256"] = hashlib.sha256(body.encode()).hexdigest()
-    index_path.write_text(json.dumps(index, indent=2) + "\n")
+    index_path.write_text(
+        json.dumps(index, indent=2) + "\n", encoding="utf-8", newline="\n"
+    )
     entries = load_dataset_index(index_path, root)
     with pytest.raises(ReleaseToolError, match="without @version") as error:
         resolve_profile_closure(

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -38,7 +38,7 @@ from tidas_tools import validate as validate_module
 
 def build_data_type_validator(definition_name):
     schema_file_path = pkg_resources.files(schemas) / "tidas_data_types.json"
-    with schema_file_path.open() as schema_file:
+    with schema_file_path.open(encoding="utf-8") as schema_file:
         root_schema = json.load(schema_file)
 
     return Draft7Validator(
@@ -53,7 +53,7 @@ def build_data_type_validator(definition_name):
 
 def load_tidas_schema(schema_name):
     schema_file_path = pkg_resources.files(schemas) / schema_name
-    with schema_file_path.open() as schema_file:
+    with schema_file_path.open(encoding="utf-8") as schema_file:
         return json.load(schema_file)
 
 
@@ -919,6 +919,15 @@ def test_retrieve_schema_resolves_bare_and_mangled_ref_uris():
         assert resource is not None
         assert "$defs" in resource.contents
     assert bare.contents == mangled_windows.contents == posix_uri.contents
+
+    product_categories = retrieve_schema("tidas_flows_product_category.json")
+    assert product_categories is not None
+    mate = next(
+        variant
+        for variant in product_categories.contents["oneOf"]
+        if variant["properties"]["@classId"]["const"] == "0163"
+    )
+    assert mate["properties"]["#text"]["const"] == "Maté leaves"
 
     # Remote references stay unresolved.
     assert retrieve_schema("https://example.com/schema.json") is None

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -328,6 +328,8 @@ def test_product_flow_category_schema_remains_controlled_contract_with_projectio
 
     assert len(schema["oneOf"]) == 4586
     assert product_category_entries_from_schema(schema) == index
+    assert index["0163"]["text"] == "Maté leaves"
+    assert index["8582"]["text"] == "Intermediation services\u00a0for telecommunication"
     assert index["46121"] == {
         "allowedInProductFlowPath": True,
         "level": "4",


### PR DESCRIPTION
Closes #112

Summary
- read packaged TIDAS schemas explicitly as UTF-8 on every platform
- write release JSON and test fixtures with deterministic LF bytes
- add Windows regression coverage for non-ASCII schema content and report bytes
- bump the recovery release version to 0.0.42 without moving v0.0.41
- record the required Docpact review evidence

Validation
- uv run pytest: 151 passed
- focused release and validation tests: 53 passed
- schema lock: 18 pairs passed
- Black check for touched Python files: passed
- release CLI help: passed
- Docpact strict validation and enforced lint: passed

Known baseline note
- a whole-repository Black check also reports three pre-existing, unrelated import-LCA files; this PR intentionally leaves them untouched.