### PR TITLE
feat: add deterministic closure validation contracts

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-22"
-lastReviewedCommit: "683f5be4786145a74dc2913a1a8512e354927575"
+lastReviewedCommit: "77cf60bc5223307c6d0a382e12cc11bd4cfb5462"
 # Review note, 2026-07-17: Issue #112 keeps UTF-8 schema reads, LF release-report writes, Windows-portable fixtures, and the 0.0.42 recovery release inside the existing validation, release-packaging, test, and release routes. No ownership, schema, dependency, dispatch, tag-pattern, or workspace-integration rule changes are required.
 
 catalog:

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-30"
-lastReviewedCommit: "9b5030e6862d5aff7776794823c88b7812441233"
+lastReviewedAt: "2026-07-22"
+lastReviewedCommit: "683f5be4786145a74dc2913a1a8512e354927575"
 # Review note, 2026-07-17: Issue #112 keeps UTF-8 schema reads, LF release-report writes, Windows-portable fixtures, and the 0.0.42 recovery release inside the existing validation, release-packaging, test, and release routes. No ownership, schema, dependency, dispatch, tag-pattern, or workspace-integration rule changes are required.
 
 catalog:
@@ -35,6 +35,8 @@ ownership:
           - src/tidas_tools/import_lca/**
           - src/tidas_tools/validate.py
           - src/tidas_tools/validation_report.py
+          - src/tidas_tools/validation_batch.py
+          - src/tidas_tools/reference_extraction.py
           - src/tidas_tools/validation_indexes/**
           - src/tidas_tools/export.py
           - src/tidas_tools/package_versions.py
@@ -82,6 +84,8 @@ coverage:
     - src/tidas_tools/import_lca/**
     - src/tidas_tools/validate.py
     - src/tidas_tools/validation_report.py
+    - src/tidas_tools/validation_batch.py
+    - src/tidas_tools/reference_extraction.py
     - src/tidas_tools/validation_indexes/**
     - src/tidas_tools/export.py
     - src/tidas_tools/package_versions.py
@@ -130,6 +134,8 @@ routing:
         - src/tidas_tools/import_lca/**
         - src/tidas_tools/validate.py
         - src/tidas_tools/validation_report.py
+        - src/tidas_tools/validation_batch.py
+        - src/tidas_tools/reference_extraction.py
         - src/tidas_tools/validation_indexes/**
         - src/tidas_tools/export.py
         - src/tidas_tools/package_versions.py
@@ -144,6 +150,8 @@ routing:
       paths:
         - src/tidas_tools/validate.py
         - src/tidas_tools/validation_report.py
+        - src/tidas_tools/validation_batch.py
+        - src/tidas_tools/reference_extraction.py
         - src/tidas_tools/validation_indexes/**
         - src/tidas_tools/tidas/schemas/**
         - src/tidas_tools/eilcd/schemas/**
@@ -261,6 +269,10 @@ rules:
       - path: src/tidas_tools/validate.py
         kind: tooling
       - path: src/tidas_tools/validation_report.py
+        kind: tooling
+      - path: src/tidas_tools/validation_batch.py
+        kind: tooling
+      - path: src/tidas_tools/reference_extraction.py
         kind: tooling
       - path: src/tidas_tools/validation_indexes/**
         kind: tooling

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-22"
-lastReviewedCommit: "77cf60bc5223307c6d0a382e12cc11bd4cfb5462"
+lastReviewedCommit: "81054f37a1ca8f428aa889decacc60a67175187b"
 # Review note, 2026-07-17: Issue #112 keeps UTF-8 schema reads, LF release-report writes, Windows-portable fixtures, and the 0.0.42 recovery release inside the existing validation, release-packaging, test, and release routes. No ownership, schema, dependency, dispatch, tag-pattern, or workspace-integration rule changes are required.
 
 catalog:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 683f5be4786145a74dc2913a1a8512e354927575
+lastReviewedCommit: 77cf60bc5223307c6d0a382e12cc11bd4cfb5462
 lastReviewedNote: "Issue #114 adds the versioned document-validation batch and reference-extraction contracts without moving database Scope resolution or Certificate ownership into tidas-tools."
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 77cf60bc5223307c6d0a382e12cc11bd4cfb5462
+lastReviewedCommit: 81054f37a1ca8f428aa889decacc60a67175187b
 lastReviewedNote: "Issue #114 adds the versioned document-validation batch and reference-extraction contracts without moving database Scope resolution or Certificate ownership into tidas-tools."
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,9 @@ checkPaths:
   - scripts/schema_lock.py
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-03
-lastReviewedCommit: e194e3a5eb0e1f926147a4c0e271b1afad9c6eb9
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 683f5be4786145a74dc2913a1a8512e354927575
+lastReviewedNote: "Issue #114 adds the versioned document-validation batch and reference-extraction contracts without moving database Scope resolution or Certificate ownership into tidas-tools."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -103,6 +104,8 @@ The authoritative path-level ownership map lives in `.docpact/config.yaml`.
 At a human-readable level, this repo owns:
 
 - standalone CLI behavior in `src/tidas_tools/convert.py`, `src/tidas_tools/import_lca/**`, `src/tidas_tools/validate.py`, and `src/tidas_tools/export.py`
+- deterministic `document-validation-batch.v1` streaming validation and reproducibility handshake in `src/tidas_tools/validation_batch.py`
+- the pure `ReferenceExtractionResultV1` / `ReferenceEdgeV1` contract and golden parity fixtures in `src/tidas_tools/reference_extraction.py` and `tests/fixtures/reference_extraction_v1/**`
 - deterministic release-profile closure, TIDAS/ILCD conversion, semantic round-trip, and byte-stable ZIP behavior in `src/tidas_tools/release.py`
 - validation report and version/export helpers in `src/tidas_tools/validation_report.py` and `src/tidas_tools/package_versions.py`
 - validator-private projection indexes under `src/tidas_tools/validation_indexes/**`
@@ -139,6 +142,7 @@ Route those tasks to:
 - do not treat the public docs site as the executable upstream for packaged schemas and methodologies
 - packaged assets under `src/tidas_tools/**` are executable tooling inputs, not just reference docs
 - validator-private projection indexes may optimize standalone validation, but they must not replace or weaken packaged TIDAS schema contracts
+- reference extraction preserves source constraints and extraction defects but does not resolve database targets, visibility, or exact-version winners
 - English and Chinese TIDAS schema assets must stay structurally aligned through `src/tidas_tools/tidas/schema.lock.json`
 - schema or methodology changes here can require downstream `tidas-sdk` follow-up through the dispatch contract
 - merged repo PRs here are repo-complete, not workspace-delivery complete

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ This tool validates whether TIDAS JSON data or eILCD/ILCD XML data complies with
 | `--verbose` | `-v` | Enable verbose logging |
 | `--data-format` | | Input data format to validate: `tidas`, `ilcd`, or `eilcd` (default: `tidas`) |
 | `--jobs` | | Number of parallel validation worker processes; use `0` for all CPU cores |
+| `--describe --format json` | | Report supported validation protocols and package/engine/Schema-lock fingerprints |
+| `--protocol document-validation-batch.v1` | | Validate exactly the JSONL manifest documents and stream issue/final events |
+| `--input-manifest` | | Batch JSONL manifest containing opaque document keys, safe relative paths, exact identities, and SHA-256 hashes |
 
 ### (3) Usage Example
 
@@ -153,7 +156,21 @@ tidas-validate --input-dir <eILCD_data_directory> --data-format ilcd
 
 # Validate large packages with all CPU cores
 tidas-validate --input-dir <TIDAS_data_directory> --data-format tidas --jobs 0
+
+# Inspect the reproducibility handshake used by closure-preflight workers
+tidas-validate --describe --format json
+
+# Stream deterministic validation evidence for exactly the manifest documents
+tidas-validate --protocol document-validation-batch.v1 \
+  --input-dir <batch_root> \
+  --input-manifest <document-validation-batch.v1.jsonl>
 ```
+
+The batch protocol treats document issues as a completed scan: it emits one
+`issue` event per finding, a final summary/hash event, and exits zero. Unsafe
+paths, duplicate keys/paths, symlinks, content-hash drift, malformed input, or
+missing execution proof are protocol failures. Reference target existence and
+database visibility are intentionally outside this document-validation layer.
 
 ## 6. TIDAS Export Tool Documentation
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -166,6 +166,9 @@ tidas-release-tool build-packages \
 | `--verbose` | `-v` | 开启详细日志模式 |
 | `--data-format` | | 待验证的数据格式：`tidas`、`ilcd` 或 `eilcd`（默认：`tidas`） |
 | `--jobs` | | 并行校验进程数；使用 `0` 表示使用全部 CPU 核心 |
+| `--describe --format json` | | 输出支持的校验协议以及 package/engine/Schema-lock 指纹 |
+| `--protocol document-validation-batch.v1` | | 只校验 JSONL manifest 明确列出的文档，并流式输出 issue/final 事件 |
+| `--input-manifest` | | Batch JSONL manifest，包含 opaque document key、安全相对路径、精确身份和 SHA-256 |
 
 ### （三）使用示例
 
@@ -178,7 +181,17 @@ tidas-validate --input-dir <eILCD数据目录> --data-format ilcd
 
 # 使用全部 CPU 核心校验大型数据包
 tidas-validate --input-dir <TIDAS数据目录> --data-format tidas --jobs 0
+
+# 查看闭包预检 Worker 使用的可复现握手信息
+tidas-validate --describe --format json
+
+# 对 manifest 中明确列出的文档流式生成确定性校验证据
+tidas-validate --protocol document-validation-batch.v1 \
+  --input-dir <batch根目录> \
+  --input-manifest <document-validation-batch.v1.jsonl>
 ```
+
+Batch 协议把数据问题视为一次正常完成的扫描：逐条输出 `issue`，最后输出摘要和逻辑 hash，并以 0 退出。路径越界、重复 key/path、符号链接、内容 hash 漂移、manifest 非法或执行完成证据缺失属于协议/系统故障。引用目标是否存在及数据库可见性不属于文档校验层。
 
 ## 六、TIDAS 数据导出工具使用说明
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,9 @@ checkPaths:
   - scripts/schema_lock.py
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-30
-lastReviewedCommit: 9b5030e6862d5aff7776794823c88b7812441233
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 683f5be4786145a74dc2913a1a8512e354927575
+lastReviewedNote: "Issue #114 adds stable validation-batch and reference-extraction contract modules; production Scope traversal and resolution remain Worker-owned."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -48,6 +49,8 @@ Review note, 2026-07-17: Issue #112 remains inside the existing validation and r
 | `src/tidas_tools/import_lca/**` | external LCA import CLI scaffolding, format detection, canonical import model, and staged source adapters |
 | `src/tidas_tools/validate.py` | standalone validation CLI |
 | `src/tidas_tools/validation_report.py` | structured validation-report rendering |
+| `src/tidas_tools/validation_batch.py` | certificate-grade manifest validation, describe handshake, streamed issue events, and deterministic logical issue hash |
+| `src/tidas_tools/reference_extraction.py` | pure version-preserving reference edge and extraction-issue contract |
 | `src/tidas_tools/validation_indexes/**` | validator-private projection indexes derived from packaged schema assets for fast runtime checks |
 | `src/tidas_tools/export.py` | standalone export CLI |
 | `src/tidas_tools/package_versions.py` | version normalization and export package metadata logic |
@@ -75,6 +78,10 @@ Review note, 2026-07-17: Issue #112 remains inside the existing validation and r
 ### Validation
 
 `validate.py` plus `validation_report.py` own standalone validation semantics and structured reporting. The validator covers TIDAS JSON with packaged JSON schemas, validator-private projection indexes, and eILCD/ILCD XML with packaged XSD schemas. TIDAS JSON validation uses a compiled `fastjsonschema` fast path for files that pass schema validation, while falling back to `jsonschema` for complete error collection when the fast path detects a schema failure.
+
+`validation_batch.py` adds `document-validation-batch.v1` for Worker orchestration. It validates exactly the regular files declared by a JSONL manifest, verifies their content hashes, streams canonical issue events, and ends with a small final event carrying the logical issue-stream hash and tool/engine/Schema-lock fingerprint. Data issues complete normally; malformed manifests, unsafe paths, drift, or missing final execution proof are protocol failures.
+
+`reference_extraction.py` exposes `ReferenceExtractionResultV1` and `ReferenceEdgeV1`. It preserves explicit or omitted requested versions, stable reference roles, JSON paths, and malformed-reference issues. It does not look up targets or decide visibility, version winners, link readiness, Scope closure, or Certificates; those remain Worker/Database responsibilities. The process-bundle writer consumes this facade as a compatibility adapter while retaining its importer-shaped UUID file layout.
 
 ### Export
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 77cf60bc5223307c6d0a382e12cc11bd4cfb5462
+lastReviewedCommit: 81054f37a1ca8f428aa889decacc60a67175187b
 lastReviewedNote: "Issue #114 adds stable validation-batch and reference-extraction contract modules; production Scope traversal and resolution remain Worker-owned."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 683f5be4786145a74dc2913a1a8512e354927575
+lastReviewedCommit: 77cf60bc5223307c6d0a382e12cc11bd4cfb5462
 lastReviewedNote: "Issue #114 adds stable validation-batch and reference-extraction contract modules; production Scope traversal and resolution remain Worker-owned."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 683f5be4786145a74dc2913a1a8512e354927575
+lastReviewedCommit: 77cf60bc5223307c6d0a382e12cc11bd4cfb5462
 lastReviewedNote: "Issue #114 adds focused proof for the batch protocol, reference extraction, golden parity fixtures, and importer compatibility."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,9 @@ checkPaths:
   - scripts/schema_lock.py
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-03
-lastReviewedCommit: e194e3a5eb0e1f926147a4c0e271b1afad9c6eb9
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 683f5be4786145a74dc2913a1a8512e354927575
+lastReviewedNote: "Issue #114 adds focused proof for the batch protocol, reference extraction, golden parity fixtures, and importer compatibility."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -58,6 +59,7 @@ The local `pre-push` hook runs docpact first and then `uv run pytest`. The GitHu
 | --- | --- | --- | --- |
 | `convert.py`, `import_lca/**`, or eILCD asset changes | `uv run pytest`; `uv run python src/tidas_tools/convert.py --help`; `uv run python src/tidas_tools/import_lca/cli.py --help` when external import paths change | run one representative conversion or import path if the task explicitly changes data transformation behavior | Keep packaged asset, conversion logic, import detection, and staged adapters aligned. |
 | `validate.py`, `validation_report.py`, TIDAS schema changes, or eILCD schema validation changes | `uv run python scripts/schema_lock.py check`; `uv run pytest`; `uv run python src/tidas_tools/validate.py --help` | run one representative TIDAS JSON or eILCD/ILCD XML validation path and record entity types touched | Validation categories, packaged JSON schemas, packaged XSD schemas, and the TIDAS schema parity lock all matter here. |
+| `validation_batch.py` or `reference_extraction.py` | `uv run pytest tests/test_validation_batch.py tests/test_reference_extraction.py tests/test_validate.py -q`; `uv run python -m tidas_tools.validate --describe --format json`; Black | run the batch CLI against a valid manifest and replay the golden fixture in the downstream Rust consumer | Data issues must end with a valid final event and exit 0; protocol/system defects must not emit completion evidence. Explicit versions and roles must survive extraction unchanged. |
 | validator-private projection index changes | `uv run pytest tests/test_validate.py -q`; `uv run python src/tidas_tools/validate.py --help` | compare the projection against its source schema and run a representative package validation path | Projection indexes may optimize validation only; they must stay derived from packaged schema contracts and must not replace them. |
 | `export.py` or `package_versions.py` changes | `uv run pytest`; `uv run python src/tidas_tools/export.py --help` | if the task includes live export proof, record the DB and storage assumptions separately | Export behavior depends on external DB and object-storage state. |
 | `release.py` changes | `uv run pytest`; `uv run python -m tidas_tools.release --help`; `uv run black --check --target-version py313 src tests` | run one four-package fixture and compare archive hashes across two builds; run ILCD XSD validation when canonical production-grade fixtures are available | Release packaging must fail closed on missing exact references and preserve deterministic member order, timestamps, modes, and bytes. |

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 77cf60bc5223307c6d0a382e12cc11bd4cfb5462
+lastReviewedCommit: 81054f37a1ca8f428aa889decacc60a67175187b
 lastReviewedNote: "Issue #114 adds focused proof for the batch protocol, reference extraction, golden parity fixtures, and importer compatibility."
 related:
   - ../../AGENTS.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidas-tools"
-version = "0.0.42"
+version = "0.0.43"
 description = "tidas-tools"
 authors = [
     { name = "Nan LI", email = "linanenv@gmail.com" },

--- a/src/tidas_tools/import_lca/adapters/openlca_jsonld.py
+++ b/src/tidas_tools/import_lca/adapters/openlca_jsonld.py
@@ -1197,7 +1197,9 @@ def _uncertainty_dispersion(value: Any) -> Any:
     return rounded
 
 
-def _report_rich_field_fidelity(store: MemoryCanonicalStore, report: ConversionReport) -> None:
+def _report_rich_field_fidelity(
+    store: MemoryCanonicalStore, report: ConversionReport
+) -> None:
     """Summarise how the rich USLCI fields landed in TIDAS fields vs the source trace.
 
     Lets the import gate verify lossless coverage and lists the evidenced residuals

--- a/src/tidas_tools/import_lca/process_bundles.py
+++ b/src/tidas_tools/import_lca/process_bundles.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from collections import deque
 import json
 from pathlib import Path, PurePosixPath
 from shutil import copy2
 from typing import Any
+
+from tidas_tools.reference_extraction import extract_references
 
 from .writers import TIDAS_CATEGORIES, ensure_tidas_package_dirs
 
@@ -99,10 +102,10 @@ def _collect_dependencies(
     }
     unresolved: list[dict[str, Any]] = []
     visited: set[tuple[str, str]] = set()
-    queue: list[tuple[str, str, str]] = [("processes", process_id, "$")]
+    queue = deque([("processes", process_id, "$")])
 
     while queue:
-        category, dataset_id, ref_path = queue.pop(0)
+        category, dataset_id, ref_path = queue.popleft()
         if category not in dependencies:
             continue
         if (category, dataset_id) in visited:
@@ -122,57 +125,53 @@ def _collect_dependencies(
 
         dependencies[category].add(dataset_id)
         payload = _read_json(dataset_path)
-        for reference in _iter_references(payload):
-            ref_category = reference.get("category")
-            ref_id = reference.get("ref_id")
-            if not isinstance(ref_category, str) or not isinstance(ref_id, str):
-                continue
+        extraction = extract_references(
+            document_key=f"{category}:{dataset_id}",
+            category=category,
+            payload=payload,
+        )
+        unresolved.extend(
+            {
+                "category": None,
+                "ref_id": None,
+                "path": issue.json_path,
+                "issue_code": issue.issue_code,
+                "reference_role": issue.reference_role,
+                "details": issue.details,
+            }
+            for issue in extraction.issues
+        )
+        for edge in extraction.edges:
+            ref_category = edge.target_category
+            ref_id = edge.target_uuid
             if ref_category not in dependencies:
                 continue
-            queue.append((ref_category, ref_id, str(reference["path"])))
+            queue.append((ref_category, ref_id, edge.json_path))
 
     return dependencies, unresolved
 
 
 def _iter_references(payload: Any, path: str = "$"):
-    if isinstance(payload, dict):
-        ref_id = payload.get("@refObjectId")
-        if isinstance(ref_id, str):
-            category = _category_for_reference(payload)
-            if category:
-                yield {
-                    "category": category,
-                    "ref_id": ref_id,
-                    "path": path,
-                }
-        for key, value in payload.items():
-            yield from _iter_references(value, f"{path}.{key}")
-    elif isinstance(payload, list):
-        for index, item in enumerate(payload):
-            yield from _iter_references(item, f"{path}[{index}]")
+    """Compatibility iterator backed by the versioned extraction contract."""
+
+    result = extract_references("process-bundle-adapter", "processes", payload)
+    for edge in result.edges:
+        edge_path = edge.json_path
+        if path != "$" and edge_path.startswith("$"):
+            edge_path = f"{path}{edge_path[1:]}"
+        yield {
+            "category": edge.target_category,
+            "ref_id": edge.target_uuid,
+            "version": edge.requested_version,
+            "version_state": edge.requested_version_state,
+            "reference_role": edge.reference_role,
+            "path": edge_path,
+        }
 
 
 def _category_for_reference(reference: dict[str, Any]) -> str | None:
-    ref_type = str(reference.get("@type") or "").lower()
-    if "flow property" in ref_type:
-        return "flowproperties"
-    if "flow" in ref_type:
-        return "flows"
-    if "unit group" in ref_type:
-        return "unitgroups"
-    if "contact" in ref_type:
-        return "contacts"
-    if "source" in ref_type:
-        return "sources"
-    if "process" in ref_type:
-        return "processes"
-
-    uri = str(reference.get("@uri") or "")
-    uri_parts = {part for part in uri.split("/") if part}
-    for category in PROCESS_BUNDLE_CATEGORIES:
-        if category in uri_parts:
-            return category
-    return None
+    result = extract_references("process-bundle-adapter", "processes", reference)
+    return result.edges[0].target_category if result.edges else None
 
 
 def _copy_dependencies(

--- a/src/tidas_tools/reference_extraction.py
+++ b/src/tidas_tools/reference_extraction.py
@@ -1,0 +1,389 @@
+"""Versioned, side-effect-free extraction of TIDAS document references.
+
+This module intentionally does not resolve references.  It preserves the
+constraint written in the source document so a caller can apply its own
+visibility, exact-version, and closure policy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import re
+from typing import Any
+from uuid import UUID
+
+REFERENCE_EXTRACTION_SCHEMA_VERSION = "tidas.reference-extraction-result.v1"
+REFERENCE_EDGE_SCHEMA_VERSION = "tidas.reference-edge.v1"
+REFERENCE_ISSUE_SCHEMA_VERSION = "tidas.reference-extraction-issue.v1"
+
+REFERENCE_ROLE_PROCESS_EXCHANGE_FLOW = "process_exchange_flow"
+REFERENCE_ROLE_LCIA_FACTOR_FLOW = "lcia_factor_flow"
+REFERENCE_ROLE_LIFECYCLE_MODEL_PROCESS = "lifecycle_model_process"
+REFERENCE_ROLE_SUPPORT_DOCUMENT = "support_document"
+
+REFERENCE_ROLES = (
+    REFERENCE_ROLE_LCIA_FACTOR_FLOW,
+    REFERENCE_ROLE_LIFECYCLE_MODEL_PROCESS,
+    REFERENCE_ROLE_PROCESS_EXCHANGE_FLOW,
+    REFERENCE_ROLE_SUPPORT_DOCUMENT,
+)
+
+_VERSION_RE = re.compile(r"^\d{2}\.\d{2}(?:\.\d{3})?$")
+
+_TYPE_TO_CATEGORY = {
+    "contact": "contacts",
+    "contact data set": "contacts",
+    "flow": "flows",
+    "flow data set": "flows",
+    "flow property": "flowproperties",
+    "flow property data set": "flowproperties",
+    "lcia method": "lciamethods",
+    "lcia method data set": "lciamethods",
+    "life cycle model": "lifecyclemodels",
+    "life cycle model data set": "lifecyclemodels",
+    "lifecycle model": "lifecyclemodels",
+    "lifecycle model data set": "lifecyclemodels",
+    "process": "processes",
+    "process data set": "processes",
+    "source": "sources",
+    "source data set": "sources",
+    "unit group": "unitgroups",
+    "unit group data set": "unitgroups",
+    "other external file": "external_files",
+}
+
+_URI_CATEGORY_ALIASES = {
+    "contacts": "contacts",
+    "contact": "contacts",
+    "flows": "flows",
+    "flow": "flows",
+    "flowproperties": "flowproperties",
+    "flowproperty": "flowproperties",
+    "flow-properties": "flowproperties",
+    "lciamethods": "lciamethods",
+    "lciamethod": "lciamethods",
+    "lcia-methods": "lciamethods",
+    "lifecyclemodels": "lifecyclemodels",
+    "lifecyclemodel": "lifecyclemodels",
+    "life-cycle-models": "lifecyclemodels",
+    "processes": "processes",
+    "process": "processes",
+    "sources": "sources",
+    "source": "sources",
+    "unitgroups": "unitgroups",
+    "unitgroup": "unitgroups",
+    "unit-groups": "unitgroups",
+}
+
+
+@dataclass(frozen=True)
+class ReferenceEdgeV1:
+    schema_version: str
+    document_key: str
+    source_category: str
+    target_category: str
+    target_uuid: str
+    requested_version_state: str
+    requested_version: str | None
+    requested_version_raw: Any
+    reference_role: str
+    json_path: str
+    raw_type: Any
+    uri: Any
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ReferenceExtractionIssueV1:
+    schema_version: str
+    issue_code: str
+    severity: str
+    document_key: str
+    source_category: str
+    json_path: str
+    reference_role: str
+    message: str
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ReferenceExtractionResultV1:
+    schema_version: str
+    document_key: str
+    source_category: str
+    edges: tuple[ReferenceEdgeV1, ...]
+    issues: tuple[ReferenceExtractionIssueV1, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "document_key": self.document_key,
+            "source_category": self.source_category,
+            "edges": [edge.to_dict() for edge in self.edges],
+            "issues": [issue.to_dict() for issue in self.issues],
+        }
+
+
+def extract_references(
+    document_key: str, category: str, payload: Any
+) -> ReferenceExtractionResultV1:
+    """Extract all recognizable references and all extraction defects.
+
+    The output order is document order and is deterministic for a given JSON
+    value.  Missing targets are deliberately not reported here because target
+    existence is a resolver concern, not a document-extraction concern.
+    """
+
+    if not document_key:
+        raise ValueError("document_key must be non-empty")
+    if not category:
+        raise ValueError("category must be non-empty")
+
+    edges: list[ReferenceEdgeV1] = []
+    issues: list[ReferenceExtractionIssueV1] = []
+    _walk_references(
+        payload,
+        document_key=document_key,
+        source_category=category,
+        path="$",
+        parent_key=None,
+        edges=edges,
+        issues=issues,
+    )
+    return ReferenceExtractionResultV1(
+        schema_version=REFERENCE_EXTRACTION_SCHEMA_VERSION,
+        document_key=document_key,
+        source_category=category,
+        edges=tuple(edges),
+        issues=tuple(issues),
+    )
+
+
+def _walk_references(
+    node: Any,
+    *,
+    document_key: str,
+    source_category: str,
+    path: str,
+    parent_key: str | None,
+    edges: list[ReferenceEdgeV1],
+    issues: list[ReferenceExtractionIssueV1],
+) -> None:
+    if isinstance(node, dict):
+        if _looks_like_reference(node, parent_key):
+            _extract_reference(
+                node,
+                document_key=document_key,
+                source_category=source_category,
+                path=path,
+                parent_key=parent_key,
+                edges=edges,
+                issues=issues,
+            )
+        for key, value in node.items():
+            _walk_references(
+                value,
+                document_key=document_key,
+                source_category=source_category,
+                path=f"{path}.{key}",
+                parent_key=key,
+                edges=edges,
+                issues=issues,
+            )
+    elif isinstance(node, list):
+        for index, item in enumerate(node):
+            _walk_references(
+                item,
+                document_key=document_key,
+                source_category=source_category,
+                path=f"{path}[{index}]",
+                parent_key=parent_key,
+                edges=edges,
+                issues=issues,
+            )
+
+
+def _looks_like_reference(node: dict[str, Any], parent_key: str | None) -> bool:
+    if "@refObjectId" in node or "@uri" in node:
+        return True
+    if parent_key and "referenceto" in parent_key.lower():
+        return True
+    return False
+
+
+def _extract_reference(
+    reference: dict[str, Any],
+    *,
+    document_key: str,
+    source_category: str,
+    path: str,
+    parent_key: str | None,
+    edges: list[ReferenceEdgeV1],
+    issues: list[ReferenceExtractionIssueV1],
+) -> None:
+    raw_type = reference.get("@type")
+    uri = reference.get("@uri")
+    target_category = _category_from_type(raw_type) or _category_from_uri(uri)
+    role = _reference_role(source_category, path, parent_key, target_category)
+
+    if target_category is None:
+        issues.append(
+            _issue(
+                "reference_type_unresolved",
+                document_key,
+                source_category,
+                path,
+                role,
+                "Reference target type cannot be resolved from @type or @uri.",
+                {"raw_type": raw_type, "uri": uri},
+            )
+        )
+
+    raw_id = reference.get("@refObjectId")
+    if not isinstance(raw_id, str) or not raw_id.strip():
+        issues.append(
+            _issue(
+                "reference_object_id_missing",
+                document_key,
+                source_category,
+                path,
+                role,
+                "Recognized reference is missing a non-empty @refObjectId.",
+                {"raw_ref_object_id": raw_id, "raw_type": raw_type, "uri": uri},
+            )
+        )
+        return
+
+    target_uuid = raw_id.strip()
+    if not _is_canonical_uuid(target_uuid):
+        issues.append(
+            _issue(
+                "reference_uuid_invalid",
+                document_key,
+                source_category,
+                path,
+                role,
+                "Reference @refObjectId is not a canonical lowercase UUID.",
+                {"raw_ref_object_id": raw_id},
+            )
+        )
+
+    raw_version = reference.get("@version")
+    if raw_version is None:
+        version_state = "omitted"
+        requested_version = None
+    elif isinstance(raw_version, str) and _VERSION_RE.fullmatch(raw_version):
+        version_state = "explicit"
+        requested_version = raw_version
+    else:
+        version_state = "invalid"
+        requested_version = raw_version if isinstance(raw_version, str) else None
+        issues.append(
+            _issue(
+                "reference_version_invalid",
+                document_key,
+                source_category,
+                path,
+                role,
+                "Reference @version must match NN.NN or NN.NN.NNN.",
+                {"requested_version_raw": raw_version},
+            )
+        )
+
+    if target_category is not None:
+        edges.append(
+            ReferenceEdgeV1(
+                schema_version=REFERENCE_EDGE_SCHEMA_VERSION,
+                document_key=document_key,
+                source_category=source_category,
+                target_category=target_category,
+                target_uuid=target_uuid,
+                requested_version_state=version_state,
+                requested_version=requested_version,
+                requested_version_raw=raw_version,
+                reference_role=role,
+                json_path=path,
+                raw_type=raw_type,
+                uri=uri,
+            )
+        )
+
+
+def _issue(
+    issue_code: str,
+    document_key: str,
+    source_category: str,
+    json_path: str,
+    reference_role: str,
+    message: str,
+    details: dict[str, Any],
+) -> ReferenceExtractionIssueV1:
+    return ReferenceExtractionIssueV1(
+        schema_version=REFERENCE_ISSUE_SCHEMA_VERSION,
+        issue_code=issue_code,
+        severity="error",
+        document_key=document_key,
+        source_category=source_category,
+        json_path=json_path,
+        reference_role=reference_role,
+        message=message,
+        details=details,
+    )
+
+
+def _category_from_type(raw_type: Any) -> str | None:
+    if not isinstance(raw_type, str):
+        return None
+    return _TYPE_TO_CATEGORY.get(" ".join(raw_type.strip().lower().split()))
+
+
+def _category_from_uri(uri: Any) -> str | None:
+    if not isinstance(uri, str):
+        return None
+    parts = [part.lower() for part in re.split(r"[/\\]", uri) if part]
+    for part in parts:
+        category = _URI_CATEGORY_ALIASES.get(part)
+        if category:
+            return category
+    return None
+
+
+def _reference_role(
+    source_category: str,
+    path: str,
+    parent_key: str | None,
+    target_category: str | None,
+) -> str:
+    normalized_path = path.lower()
+    normalized_key = (parent_key or "").lower()
+    if (
+        source_category == "processes"
+        and target_category == "flows"
+        and "exchange" in normalized_path
+        and normalized_key == "referencetoflowdataset"
+    ):
+        return REFERENCE_ROLE_PROCESS_EXCHANGE_FLOW
+    if (
+        source_category == "lciamethods"
+        and target_category == "flows"
+        and (
+            "characterisation" in normalized_path
+            or "characterization" in normalized_path
+        )
+    ):
+        return REFERENCE_ROLE_LCIA_FACTOR_FLOW
+    if source_category == "lifecyclemodels" and target_category == "processes":
+        return REFERENCE_ROLE_LIFECYCLE_MODEL_PROCESS
+    return REFERENCE_ROLE_SUPPORT_DOCUMENT
+
+
+def _is_canonical_uuid(value: str) -> bool:
+    try:
+        return str(UUID(value)) == value
+    except (ValueError, AttributeError):
+        return False

--- a/src/tidas_tools/reference_extraction.py
+++ b/src/tidas_tools/reference_extraction.py
@@ -49,7 +49,6 @@ _TYPE_TO_CATEGORY = {
     "source data set": "sources",
     "unit group": "unitgroups",
     "unit group data set": "unitgroups",
-    "other external file": "external_files",
 }
 
 _URI_CATEGORY_ALIASES = {

--- a/src/tidas_tools/validate.py
+++ b/src/tidas_tools/validate.py
@@ -1417,8 +1417,60 @@ def main():
             "Use 0 to use all CPU cores. Defaults to 1."
         ),
     )
+    parser.add_argument(
+        "--describe",
+        action="store_true",
+        help="Describe versioned validation protocols and runtime fingerprints.",
+    )
+    parser.add_argument(
+        "--protocol",
+        choices=["document-validation-batch.v1"],
+        help="Run a versioned streaming validation protocol.",
+    )
+    parser.add_argument(
+        "--input-manifest",
+        help=(
+            "JSONL manifest for document-validation-batch.v1. Relative paths "
+            "are resolved only beneath --input-dir."
+        ),
+    )
+    parser.add_argument(
+        "--profile",
+        default="tidas-document-conformance.v1",
+        help="Versioned document-validation profile.",
+    )
     try:
         args = parser.parse_args()
+
+        if args.describe:
+            if args.report_format != "json":
+                parser.error("--describe requires --format json")
+            from tidas_tools.validation_batch import describe_document_validation
+
+            print(
+                json.dumps(describe_document_validation(), indent=2, ensure_ascii=False)
+            )
+            return
+
+        if args.protocol:
+            if not args.input_dir or not args.input_manifest:
+                parser.error(
+                    f"--protocol {args.protocol} requires --input-dir and "
+                    "--input-manifest"
+                )
+            if args.data_format != "tidas":
+                parser.error("document-validation-batch.v1 supports TIDAS JSON only")
+            from tidas_tools.validation_batch import run_document_validation_batch
+
+            run_document_validation_batch(
+                input_dir=args.input_dir,
+                input_manifest=args.input_manifest,
+                profile=args.profile,
+                emit_event=lambda event: print(
+                    json.dumps(event, ensure_ascii=False), flush=True
+                ),
+            )
+            return
 
         if not args.input_dir:
             parser.error("the following arguments are required: --input-dir/-i")
@@ -1467,7 +1519,9 @@ def main():
     except Exception as e:
         error_msg = f"Error validating: {e}"
         logging.error(error_msg)
-        sys.exit(1)
+        from tidas_tools.validation_batch import BatchProtocolError
+
+        sys.exit(2 if isinstance(e, BatchProtocolError) else 1)
 
 
 if __name__ == "__main__":

--- a/src/tidas_tools/validation_batch.py
+++ b/src/tidas_tools/validation_batch.py
@@ -95,9 +95,17 @@ def run_document_validation_batch(
         if validator is None:
             validator = _build_tidas_validator(document.category)
             validators[document.category] = validator
+
+        # The manifest preflight establishes that every declared document was
+        # present and matched its expected bytes before the first issue can be
+        # emitted. Recheck immediately around the validator as well: otherwise
+        # a file that changes after preflight could produce evidence for bytes
+        # different from the hash carried by the final certificate.
+        _assert_document_hash(document)
         issues = _collect_tidas_file_issues(
             str(document.path), document.category, validator
         )
+        _assert_document_hash(document)
         for issue_ordinal, issue in enumerate(issues):
             issue_payload = issue.to_dict()
             issue_payload["file_path"] = document.relative_path
@@ -193,13 +201,6 @@ def load_batch_manifest(root: Path, input_manifest: str | Path) -> list[BatchDoc
                 )
 
             path = _safe_regular_file(root, normalized_relative, line_number)
-            actual_sha256 = sha256(path.read_bytes()).hexdigest()
-            if actual_sha256 != content_sha256:
-                raise BatchProtocolError(
-                    f"content hash mismatch for {normalized_relative}: "
-                    f"expected {content_sha256}, got {actual_sha256}"
-                )
-
             seen_keys.add(document_key)
             seen_paths.add(normalized_relative)
             identity = item.get("identity") or {}
@@ -207,22 +208,20 @@ def load_batch_manifest(root: Path, input_manifest: str | Path) -> list[BatchDoc
                 raise BatchProtocolError(
                     f"manifest line {line_number} identity must be an object"
                 )
-            documents.append(
-                BatchDocument(
-                    document_key=document_key,
-                    category=category,
-                    relative_path=normalized_relative,
-                    content_sha256=content_sha256,
-                    dataset_type=_optional_string(
-                        identity, "dataset_type", line_number
-                    ),
-                    dataset_id=_optional_string(identity, "dataset_id", line_number),
-                    dataset_version=_optional_string(
-                        identity, "dataset_version", line_number
-                    ),
-                    path=path,
-                )
+            document = BatchDocument(
+                document_key=document_key,
+                category=category,
+                relative_path=normalized_relative,
+                content_sha256=content_sha256,
+                dataset_type=_optional_string(identity, "dataset_type", line_number),
+                dataset_id=_optional_string(identity, "dataset_id", line_number),
+                dataset_version=_optional_string(
+                    identity, "dataset_version", line_number
+                ),
+                path=path,
             )
+            _assert_document_hash(document)
+            documents.append(document)
 
     return documents
 
@@ -298,6 +297,38 @@ def _safe_regular_file(root: Path, relative_path: str, line_number: int) -> Path
             f"manifest line {line_number} path escapes the batch root: {relative_path}"
         ) from error
     return resolved
+
+
+def _assert_document_hash(document: BatchDocument) -> None:
+    actual_sha256 = _sha256_regular_file(document.path, document.relative_path)
+    if actual_sha256 != document.content_sha256:
+        raise BatchProtocolError(
+            f"content hash mismatch for {document.relative_path}: "
+            f"expected {document.content_sha256}, got {actual_sha256}"
+        )
+
+
+def _sha256_regular_file(path: Path, relative_path: str) -> str:
+    """Hash an input incrementally without weakening the regular-file guard."""
+
+    if path.is_symlink():
+        raise BatchProtocolError(f"manifest document became a symlink: {relative_path}")
+    try:
+        metadata = path.stat()
+    except FileNotFoundError as error:
+        raise BatchProtocolError(
+            f"manifest document no longer exists: {relative_path}"
+        ) from error
+    if not stat.S_ISREG(metadata.st_mode):
+        raise BatchProtocolError(
+            f"manifest document is not a regular file: {relative_path}"
+        )
+
+    digest = sha256()
+    with path.open("rb") as document_file:
+        while chunk := document_file.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _supported_categories() -> frozenset[str]:

--- a/src/tidas_tools/validation_batch.py
+++ b/src/tidas_tools/validation_batch.py
@@ -1,0 +1,334 @@
+"""Deterministic streaming facade for certificate-grade document validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from importlib.metadata import PackageNotFoundError, version
+import importlib.resources as pkg_resources
+import json
+from pathlib import Path, PurePosixPath
+import stat
+from typing import Any, Callable
+
+import fastjsonschema
+
+import tidas_tools.tidas as tidas_assets
+
+DOCUMENT_VALIDATION_BATCH_PROTOCOL = "document-validation-batch.v1"
+DOCUMENT_VALIDATION_PROFILE = "tidas-document-conformance.v1"
+VALIDATION_REPORT_SCHEMA_VERSION = "tidas.validation-report.v1"
+VALIDATION_ISSUE_EVENT_SCHEMA_VERSION = "tidas.validation-issue-event.v1"
+VALIDATION_FINAL_EVENT_SCHEMA_VERSION = "tidas.validation-final-event.v1"
+
+
+class BatchProtocolError(ValueError):
+    """The caller violated the batch input or streaming protocol."""
+
+
+@dataclass(frozen=True)
+class BatchDocument:
+    document_key: str
+    category: str
+    relative_path: str
+    content_sha256: str
+    dataset_type: str | None
+    dataset_id: str | None
+    dataset_version: str | None
+    path: Path
+
+
+def describe_document_validation() -> dict[str, Any]:
+    """Return the reproducibility handshake consumed before a batch run."""
+
+    return {
+        "schema_version": "tidas.validation-describe.v1",
+        "package": {"name": "tidas-tools", "version": _package_version()},
+        "protocols": [DOCUMENT_VALIDATION_BATCH_PROTOCOL],
+        "profiles": [DOCUMENT_VALIDATION_PROFILE],
+        "report_schema_versions": [VALIDATION_REPORT_SCHEMA_VERSION],
+        "event_schema_versions": [
+            VALIDATION_ISSUE_EVENT_SCHEMA_VERSION,
+            VALIDATION_FINAL_EVENT_SCHEMA_VERSION,
+        ],
+        "engines": {
+            "python": _python_version(),
+            "fastjsonschema": _distribution_version("fastjsonschema"),
+            "jsonschema": _distribution_version("jsonschema"),
+        },
+        "tidas_schema_lock_sha256": _schema_lock_sha256(),
+    }
+
+
+def run_document_validation_batch(
+    *,
+    input_dir: str | Path,
+    input_manifest: str | Path,
+    profile: str = DOCUMENT_VALIDATION_PROFILE,
+    emit_event: Callable[[dict[str, Any]], None],
+) -> dict[str, Any]:
+    """Validate exactly the manifest documents and stream issue/final events.
+
+    Data issues are a successful protocol run.  Invalid manifests, unsafe
+    paths, content drift, and validator failures raise ``BatchProtocolError``
+    or the underlying system exception and therefore never emit a final event.
+    """
+
+    if profile != DOCUMENT_VALIDATION_PROFILE:
+        raise BatchProtocolError(f"unsupported document validation profile: {profile}")
+
+    from .validate import _build_tidas_validator, _collect_tidas_file_issues
+
+    root = Path(input_dir).resolve(strict=True)
+    if not root.is_dir():
+        raise BatchProtocolError("--input-dir must be a directory")
+    documents = load_batch_manifest(root, input_manifest)
+    validators = {}
+    logical_hasher = sha256()
+    issue_count = 0
+    error_count = 0
+    warning_count = 0
+    info_count = 0
+
+    for document_ordinal, document in enumerate(documents):
+        validator = validators.get(document.category)
+        if validator is None:
+            validator = _build_tidas_validator(document.category)
+            validators[document.category] = validator
+        issues = _collect_tidas_file_issues(
+            str(document.path), document.category, validator
+        )
+        for issue_ordinal, issue in enumerate(issues):
+            issue_payload = issue.to_dict()
+            issue_payload["file_path"] = document.relative_path
+            event = {
+                "type": "issue",
+                "schema_version": VALIDATION_ISSUE_EVENT_SCHEMA_VERSION,
+                "protocol": DOCUMENT_VALIDATION_BATCH_PROTOCOL,
+                "profile": profile,
+                "document_key": document.document_key,
+                "document_ordinal": document_ordinal,
+                "issue_ordinal": issue_ordinal,
+                "identity": {
+                    "dataset_type": document.dataset_type,
+                    "dataset_id": document.dataset_id,
+                    "dataset_version": document.dataset_version,
+                    "content_sha256": document.content_sha256,
+                },
+                "issue": issue_payload,
+            }
+            encoded = canonical_json_line(event)
+            logical_hasher.update(encoded)
+            emit_event(event)
+            issue_count += 1
+            if issue.severity == "error":
+                error_count += 1
+            elif issue.severity == "warning":
+                warning_count += 1
+            else:
+                info_count += 1
+
+    describe = describe_document_validation()
+    final_event = {
+        "type": "final",
+        "schema_version": VALIDATION_FINAL_EVENT_SCHEMA_VERSION,
+        "protocol": DOCUMENT_VALIDATION_BATCH_PROTOCOL,
+        "profile": profile,
+        "completed": True,
+        "summary": {
+            "document_count": len(documents),
+            "issue_count": issue_count,
+            "error_count": error_count,
+            "warning_count": warning_count,
+            "info_count": info_count,
+        },
+        "logical_issue_stream_sha256": logical_hasher.hexdigest(),
+        "fingerprints": describe,
+    }
+    emit_event(final_event)
+    return final_event
+
+
+def load_batch_manifest(root: Path, input_manifest: str | Path) -> list[BatchDocument]:
+    manifest_path = Path(input_manifest)
+    seen_keys: set[str] = set()
+    seen_paths: set[str] = set()
+    documents: list[BatchDocument] = []
+
+    with manifest_path.open("r", encoding="utf-8") as manifest_file:
+        for line_number, raw_line in enumerate(manifest_file, start=1):
+            if not raw_line.strip():
+                continue
+            try:
+                item = json.loads(raw_line)
+            except json.JSONDecodeError as error:
+                raise BatchProtocolError(
+                    f"manifest line {line_number} is not valid JSON: {error}"
+                ) from error
+            if not isinstance(item, dict):
+                raise BatchProtocolError(
+                    f"manifest line {line_number} must be a JSON object"
+                )
+
+            document_key = _required_string(item, "document_key", line_number)
+            category = _required_string(item, "category", line_number).lower()
+            relative_path = _required_string(item, "relative_path", line_number)
+            content_sha256 = _required_string(
+                item, "content_sha256", line_number
+            ).lower()
+            if category not in _supported_categories():
+                raise BatchProtocolError(
+                    f"manifest line {line_number} has unsupported category: {category}"
+                )
+            if not _is_sha256(content_sha256):
+                raise BatchProtocolError(
+                    f"manifest line {line_number} content_sha256 is invalid"
+                )
+            if document_key in seen_keys:
+                raise BatchProtocolError(f"duplicate document_key: {document_key}")
+            normalized_relative = _normalize_relative_path(relative_path, line_number)
+            if normalized_relative in seen_paths:
+                raise BatchProtocolError(
+                    f"duplicate relative_path: {normalized_relative}"
+                )
+
+            path = _safe_regular_file(root, normalized_relative, line_number)
+            actual_sha256 = sha256(path.read_bytes()).hexdigest()
+            if actual_sha256 != content_sha256:
+                raise BatchProtocolError(
+                    f"content hash mismatch for {normalized_relative}: "
+                    f"expected {content_sha256}, got {actual_sha256}"
+                )
+
+            seen_keys.add(document_key)
+            seen_paths.add(normalized_relative)
+            identity = item.get("identity") or {}
+            if not isinstance(identity, dict):
+                raise BatchProtocolError(
+                    f"manifest line {line_number} identity must be an object"
+                )
+            documents.append(
+                BatchDocument(
+                    document_key=document_key,
+                    category=category,
+                    relative_path=normalized_relative,
+                    content_sha256=content_sha256,
+                    dataset_type=_optional_string(
+                        identity, "dataset_type", line_number
+                    ),
+                    dataset_id=_optional_string(identity, "dataset_id", line_number),
+                    dataset_version=_optional_string(
+                        identity, "dataset_version", line_number
+                    ),
+                    path=path,
+                )
+            )
+
+    return documents
+
+
+def canonical_json_line(payload: dict[str, Any]) -> bytes:
+    return (
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _required_string(item: dict[str, Any], key: str, line_number: int) -> str:
+    value = item.get(key)
+    if not isinstance(value, str) or not value:
+        raise BatchProtocolError(
+            f"manifest line {line_number} requires non-empty string {key}"
+        )
+    return value
+
+
+def _optional_string(item: dict[str, Any], key: str, line_number: int) -> str | None:
+    value = item.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise BatchProtocolError(
+            f"manifest line {line_number} {key} must be a non-empty string or null"
+        )
+    return value
+
+
+def _normalize_relative_path(relative_path: str, line_number: int) -> str:
+    posix_path = PurePosixPath(relative_path)
+    if posix_path.is_absolute() or not posix_path.parts:
+        raise BatchProtocolError(
+            f"manifest line {line_number} relative_path must be relative"
+        )
+    if any(part in {"", ".", ".."} for part in posix_path.parts):
+        raise BatchProtocolError(
+            f"manifest line {line_number} relative_path escapes the batch root"
+        )
+    return str(posix_path)
+
+
+def _safe_regular_file(root: Path, relative_path: str, line_number: int) -> Path:
+    current = root
+    for part in PurePosixPath(relative_path).parts:
+        current = current / part
+        if current.is_symlink():
+            raise BatchProtocolError(
+                f"manifest line {line_number} references a symlink: {relative_path}"
+            )
+    try:
+        metadata = current.stat()
+    except FileNotFoundError as error:
+        raise BatchProtocolError(
+            f"manifest line {line_number} file does not exist: {relative_path}"
+        ) from error
+    if not stat.S_ISREG(metadata.st_mode):
+        raise BatchProtocolError(
+            f"manifest line {line_number} path is not a regular file: {relative_path}"
+        )
+    resolved = current.resolve(strict=True)
+    try:
+        resolved.relative_to(root)
+    except ValueError as error:
+        raise BatchProtocolError(
+            f"manifest line {line_number} path escapes the batch root: {relative_path}"
+        ) from error
+    return resolved
+
+
+def _supported_categories() -> frozenset[str]:
+    from .validate import SUPPORTED_CATEGORIES
+
+    return frozenset(SUPPORTED_CATEGORIES)
+
+
+def _schema_lock_sha256() -> str:
+    schema_lock = pkg_resources.files(tidas_assets) / "schema.lock.json"
+    return sha256(schema_lock.read_bytes()).hexdigest()
+
+
+def _package_version() -> str:
+    return _distribution_version("tidas-tools")
+
+
+def _distribution_version(distribution: str) -> str:
+    try:
+        return version(distribution)
+    except PackageNotFoundError:
+        return "0+unknown"
+
+
+def _python_version() -> str:
+    import platform
+
+    return platform.python_version()
+
+
+def _is_sha256(value: str) -> bool:
+    return len(value) == 64 and all(
+        character in "0123456789abcdef" for character in value
+    )

--- a/tests/fixtures/reference_extraction_v1/golden.json
+++ b/tests/fixtures/reference_extraction_v1/golden.json
@@ -171,6 +171,41 @@
       }
     },
     {
+      "name": "schema_valid_external_file_is_not_misrepresented_as_a_dataset_edge",
+      "document_key": "process:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:01.00.000",
+      "category": "processes",
+      "payload": {
+        "referenceToExternalFile": {
+          "@type": "other external file",
+          "@refObjectId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+          "@version": "01.00.000",
+          "@uri": "../external-files/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.pdf"
+        }
+      },
+      "expected": {
+        "schema_version": "tidas.reference-extraction-result.v1",
+        "document_key": "process:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:01.00.000",
+        "source_category": "processes",
+        "edges": [],
+        "issues": [
+          {
+            "schema_version": "tidas.reference-extraction-issue.v1",
+            "issue_code": "reference_type_unresolved",
+            "severity": "error",
+            "document_key": "process:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:01.00.000",
+            "source_category": "processes",
+            "json_path": "$.referenceToExternalFile",
+            "reference_role": "support_document",
+            "message": "Reference target type cannot be resolved from @type or @uri.",
+            "details": {
+              "raw_type": "other external file",
+              "uri": "../external-files/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.pdf"
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "cycle_and_shared_dependency_edges_remain_occurrences",
       "document_key": "process:77777777-7777-7777-7777-777777777777:01.00.000",
       "category": "processes",

--- a/tests/fixtures/reference_extraction_v1/golden.json
+++ b/tests/fixtures/reference_extraction_v1/golden.json
@@ -1,0 +1,206 @@
+{
+  "schema_version": "tidas.reference-extraction-golden.v1",
+  "cases": [
+    {
+      "name": "process_exchange_preserves_exact_version_and_role",
+      "document_key": "process:11111111-1111-1111-1111-111111111111:01.00.000",
+      "category": "processes",
+      "payload": {
+        "processDataSet": {
+          "exchanges": {
+            "exchange": [
+              {
+                "referenceToFlowDataSet": {
+                  "@type": "flow data set",
+                  "@refObjectId": "22222222-2222-2222-2222-222222222222",
+                  "@version": "01.02.003",
+                  "@uri": "../flows/22222222-2222-2222-2222-222222222222.json"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "schema_version": "tidas.reference-extraction-result.v1",
+        "document_key": "process:11111111-1111-1111-1111-111111111111:01.00.000",
+        "source_category": "processes",
+        "edges": [
+          {
+            "schema_version": "tidas.reference-edge.v1",
+            "document_key": "process:11111111-1111-1111-1111-111111111111:01.00.000",
+            "source_category": "processes",
+            "target_category": "flows",
+            "target_uuid": "22222222-2222-2222-2222-222222222222",
+            "requested_version_state": "explicit",
+            "requested_version": "01.02.003",
+            "requested_version_raw": "01.02.003",
+            "reference_role": "process_exchange_flow",
+            "json_path": "$.processDataSet.exchanges.exchange[0].referenceToFlowDataSet",
+            "raw_type": "flow data set",
+            "uri": "../flows/22222222-2222-2222-2222-222222222222.json"
+          }
+        ],
+        "issues": []
+      }
+    },
+    {
+      "name": "lcia_factor_flow_uses_distinct_role_and_short_version",
+      "document_key": "method:33333333-3333-3333-3333-333333333333:01.00.000",
+      "category": "lciamethods",
+      "payload": {
+        "LCIAMethodDataSet": {
+          "characterisationFactors": {
+            "characterisationFactor": [
+              {
+                "referenceToFlowDataSet": {
+                  "@type": "flow data set",
+                  "@refObjectId": "22222222-2222-2222-2222-222222222222",
+                  "@version": "01.02",
+                  "@uri": "../flows/22222222-2222-2222-2222-222222222222.json"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "schema_version": "tidas.reference-extraction-result.v1",
+        "document_key": "method:33333333-3333-3333-3333-333333333333:01.00.000",
+        "source_category": "lciamethods",
+        "edges": [
+          {
+            "schema_version": "tidas.reference-edge.v1",
+            "document_key": "method:33333333-3333-3333-3333-333333333333:01.00.000",
+            "source_category": "lciamethods",
+            "target_category": "flows",
+            "target_uuid": "22222222-2222-2222-2222-222222222222",
+            "requested_version_state": "explicit",
+            "requested_version": "01.02",
+            "requested_version_raw": "01.02",
+            "reference_role": "lcia_factor_flow",
+            "json_path": "$.LCIAMethodDataSet.characterisationFactors.characterisationFactor[0].referenceToFlowDataSet",
+            "raw_type": "flow data set",
+            "uri": "../flows/22222222-2222-2222-2222-222222222222.json"
+          }
+        ],
+        "issues": []
+      }
+    },
+    {
+      "name": "missing_object_id_is_not_silently_dropped",
+      "document_key": "process:44444444-4444-4444-4444-444444444444:01.00.000",
+      "category": "processes",
+      "payload": {
+        "referenceToContact": {
+          "@type": "contact data set",
+          "@version": "01.00.000",
+          "@uri": "../contacts/missing.json"
+        }
+      },
+      "expected": {
+        "schema_version": "tidas.reference-extraction-result.v1",
+        "document_key": "process:44444444-4444-4444-4444-444444444444:01.00.000",
+        "source_category": "processes",
+        "edges": [],
+        "issues": [
+          {
+            "schema_version": "tidas.reference-extraction-issue.v1",
+            "issue_code": "reference_object_id_missing",
+            "severity": "error",
+            "document_key": "process:44444444-4444-4444-4444-444444444444:01.00.000",
+            "source_category": "processes",
+            "json_path": "$.referenceToContact",
+            "reference_role": "support_document",
+            "message": "Recognized reference is missing a non-empty @refObjectId.",
+            "details": {
+              "raw_ref_object_id": null,
+              "raw_type": "contact data set",
+              "uri": "../contacts/missing.json"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "unknown_type_and_invalid_version_are_structured",
+      "document_key": "source:55555555-5555-5555-5555-555555555555:01.00.000",
+      "category": "sources",
+      "payload": {
+        "unknownReference": {
+          "@type": "mystery data set",
+          "@refObjectId": "66666666-6666-6666-6666-666666666666",
+          "@version": "1.0",
+          "@uri": "opaque:target"
+        }
+      },
+      "expected": {
+        "schema_version": "tidas.reference-extraction-result.v1",
+        "document_key": "source:55555555-5555-5555-5555-555555555555:01.00.000",
+        "source_category": "sources",
+        "edges": [],
+        "issues": [
+          {
+            "schema_version": "tidas.reference-extraction-issue.v1",
+            "issue_code": "reference_type_unresolved",
+            "severity": "error",
+            "document_key": "source:55555555-5555-5555-5555-555555555555:01.00.000",
+            "source_category": "sources",
+            "json_path": "$.unknownReference",
+            "reference_role": "support_document",
+            "message": "Reference target type cannot be resolved from @type or @uri.",
+            "details": {
+              "raw_type": "mystery data set",
+              "uri": "opaque:target"
+            }
+          },
+          {
+            "schema_version": "tidas.reference-extraction-issue.v1",
+            "issue_code": "reference_version_invalid",
+            "severity": "error",
+            "document_key": "source:55555555-5555-5555-5555-555555555555:01.00.000",
+            "source_category": "sources",
+            "json_path": "$.unknownReference",
+            "reference_role": "support_document",
+            "message": "Reference @version must match NN.NN or NN.NN.NNN.",
+            "details": {
+              "requested_version_raw": "1.0"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "cycle_and_shared_dependency_edges_remain_occurrences",
+      "document_key": "process:77777777-7777-7777-7777-777777777777:01.00.000",
+      "category": "processes",
+      "payload": {
+        "references": [
+          {
+            "@type": "process data set",
+            "@refObjectId": "88888888-8888-8888-8888-888888888888",
+            "@version": "01.00.000",
+            "@uri": "../processes/88888888-8888-8888-8888-888888888888.json"
+          },
+          {
+            "@type": "source data set",
+            "@refObjectId": "99999999-9999-9999-9999-999999999999",
+            "@version": "01.00.000",
+            "@uri": "../sources/99999999-9999-9999-9999-999999999999.json"
+          },
+          {
+            "@type": "source data set",
+            "@refObjectId": "99999999-9999-9999-9999-999999999999",
+            "@version": "01.00.000",
+            "@uri": "../sources/99999999-9999-9999-9999-999999999999.json"
+          }
+        ]
+      },
+      "expected_edge_targets": [
+        "88888888-8888-8888-8888-888888888888",
+        "99999999-9999-9999-9999-999999999999",
+        "99999999-9999-9999-9999-999999999999"
+      ]
+    }
+  ]
+}

--- a/tests/test_import_lca_openlca_jsonld.py
+++ b/tests/test_import_lca_openlca_jsonld.py
@@ -1213,9 +1213,7 @@ def test_unit_group_reference_unit_honors_explicit_flag():
     qr = ds["unitGroupDataSet"]["unitGroupInformation"]["quantitativeReference"]
     units = ds["unitGroupDataSet"]["units"]["unit"]
     ref_unit = next(
-        u
-        for u in units
-        if u["@dataSetInternalID"] == qr["referenceToReferenceUnit"]
+        u for u in units if u["@dataSetInternalID"] == qr["referenceToReferenceUnit"]
     )
     assert ref_unit["name"] == "a"
 
@@ -1225,7 +1223,10 @@ def test_percentage_strips_trailing_zeros_to_fit_eilcd_perc():
     # which the eILCD Perc pattern (totalDigits=5) rejects -> 6,943 schema errors
     # in a full USLCI conversion. _percentage must strip trailing fractional zeros.
     import json, re
-    from tidas_tools.import_lca.writers.tidas_json import _percentage, _allocation_fraction
+    from tidas_tools.import_lca.writers.tidas_json import (
+        _percentage,
+        _allocation_fraction,
+    )
 
     perc_pattern = json.loads(
         (

--- a/tests/test_import_lca_writer_placeholders.py
+++ b/tests/test_import_lca_writer_placeholders.py
@@ -150,7 +150,10 @@ def test_land_use_categorization_by_name():
         {"@level": "0", "@catId": "3", "#text": "Land use"},
         {"@level": "1", "@catId": "3.1", "#text": "Land occupation"},
     ]
-    for name in ("Transformation, from pasture and meadow", "Transformation, to forest"):
+    for name in (
+        "Transformation, from pasture and meadow",
+        "Transformation, to forest",
+    ):
         assert W._land_use_categorization(name) == [
             {"@level": "0", "@catId": "3", "#text": "Land use"},
             {"@level": "1", "@catId": "3.2", "#text": "Land transformation"},
@@ -162,8 +165,11 @@ def test_land_use_categorization_by_name():
 
 def test_land_use_product_flow_promoted_to_elementary_land_category():
     # USLCI ships land-transformation flows as PRODUCT_FLOW / "Ecosystem Services".
-    raw = {"name": "Transformation, from pasture and meadow", "flowType": "PRODUCT_FLOW",
-           "category": "Ecosystem Services"}
+    raw = {
+        "name": "Transformation, from pasture and meadow",
+        "flowType": "PRODUCT_FLOW",
+        "category": "Ecosystem Services",
+    }
     flow_type = W._flow_type(raw["flowType"])
     if flow_type == "Product flow" and W._is_land_use_flow(raw):
         flow_type = "Elementary flow"
@@ -179,12 +185,16 @@ def test_land_use_product_flow_promoted_to_elementary_land_category():
     # No conversion gap, but original PRODUCT_FLOW preserved as provenance.
     other = block["common:elementaryFlowCategorization"]["common:other"]
     assert "tidasimport:conversionGap" not in other
-    assert other["tidasimport:sourceTrace"]["payload"]["sourceFlowType"] == "PRODUCT_FLOW"
+    assert (
+        other["tidasimport:sourceTrace"]["payload"]["sourceFlowType"] == "PRODUCT_FLOW"
+    )
 
 
 def test_ecospold_style_raw_without_name_not_reclassified():
     # ecoSpold/BAFU flow raw carries no "name" key -> never promoted/reclassified.
-    assert W._is_land_use_flow({"flowType": "PRODUCT_FLOW", "category": "land"}) is False
+    assert (
+        W._is_land_use_flow({"flowType": "PRODUCT_FLOW", "category": "land"}) is False
+    )
     assert W._elementary_categorization({"category": "resource/ground"}) is not None
     assert W._land_use_categorization(None) is None
 
@@ -278,15 +288,23 @@ def test_imported_source_url_goes_to_description_not_digital_file():
             "url": "https://cfpub.epa.gov/webfire/",
         },
     )
-    di = _imported_source_dataset(e)["sourceDataSet"]["sourceInformation"]["dataSetInformation"]
+    di = _imported_source_dataset(e)["sourceDataSet"]["sourceInformation"][
+        "dataSetInformation"
+    ]
     assert "referenceToDigitalFile" not in di
     desc = di["sourceDescriptionOrComment"]["#text"]
     assert "https://cfpub.epa.gov/webfire/" in desc
     assert "U.S. Environmental Protection Agency, WebFIRE, 2012" in desc
 
     # url-only source: still no digital file, URL preserved as text
-    e2 = CanonicalEntity(entity_type="sources", internal_id="x", name="S",
-                         raw={"url": "https://example.com/doc.pdf"})
-    di2 = _imported_source_dataset(e2)["sourceDataSet"]["sourceInformation"]["dataSetInformation"]
+    e2 = CanonicalEntity(
+        entity_type="sources",
+        internal_id="x",
+        name="S",
+        raw={"url": "https://example.com/doc.pdf"},
+    )
+    di2 = _imported_source_dataset(e2)["sourceDataSet"]["sourceInformation"][
+        "dataSetInformation"
+    ]
     assert "referenceToDigitalFile" not in di2
     assert "https://example.com/doc.pdf" in di2["sourceDescriptionOrComment"]["#text"]

--- a/tests/test_reference_extraction.py
+++ b/tests/test_reference_extraction.py
@@ -1,0 +1,102 @@
+import json
+from pathlib import Path
+
+from tidas_tools.import_lca.process_bundles import _collect_dependencies
+from tidas_tools.reference_extraction import REFERENCE_ROLES, extract_references
+
+FIXTURE = Path(__file__).parent / "fixtures" / "reference_extraction_v1" / "golden.json"
+
+
+def test_reference_extraction_v1_golden_cases():
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+    for case in fixture["cases"]:
+        result = extract_references(
+            case["document_key"], case["category"], case["payload"]
+        ).to_dict()
+        if "expected" in case:
+            assert result == case["expected"], case["name"]
+        else:
+            assert [edge["target_uuid"] for edge in result["edges"]] == case[
+                "expected_edge_targets"
+            ]
+            assert result["issues"] == []
+
+
+def test_reference_role_vocabulary_is_versioned_and_closed():
+    assert REFERENCE_ROLES == (
+        "lcia_factor_flow",
+        "lifecycle_model_process",
+        "process_exchange_flow",
+        "support_document",
+    )
+
+
+def test_process_bundle_adapter_is_cycle_safe_and_reports_all_missing_targets(
+    tmp_path,
+):
+    process_a = "11111111-1111-1111-1111-111111111111"
+    process_b = "22222222-2222-2222-2222-222222222222"
+    missing_source = "33333333-3333-3333-3333-333333333333"
+
+    processes = tmp_path / "processes"
+    processes.mkdir()
+    (processes / f"{process_a}.json").write_text(
+        json.dumps(
+            {
+                "references": [
+                    _reference("process data set", process_b, "processes"),
+                    _reference("source data set", missing_source, "sources"),
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (processes / f"{process_b}.json").write_text(
+        json.dumps(
+            {
+                "references": [
+                    _reference("process data set", process_a, "processes"),
+                    _reference("source data set", missing_source, "sources"),
+                    {
+                        "@type": "contact data set",
+                        "@version": "01.00.000",
+                        "@uri": "../contacts/missing.json",
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    package_index = {
+        category: {}
+        for category in (
+            "contacts",
+            "sources",
+            "unitgroups",
+            "flowproperties",
+            "flows",
+            "processes",
+        )
+    }
+    package_index["processes"] = {
+        process_a: processes / f"{process_a}.json",
+        process_b: processes / f"{process_b}.json",
+    }
+
+    dependencies, unresolved = _collect_dependencies(process_a, package_index)
+
+    assert dependencies["processes"] == {process_a, process_b}
+    assert [item["ref_id"] for item in unresolved if item["ref_id"]] == [missing_source]
+    assert [item["issue_code"] for item in unresolved if item.get("issue_code")] == [
+        "reference_object_id_missing"
+    ]
+
+
+def _reference(ref_type: str, ref_id: str, category: str) -> dict:
+    return {
+        "@type": ref_type,
+        "@refObjectId": ref_id,
+        "@version": "01.00.000",
+        "@uri": f"../{category}/{ref_id}.json",
+    }

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -11,6 +11,7 @@ from referencing import Registry
 
 import tidas_tools.eilcd.stylesheets as eilcd_stylesheets
 import tidas_tools.tidas.schemas as schemas
+from tidas_tools.reference_extraction import extract_references
 from tidas_tools.validate import (
     FORMAT_CHECKER,
     SUPPORTED_CATEGORIES,
@@ -836,6 +837,28 @@ def test_common_other_schema_rejects_common_namespace_children():
     errors = list(validator.iter_errors({"common:note": "not allowed here"}))
 
     assert errors
+
+
+def test_schema_valid_missing_target_reference_stays_a_closure_concern():
+    missing_target = "22222222-2222-2222-2222-222222222222"
+    reference = {
+        "@type": "flow data set",
+        "@refObjectId": missing_target,
+        "@version": "01.00.000",
+        "@uri": f"../flows/{missing_target}.json",
+        "common:shortDescription": {"@xml:lang": "en", "#text": "Missing"},
+    }
+
+    document_validator = build_data_type_validator("GlobalReferenceType")
+    extraction = extract_references(
+        "process:test:01.00.000",
+        "processes",
+        {"referenceToFlowDataSet": reference},
+    )
+
+    assert list(document_validator.iter_errors(reference)) == []
+    assert extraction.issues == ()
+    assert extraction.edges[0].target_uuid == missing_target
 
 
 def test_common_other_schema_references_common_other_definition():

--- a/tests/test_validation_batch.py
+++ b/tests/test_validation_batch.py
@@ -200,6 +200,26 @@ def test_batch_rejects_duplicate_keys_and_paths(tmp_path):
         )
 
 
+def test_batch_rejects_duplicate_path_with_distinct_document_keys(tmp_path):
+    batch_root = tmp_path / "batch"
+    source_path = batch_root / "sources" / "bad.json"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("{}", encoding="utf-8")
+    first = _manifest_item(source_path, batch_root)
+    second = {**first, "document_key": "source:other:01.00.000"}
+    manifest = tmp_path / "manifest.jsonl"
+    manifest.write_text(
+        json.dumps(first) + "\n" + json.dumps(second) + "\n", encoding="utf-8"
+    )
+
+    with pytest.raises(BatchProtocolError, match="duplicate relative_path"):
+        run_document_validation_batch(
+            input_dir=batch_root,
+            input_manifest=manifest,
+            emit_event=lambda _event: None,
+        )
+
+
 def test_batch_rejects_symlink_input(tmp_path):
     batch_root = tmp_path / "batch"
     outside = tmp_path / "outside.json"
@@ -216,6 +236,34 @@ def test_batch_rejects_symlink_input(tmp_path):
             input_manifest=manifest,
             emit_event=lambda _event: None,
         )
+
+
+def test_batch_refuses_content_drift_during_validation(tmp_path, monkeypatch):
+    batch_root = tmp_path / "batch"
+    source_path = batch_root / "sources" / "bad.json"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("{}", encoding="utf-8")
+    manifest = tmp_path / "manifest.jsonl"
+    _write_manifest(manifest, source_path, batch_root)
+    original = validate_module._collect_tidas_file_issues
+
+    def mutate_after_validation(*args, **kwargs):
+        result = original(*args, **kwargs)
+        source_path.write_text('{"changed":true}', encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(
+        validate_module, "_collect_tidas_file_issues", mutate_after_validation
+    )
+    events = []
+    with pytest.raises(BatchProtocolError, match="content hash mismatch"):
+        run_document_validation_batch(
+            input_dir=batch_root,
+            input_manifest=manifest,
+            emit_event=events.append,
+        )
+
+    assert events == []
 
 
 def _write_manifest(

--- a/tests/test_validation_batch.py
+++ b/tests/test_validation_batch.py
@@ -1,0 +1,246 @@
+from hashlib import sha256
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+from tidas_tools.validation_batch import (
+    BatchProtocolError,
+    canonical_json_line,
+    describe_document_validation,
+    run_document_validation_batch,
+)
+from tidas_tools import validate as validate_module
+
+
+def test_describe_handshake_exposes_reproducibility_fingerprint():
+    description = describe_document_validation()
+
+    assert description["schema_version"] == "tidas.validation-describe.v1"
+    assert description["protocols"] == ["document-validation-batch.v1"]
+    assert description["profiles"] == ["tidas-document-conformance.v1"]
+    assert description["report_schema_versions"] == ["tidas.validation-report.v1"]
+    assert len(description["tidas_schema_lock_sha256"]) == 64
+    assert description["package"]["version"]
+    assert description["engines"]["python"]
+    assert description["engines"]["fastjsonschema"]
+    assert description["engines"]["jsonschema"]
+
+
+def test_describe_cli_outputs_json(monkeypatch, capsys):
+    monkeypatch.setattr(
+        sys, "argv", ["tidas-validate", "--describe", "--format", "json"]
+    )
+
+    validate_module.main()
+
+    assert json.loads(capsys.readouterr().out)["protocols"] == [
+        "document-validation-batch.v1"
+    ]
+
+
+def test_batch_streams_issues_then_final_without_repeating_report(tmp_path):
+    batch_root = tmp_path / "batch"
+    source_path = batch_root / "sources" / "bad.json"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("{}", encoding="utf-8")
+    manifest = tmp_path / "manifest.jsonl"
+    _write_manifest(manifest, source_path, batch_root)
+    events = []
+
+    final = run_document_validation_batch(
+        input_dir=batch_root,
+        input_manifest=manifest,
+        emit_event=events.append,
+    )
+
+    assert [event["type"] for event in events] == ["issue", "final"]
+    issue = events[0]
+    assert issue["document_key"] == "source:test:01.00.000"
+    assert issue["issue"]["file_path"] == "sources/bad.json"
+    assert final["completed"] is True
+    assert final["summary"]["document_count"] == 1
+    assert final["summary"]["error_count"] == 1
+    assert "issues" not in final
+    assert (
+        final["logical_issue_stream_sha256"]
+        == sha256(canonical_json_line(issue)).hexdigest()
+    )
+
+
+def test_batch_cli_exits_zero_even_when_data_issues_exist(
+    tmp_path, monkeypatch, capsys
+):
+    batch_root = tmp_path / "batch"
+    source_path = batch_root / "sources" / "bad.json"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("{}", encoding="utf-8")
+    manifest = tmp_path / "manifest.jsonl"
+    _write_manifest(manifest, source_path, batch_root)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "tidas-validate",
+            "--protocol",
+            "document-validation-batch.v1",
+            "--input-dir",
+            str(batch_root),
+            "--input-manifest",
+            str(manifest),
+        ],
+    )
+
+    validate_module.main()
+
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events[-1]["type"] == "final"
+    assert events[-1]["summary"]["error_count"] == 1
+
+
+def test_batch_cli_protocol_failure_exits_two(tmp_path, monkeypatch):
+    batch_root = tmp_path / "batch"
+    batch_root.mkdir()
+    manifest = tmp_path / "manifest.jsonl"
+    manifest.write_text(
+        json.dumps(
+            {
+                "document_key": "missing",
+                "category": "sources",
+                "relative_path": "missing.json",
+                "content_sha256": "0" * 64,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "tidas-validate",
+            "--protocol",
+            "document-validation-batch.v1",
+            "--input-dir",
+            str(batch_root),
+            "--input-manifest",
+            str(manifest),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        validate_module.main()
+
+    assert exit_info.value.code == 2
+
+
+def test_batch_event_order_and_hash_are_deterministic(tmp_path):
+    batch_root = tmp_path / "batch"
+    source_path = batch_root / "sources" / "bad.json"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("{}", encoding="utf-8")
+    manifest = tmp_path / "manifest.jsonl"
+    _write_manifest(manifest, source_path, batch_root)
+
+    first = []
+    second = []
+    run_document_validation_batch(
+        input_dir=batch_root, input_manifest=manifest, emit_event=first.append
+    )
+    run_document_validation_batch(
+        input_dir=batch_root, input_manifest=manifest, emit_event=second.append
+    )
+
+    assert first == second
+
+
+@pytest.mark.parametrize(
+    "mutate,expected",
+    [
+        (lambda item: item.update(document_key=""), "document_key"),
+        (lambda item: item.update(relative_path="../bad.json"), "escapes"),
+        (lambda item: item.update(content_sha256="0" * 64), "hash mismatch"),
+    ],
+)
+def test_batch_rejects_invalid_manifest_contract(tmp_path, mutate, expected):
+    batch_root = tmp_path / "batch"
+    source_path = batch_root / "sources" / "bad.json"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("{}", encoding="utf-8")
+    item = _manifest_item(source_path, batch_root)
+    mutate(item)
+    manifest = tmp_path / "manifest.jsonl"
+    manifest.write_text(json.dumps(item) + "\n", encoding="utf-8")
+
+    with pytest.raises(BatchProtocolError, match=expected):
+        run_document_validation_batch(
+            input_dir=batch_root,
+            input_manifest=manifest,
+            emit_event=lambda _event: None,
+        )
+
+
+def test_batch_rejects_duplicate_keys_and_paths(tmp_path):
+    batch_root = tmp_path / "batch"
+    source_path = batch_root / "sources" / "bad.json"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("{}", encoding="utf-8")
+    item = _manifest_item(source_path, batch_root)
+    manifest = tmp_path / "manifest.jsonl"
+    manifest.write_text(
+        json.dumps(item) + "\n" + json.dumps(item) + "\n", encoding="utf-8"
+    )
+
+    with pytest.raises(BatchProtocolError, match="duplicate document_key"):
+        run_document_validation_batch(
+            input_dir=batch_root,
+            input_manifest=manifest,
+            emit_event=lambda _event: None,
+        )
+
+
+def test_batch_rejects_symlink_input(tmp_path):
+    batch_root = tmp_path / "batch"
+    outside = tmp_path / "outside.json"
+    outside.write_text("{}", encoding="utf-8")
+    source_path = batch_root / "sources" / "bad.json"
+    source_path.parent.mkdir(parents=True)
+    source_path.symlink_to(outside)
+    manifest = tmp_path / "manifest.jsonl"
+    _write_manifest(manifest, source_path, batch_root, content_path=outside)
+
+    with pytest.raises(BatchProtocolError, match="symlink"):
+        run_document_validation_batch(
+            input_dir=batch_root,
+            input_manifest=manifest,
+            emit_event=lambda _event: None,
+        )
+
+
+def _write_manifest(
+    manifest: Path,
+    source_path: Path,
+    batch_root: Path,
+    *,
+    content_path: Path | None = None,
+) -> None:
+    item = _manifest_item(source_path, batch_root)
+    item["content_sha256"] = sha256(
+        (content_path or source_path).read_bytes()
+    ).hexdigest()
+    manifest.write_text(json.dumps(item) + "\n", encoding="utf-8")
+
+
+def _manifest_item(source_path: Path, batch_root: Path) -> dict:
+    return {
+        "document_key": "source:test:01.00.000",
+        "category": "sources",
+        "relative_path": source_path.relative_to(batch_root).as_posix(),
+        "content_sha256": sha256(source_path.read_bytes()).hexdigest(),
+        "identity": {
+            "dataset_type": "source",
+            "dataset_id": "11111111-1111-1111-1111-111111111111",
+            "dataset_version": "01.00.000",
+        },
+    }


### PR DESCRIPTION
## Summary
- add versioned batch validation and reference-extraction contracts for scope closure
- lock schema/describe fingerprints and deterministic JSONL evidence
- preserve exact unresolved reference semantics for Worker consumption

## Validation
- 168 pytest tests passed
- 18 schema-lock pairs passed
- validate --describe, Black, and cumulative Docpact lint passed

## Dependencies
- Parent delivery: tiangong-lca/workspace#452

## Workspace Integration
- Root integration must pin the exact merged commit after this PR lands.

Closes #114