### PR TITLE
feat: define unified tidas CLI contracts

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -2,9 +2,9 @@ version: 1
 layout: repo
 lastReviewedAt: "2026-07-25"
 lastReviewedCommit: "1dd24944f3f076864121b7cb3eda7f3e184099e5"
-# Issue #118 adds the Rust workspace, stable contracts, executable-asset lock,
-# migration inventory, and five-platform Rust CI while Python remains a frozen
-# parity oracle during the dependency-ordered #117 migration.
+# Issue #119 fixes the unified CLI command/configuration/stream contract,
+# versioned invocation context, deterministic completion surface, and bounded
+# runtime adapter while Python remains a frozen parity oracle.
 
 catalog:
   repos:
@@ -15,6 +15,7 @@ catalog:
       workflowDocs:
         - docs/agents/repo-validation.md
         - docs/agents/repo-architecture.md
+        - docs/agents/cli-contract.md
       workspaceIntegrationRequired: true
 
 ownership:
@@ -27,6 +28,7 @@ ownership:
           - README_CN.md
           - .gitattributes
           - .docpact/config.yaml
+          - docs/agents/cli-contract.md
           - docs/agents/**
           - migration/**
           - .github/workflows/ai-doc-lint.yml
@@ -89,6 +91,7 @@ coverage:
     - README_CN.md
     - .gitattributes
     - .docpact/config.yaml
+    - docs/agents/cli-contract.md
     - docs/agents/**
     - migration/**
     - Cargo.toml
@@ -147,6 +150,7 @@ routing:
         - scripts/install-git-hooks.sh
     tool-runtime:
       paths:
+        - docs/agents/cli-contract.md
         - Cargo.toml
         - Cargo.lock
         - crates/**
@@ -229,6 +233,7 @@ routing:
         - .github/workflows/python-package-deploy.yml
     proof:
       paths:
+        - docs/agents/cli-contract.md
         - docs/agents/repo-validation.md
         - Cargo.toml
         - Cargo.lock
@@ -252,6 +257,7 @@ routing:
         - README_CN.md
         - .gitattributes
         - .docpact/config.yaml
+        - docs/agents/cli-contract.md
         - docs/agents/**
         - migration/**
     root-integration:
@@ -264,6 +270,7 @@ docInventory:
     - README.md
     - README_CN.md
     - .docpact/config.yaml
+    - docs/agents/cli-contract.md
     - docs/agents/repo-validation.md
     - docs/agents/repo-architecture.md
     - migration/python-to-rust-owners.md
@@ -285,6 +292,8 @@ rules:
         kind: deep-doc
       - path: docs/agents/repo-architecture.md
         kind: deep-doc
+      - path: docs/agents/cli-contract.md
+        kind: cli-contract
     requiredDocs:
       - path: AGENTS.md
         mode: review_or_update
@@ -293,6 +302,8 @@ rules:
       - path: docs/agents/repo-validation.md
         mode: review_or_update
       - path: docs/agents/repo-architecture.md
+        mode: review_or_update
+      - path: docs/agents/cli-contract.md
         mode: review_or_update
     reason: Repo entry guidance, machine-readable routing, and retained source docs must stay aligned.
   - id: tidas-tools-readme-contract
@@ -307,6 +318,8 @@ rules:
       - path: AGENTS.md
         mode: must_exist
       - path: .docpact/config.yaml
+        mode: must_exist
+      - path: docs/agents/cli-contract.md
         mode: must_exist
     reason: User-facing landing docs should stay aligned with the current repo contract and CLI/release surface.
   - id: tidas-tools-runtime-contract
@@ -353,6 +366,8 @@ rules:
       - path: docs/agents/repo-validation.md
         mode: review_or_update
       - path: docs/agents/repo-architecture.md
+        mode: review_or_update
+      - path: docs/agents/cli-contract.md
         mode: review_or_update
     reason: Core standalone tooling changes alter the repo's executable contract and proof expectations.
   - id: tidas-tools-asset-contract

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,9 +39,10 @@ checkPaths:
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-25
 lastReviewedCommit: 1dd24944f3f076864121b7cb3eda7f3e184099e5
-lastReviewedNote: "Issue #118 establishes the Rust workspace, stable report/runtime contracts, executable-asset lock, and cross-platform XML boundary for the staged #117 migration."
+lastReviewedNote: "Issue #119 establishes the authoritative unified CLI, invocation context, output-channel, completion, and bounded-runtime adapter contract."
 related:
   - .docpact/config.yaml
+  - docs/agents/cli-contract.md
   - docs/agents/repo-validation.md
   - docs/agents/repo-architecture.md
   - README.md
@@ -67,6 +68,7 @@ Review note, 2026-07-17: Issue #112 makes packaged schema reads explicitly UTF-8
 | `.docpact/config.yaml` | machine-readable repo facts, routing intents, governed-doc rules, ownership, coverage, and freshness | explanatory prose or long-form walkthroughs |
 | `docs/agents/repo-validation.md` | minimum proof by change type, manual CLI probes, PR validation note shape | repo contract, branch policy truth, or architecture explanations |
 | `docs/agents/repo-architecture.md` | compact tool topology, stable path map, upstream asset chain, dispatch and release model | checklist-style proof guidance or user-facing CLI docs |
+| `docs/agents/cli-contract.md` | authoritative unified command, configuration, stream, machine-report, completion, and exit contract | domain conversion, validation, import, export, or release semantics |
 | `README.md` | English user-facing CLI examples and basic development commands | machine-readable routing or lint semantics |
 | `README_CN.md` | Chinese user-facing CLI examples and basic development commands | machine-readable routing or lint semantics |
 
@@ -76,7 +78,7 @@ Read in this order:
 
 1. `AGENTS.md`
 2. `.docpact/config.yaml`
-3. `docs/agents/repo-validation.md` or `docs/agents/repo-architecture.md`
+3. `docs/agents/cli-contract.md` for public CLI work, otherwise `docs/agents/repo-validation.md` or `docs/agents/repo-architecture.md`
 4. `README.md` or `README_CN.md` only for user-facing CLI examples
 
 ## Operational Pointers
@@ -84,6 +86,7 @@ Read in this order:
 - path-level ownership, routing intents, governed-doc inventory, and lint rules live in `.docpact/config.yaml`
 - minimum proof and manual CLI probe guidance live in `docs/agents/repo-validation.md`
 - stable path groups, upstream asset handoffs, and release / dispatch topology live in `docs/agents/repo-architecture.md`
+- unified CLI behavior and machine-output stability live in `docs/agents/cli-contract.md`
 - repo-local documentation maintenance is enforced locally by the pre-push docpact gate; `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback
 - schema asset parity and lock validation are enforced by `scripts/schema_lock.py` and `.github/workflows/ci.yml`
 - the main routing intents are `tool-runtime`, `conversion`, `validation`, `export`, `packaged-assets`, `sdk-dispatch`, `release`, `proof`, `repo-docs`, and `root-integration`
@@ -95,6 +98,8 @@ Keep these entry-level facts in `AGENTS.md`. Use `README.md`, `README_CN.md`, an
 - Rust workspace toolchain: Rust 1.88 or newer, Cargo resolver 3
 - final product entry point: `cargo run -p tidas-cli --bin tidas -- <subcommand>`
 - final command tree: `convert`, `import`, `export`, `validate`, `release`, `ruleset`, `version`
+- configuration precedence: explicit CLI option, then matching `TIDAS_*` environment variable, then the documented built-in default; no implicit current-directory config
+- stdout is reserved for one report or completion script; logs, progress, and file-write confirmations use stderr
 - canonical Rust checks: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace --all-targets`
 - executable asset lock: `cargo run -p tidas-assets --bin tidas-asset-lock -- check`
 - migration-oracle package manager and runner: `uv`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +117,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clang-sys"
@@ -140,6 +155,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
 ]
 
 [[package]]
@@ -206,6 +230,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +249,18 @@ dependencies = [
  "block-buffer",
  "const-oid",
  "crypto-common",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -369,6 +416,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +436,21 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -624,9 +698,14 @@ name = "tidas-cli"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "clap_complete",
+ "ctrlc",
+ "serde",
  "serde_json",
+ "tempfile",
  "tidas-assets",
  "tidas-contracts",
+ "tidas-runtime",
  "tidas-xml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,10 @@ license = "MIT"
 repository = "https://github.com/tiangong-lca/tidas-tools"
 
 [workspace.dependencies]
-clap = { version = "4.6.4", features = ["derive"] }
+clap = { version = "4.6.4", features = ["derive", "env"] }
+clap_complete = "4.6.7"
 crossbeam-channel = "0.5.16"
+ctrlc = "3.5.2"
 include_dir = "0.7.4"
 libxml = "0.3.16"
 libxslt = "0.1.5"

--- a/README.md
+++ b/README.md
@@ -13,14 +13,15 @@ release, and ruleset behavior to one cross-platform Rust executable named
 
 ## Rust migration preview
 
-The first migration slice establishes the Cargo workspace, stable machine
-contracts, bounded runtime primitives, executable-asset integrity lock, and
-the XML/XSD/XSLT portability boundary:
+The current Rust slices establish the Cargo workspace, stable machine and
+invocation contracts, bounded runtime primitives, executable-asset integrity
+lock, XML/XSD/XSLT portability boundary, and the final unified CLI adapter:
 
 ```bash
 cargo build --workspace
 cargo run -p tidas-cli --bin tidas -- --help
 cargo run -p tidas-cli --bin tidas -- --format json version
+cargo run -p tidas-cli --bin tidas -- --completion bash > tidas.bash
 cargo run -p tidas-assets --bin tidas-asset-lock -- check
 ```
 
@@ -28,6 +29,14 @@ The final command tree is `convert`, `import`, `export`, `validate`, `release`,
 `ruleset`, and `version`. Only `version` is functional in this foundation
 slice; the other Rust commands fail explicitly with exit class
 `unavailable`/code `69` and never invoke Python.
+
+Global runtime options follow `CLI > TIDAS_* environment > built-in default`
+precedence. No configuration file is loaded implicitly. Stdout contains only
+the requested human/JSON report or completion script; logs, progress,
+diagnostics, and report-file confirmations use stderr. Use `--report <PATH>`
+to persist the report without occupying stdout. The default accounted memory
+budget is 512 MiB and the default bounded queue capacity is 256. The normative
+contract is [docs/agents/cli-contract.md](docs/agents/cli-contract.md).
 
 The Python package described below is feature-frozen and remains temporarily
 available as an internal golden/parity oracle. It is not the final product and

--- a/README_CN.md
+++ b/README_CN.md
@@ -47,19 +47,27 @@ Rust 可执行文件 `tidas`。
 
 ## Rust 迁移预览
 
-首个迁移切片建立 Cargo workspace、稳定机器契约、有界运行时基础设施、可执行资产
-完整性锁，以及 XML/XSD/XSLT 跨平台边界：
+当前 Rust 切片已经建立 Cargo workspace、稳定机器与 invocation 契约、有界运行时
+基础设施、可执行资产完整性锁、XML/XSD/XSLT 跨平台边界，以及最终统一 CLI
+适配层：
 
 ```bash
 cargo build --workspace
 cargo run -p tidas-cli --bin tidas -- --help
 cargo run -p tidas-cli --bin tidas -- --format json version
+cargo run -p tidas-cli --bin tidas -- --completion bash > tidas.bash
 cargo run -p tidas-assets --bin tidas-asset-lock -- check
 ```
 
 最终命令树固定为 `convert`、`import`、`export`、`validate`、`release`、
 `ruleset` 和 `version`。本基础切片只有 `version` 已可用；其他 Rust 命令会明确
 返回 `unavailable`（退出码 `69`），绝不调用 Python 回退。
+
+全局运行参数遵循“命令行 > `TIDAS_*` 环境变量 > 内置默认值”的优先级，不会隐式
+读取当前目录中的配置文件。stdout 只包含一次 human/JSON 报告或 completion 脚本；
+日志、进度、诊断与报告落盘确认写入 stderr。使用 `--report <PATH>` 可在不占用
+stdout 的情况下持久化报告。默认计入内存预算为 512 MiB，有界队列容量为 256。
+规范契约见 [docs/agents/cli-contract.md](docs/agents/cli-contract.md)。
 
 下文记录的 Python 包已经 feature freeze，只在迁移期间作为内部 golden/parity
 oracle。它不是最终产品，旧可执行文件名和参数布局不会保留。只有 Rust 功能语义、

--- a/contracts/operation-report.v1.schema.json
+++ b/contracts/operation-report.v1.schema.json
@@ -19,18 +19,20 @@
     "schema_version": {
       "const": "tidas.operation-report.v1"
     },
-    "command": {
-      "type": "string",
-      "minLength": 1
-    },
     "status": {
       "enum": ["succeeded", "completed-with-issues", "failed", "cancelled"]
+    },
+    "command": {
+      "enum": ["convert", "import", "export", "validate", "release", "ruleset", "version"]
     },
     "exit_class": {
       "enum": ["success", "data-issues", "usage", "unavailable", "internal", "io", "cancelled"]
     },
     "completeness": {
       "enum": ["complete", "partial", "not-started"]
+    },
+    "invocation": {
+      "$ref": "#/$defs/invocation"
     },
     "summary": {
       "type": "object"
@@ -55,6 +57,60 @@
     }
   },
   "$defs": {
+    "invocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "config_source",
+        "config_path",
+        "log_level",
+        "progress_mode",
+        "progress_enabled",
+        "memory_budget_bytes",
+        "queue_capacity",
+        "input_policy",
+        "report_destination",
+        "diagnostic_destination"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "tidas.invocation-context.v1"
+        },
+        "config_source": {
+          "enum": ["none", "environment", "cli"]
+        },
+        "config_path": {
+          "type": ["string", "null"]
+        },
+        "log_level": {
+          "enum": ["error", "warn", "info", "debug", "trace"]
+        },
+        "progress_mode": {
+          "enum": ["auto", "never", "always"]
+        },
+        "progress_enabled": {
+          "type": "boolean"
+        },
+        "memory_budget_bytes": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "queue_capacity": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "input_policy": {
+          "const": "explicit-path-or-dash"
+        },
+        "report_destination": {
+          "enum": ["stdout", "file"]
+        },
+        "diagnostic_destination": {
+          "const": "stderr"
+        }
+      }
+    },
     "diagnostic": {
       "type": "object",
       "additionalProperties": false,

--- a/crates/tidas-cli/Cargo.toml
+++ b/crates/tidas-cli/Cargo.toml
@@ -13,10 +13,17 @@ path = "src/main.rs"
 
 [dependencies]
 clap.workspace = true
+clap_complete.workspace = true
+ctrlc.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 tidas-assets = { path = "../tidas-assets" }
 tidas-contracts = { path = "../tidas-contracts" }
+tidas-runtime = { path = "../tidas-runtime" }
 tidas-xml = { path = "../tidas-xml" }
+
+[dev-dependencies]
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/tidas-cli/src/args.rs
+++ b/crates/tidas-cli/src/args.rs
@@ -1,0 +1,272 @@
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+use clap::error::ErrorKind;
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use clap_complete::Shell;
+use tidas_contracts::{CommandNameV1, LogLevelV1, ProgressModeV1};
+
+pub const DEFAULT_MEMORY_BUDGET_MIB: u64 = 512;
+pub const DEFAULT_QUEUE_CAPACITY: usize = 256;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "tidas",
+    version,
+    disable_help_subcommand = true,
+    about = "Cross-platform TIDAS conversion, import, export, validation, and release tooling",
+    long_about = "The unified TIDAS executable. Domain behavior lives in reusable Rust crates; this binary only parses inputs, supplies bounded runtime controls, and renders stable human or JSON reports.",
+    after_help = "Examples:\n  tidas version --format json\n  tidas --completion bash > tidas.bash\n\nPrecedence: command-line options override TIDAS_* environment variables, which override documented built-in defaults. No configuration file is loaded implicitly from the current directory.\n\nStdout contains only the requested report or completion script. Logs, progress, diagnostics, and file-write confirmations use stderr. During migration, incomplete Rust commands return unavailable (69) and never invoke Python."
+)]
+pub struct Cli {
+    /// Reading-oriented human output or stable machine-readable JSON.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Human, global = true)]
+    pub format: OutputFormat,
+
+    /// Persist the complete report atomically instead of writing it to stdout.
+    #[arg(long, value_name = "PATH", global = true)]
+    pub report: Option<PathBuf>,
+
+    /// Explicit configuration file; otherwise `TIDAS_CONFIG` is used when set.
+    #[arg(long, value_name = "PATH", global = true)]
+    pub config: Option<PathBuf>,
+
+    /// Diagnostic verbosity; may also be set with `TIDAS_LOG`.
+    #[arg(
+        long,
+        value_enum,
+        env = "TIDAS_LOG",
+        default_value_t = CliLogLevel::Warn,
+        global = true
+    )]
+    pub log_level: CliLogLevel,
+
+    /// Progress policy; may also be set with `TIDAS_PROGRESS`.
+    #[arg(
+        long,
+        value_enum,
+        env = "TIDAS_PROGRESS",
+        default_value_t = CliProgressMode::Auto,
+        global = true
+    )]
+    pub progress: CliProgressMode,
+
+    /// Maximum accounted in-flight memory in MiB.
+    #[arg(
+        long,
+        env = "TIDAS_MEMORY_BUDGET_MIB",
+        default_value_t = DEFAULT_MEMORY_BUDGET_MIB,
+        value_parser = parse_positive_u64,
+        global = true
+    )]
+    pub memory_budget_mib: u64,
+
+    /// Maximum number of items in each bounded work queue.
+    #[arg(
+        long,
+        env = "TIDAS_QUEUE_CAPACITY",
+        default_value_t = DEFAULT_QUEUE_CAPACITY,
+        value_parser = parse_positive_usize,
+        global = true
+    )]
+    pub queue_capacity: usize,
+
+    /// Write a deterministic shell completion script to stdout and exit.
+    #[arg(long, value_enum, value_name = "SHELL")]
+    pub completion: Option<Shell>,
+
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+impl Cli {
+    pub fn try_parse_checked() -> Result<Self, clap::Error> {
+        let cli = Self::try_parse()?;
+        cli.validate()?;
+        Ok(cli)
+    }
+
+    fn validate(&self) -> Result<(), clap::Error> {
+        match (self.completion, self.command) {
+            (None, None) => Err(Self::command().error(
+                ErrorKind::MissingSubcommand,
+                "a product command is required; use `tidas --help` or request `--completion <shell>`",
+            )),
+            (Some(_), Some(_)) => Err(Self::command().error(
+                ErrorKind::ArgumentConflict,
+                "--completion generates a script and cannot be combined with a product command",
+            )),
+            (Some(_), None) if self.report.is_some() => Err(Self::command().error(
+                ErrorKind::ArgumentConflict,
+                "--completion writes to stdout and cannot be combined with --report",
+            )),
+            _ => {
+                self.memory_budget_mib.checked_mul(1024 * 1024).ok_or_else(|| {
+                    Self::command().error(
+                        ErrorKind::InvalidValue,
+                        "--memory-budget-mib is too large to represent in bytes",
+                    )
+                })?;
+                Ok(())
+            }
+        }
+    }
+
+    #[must_use]
+    pub const fn memory_budget_bytes(&self) -> u64 {
+        self.memory_budget_mib * 1024 * 1024
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum OutputFormat {
+    Human,
+    Json,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum CliLogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl From<CliLogLevel> for LogLevelV1 {
+    fn from(value: CliLogLevel) -> Self {
+        match value {
+            CliLogLevel::Error => Self::Error,
+            CliLogLevel::Warn => Self::Warn,
+            CliLogLevel::Info => Self::Info,
+            CliLogLevel::Debug => Self::Debug,
+            CliLogLevel::Trace => Self::Trace,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum CliProgressMode {
+    Auto,
+    Never,
+    Always,
+}
+
+impl From<CliProgressMode> for ProgressModeV1 {
+    fn from(value: CliProgressMode) -> Self {
+        match value {
+            CliProgressMode::Auto => Self::Auto,
+            CliProgressMode::Never => Self::Never,
+            CliProgressMode::Always => Self::Always,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Subcommand)]
+pub enum Commands {
+    /// Convert between TIDAS JSON and eILCD XML.
+    Convert,
+    /// Import supported external LCA formats into TIDAS.
+    Import,
+    /// Export database records and external documents as a package.
+    Export,
+    /// Validate TIDAS JSON or eILCD/ILCD XML.
+    Validate,
+    /// Build and verify deterministic release packages.
+    Release,
+    /// Inspect and validate packaged methodology rulesets.
+    Ruleset,
+    /// Print binary, contract, asset, XML engine, and runtime fingerprints.
+    Version,
+}
+
+impl Commands {
+    #[must_use]
+    pub const fn name(self) -> CommandNameV1 {
+        match self {
+            Self::Convert => CommandNameV1::Convert,
+            Self::Import => CommandNameV1::Import,
+            Self::Export => CommandNameV1::Export,
+            Self::Validate => CommandNameV1::Validate,
+            Self::Release => CommandNameV1::Release,
+            Self::Ruleset => CommandNameV1::Ruleset,
+            Self::Version => CommandNameV1::Version,
+        }
+    }
+}
+
+pub fn write_completion(shell: Shell, writer: &mut impl Write) -> io::Result<()> {
+    let mut command = Cli::command();
+    let mut bytes = Vec::new();
+    clap_complete::generate(shell, &mut command, "tidas", &mut bytes);
+    writer.write_all(&bytes)
+}
+
+fn parse_positive_u64(value: &str) -> Result<u64, String> {
+    value
+        .parse::<u64>()
+        .map_err(|error| format!("expected a positive integer: {error}"))
+        .and_then(|parsed| {
+            if parsed == 0 {
+                Err("value must be greater than zero".to_owned())
+            } else {
+                Ok(parsed)
+            }
+        })
+}
+
+fn parse_positive_usize(value: &str) -> Result<usize, String> {
+    value
+        .parse::<usize>()
+        .map_err(|error| format!("expected a positive integer: {error}"))
+        .and_then(|parsed| {
+            if parsed == 0 {
+                Err("value must be greater than zero".to_owned())
+            } else {
+                Ok(parsed)
+            }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clap_contract_is_internally_consistent() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn only_the_final_command_names_are_registered() {
+        let command = Cli::command();
+        let names: Vec<_> = command
+            .get_subcommands()
+            .map(clap::Command::get_name)
+            .collect();
+        assert_eq!(
+            names,
+            [
+                "convert", "import", "export", "validate", "release", "ruleset", "version"
+            ]
+        );
+    }
+
+    #[test]
+    fn every_supported_completion_is_repeatable() {
+        for shell in [
+            Shell::Bash,
+            Shell::Elvish,
+            Shell::Fish,
+            Shell::PowerShell,
+            Shell::Zsh,
+        ] {
+            let mut first = Vec::new();
+            let mut second = Vec::new();
+            write_completion(shell, &mut first).unwrap();
+            write_completion(shell, &mut second).unwrap();
+            assert_eq!(first, second);
+            assert!(!first.is_empty());
+        }
+    }
+}

--- a/crates/tidas-cli/src/context.rs
+++ b/crates/tidas-cli/src/context.rs
@@ -1,0 +1,95 @@
+use std::env;
+use std::io::{self, IsTerminal};
+
+use tidas_contracts::{
+    ConfigSourceV1, DiagnosticDestinationV1, INVOCATION_CONTEXT_SCHEMA_V1, InputPolicyV1,
+    InvocationContextV1, ReportDestinationV1,
+};
+use tidas_runtime::{CancellationToken, MemoryBudget};
+
+use crate::args::{Cli, CliProgressMode, OutputFormat};
+
+#[derive(Clone, Debug)]
+pub struct ExecutionContext {
+    pub invocation: InvocationContextV1,
+    pub cancellation: CancellationToken,
+    pub memory_budget: MemoryBudget,
+}
+
+impl ExecutionContext {
+    #[must_use]
+    pub fn from_cli(cli: &Cli) -> Self {
+        let (config_source, config_path) = resolve_config(cli);
+        let progress_enabled = match cli.progress {
+            CliProgressMode::Always => true,
+            CliProgressMode::Never => false,
+            CliProgressMode::Auto => {
+                io::stderr().is_terminal() && matches!(cli.format, OutputFormat::Human)
+            }
+        };
+        let memory_budget = MemoryBudget::new(cli.memory_budget_bytes());
+        Self {
+            invocation: InvocationContextV1 {
+                schema_version: INVOCATION_CONTEXT_SCHEMA_V1.to_owned(),
+                config_source,
+                config_path,
+                log_level: cli.log_level.into(),
+                progress_mode: cli.progress.into(),
+                progress_enabled,
+                memory_budget_bytes: memory_budget.limit(),
+                queue_capacity: cli.queue_capacity,
+                input_policy: InputPolicyV1::ExplicitPathOrDash,
+                report_destination: if cli.report.is_some() {
+                    ReportDestinationV1::File
+                } else {
+                    ReportDestinationV1::Stdout
+                },
+                diagnostic_destination: DiagnosticDestinationV1::Stderr,
+            },
+            cancellation: CancellationToken::default(),
+            memory_budget,
+        }
+    }
+
+    pub fn install_cancellation_handler(&self) -> Result<(), ctrlc::Error> {
+        let cancellation = self.cancellation.clone();
+        ctrlc::set_handler(move || cancellation.cancel())
+    }
+}
+
+fn resolve_config(cli: &Cli) -> (ConfigSourceV1, Option<String>) {
+    if let Some(path) = &cli.config {
+        return (
+            ConfigSourceV1::Cli,
+            Some(path.to_string_lossy().into_owned()),
+        );
+    }
+    match env::var_os("TIDAS_CONFIG").filter(|value| !value.is_empty()) {
+        Some(path) => (
+            ConfigSourceV1::Environment,
+            Some(path.to_string_lossy().into_owned()),
+        ),
+        None => (ConfigSourceV1::None, None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+    use crate::args::DEFAULT_MEMORY_BUDGET_MIB;
+
+    #[test]
+    fn defaults_are_bounded_and_do_not_search_the_current_directory() {
+        let cli = Cli::try_parse_from(["tidas", "version"]).unwrap();
+        let context = ExecutionContext::from_cli(&cli);
+        assert_eq!(context.invocation.config_source, ConfigSourceV1::None);
+        assert_eq!(context.invocation.config_path, None);
+        assert_eq!(
+            context.invocation.memory_budget_bytes,
+            DEFAULT_MEMORY_BUDGET_MIB * 1024 * 1024
+        );
+        assert_eq!(context.memory_budget.limit(), 512 * 1024 * 1024);
+    }
+}

--- a/crates/tidas-cli/src/main.rs
+++ b/crates/tidas-cli/src/main.rs
@@ -1,239 +1,148 @@
-use std::fmt::Write as _;
-use std::fs;
-use std::io::{self, Write};
-use std::path::{Path, PathBuf};
+mod args;
+mod context;
+mod output;
+
 use std::process::ExitCode;
 
-#[cfg(test)]
-use clap::CommandFactory;
+use args::{Cli, Commands};
 use clap::error::ErrorKind;
-use clap::{Parser, Subcommand, ValueEnum};
+use context::ExecutionContext;
 use tidas_assets::{asset_fingerprint, bundled_assets};
-use tidas_contracts::{ExitClass, OperationReportV1};
+use tidas_contracts::{
+    CommandNameV1, ExitClass, INVOCATION_CONTEXT_SCHEMA_V1, OPERATION_REPORT_SCHEMA_V1,
+    OperationReportV1,
+};
 use tidas_xml::engine_decision;
 
-#[derive(Debug, Parser)]
-#[command(
-    name = "tidas",
-    version,
-    about = "Cross-platform TIDAS conversion, import, export, validation, and release tooling",
-    long_about = "The unified TIDAS executable. Domain behavior lives in reusable Rust crates; this binary only parses inputs and renders stable human or JSON results.",
-    after_help = "JSON stdout is a stable contract and never includes logs. Use --output for durable reports. During migration, commands whose Rust slice is not complete fail with the unavailable exit class instead of invoking Python."
-)]
-struct Cli {
-    /// Reading-oriented human output or stable machine-readable JSON.
-    #[arg(long, value_enum, default_value_t = OutputFormat::Human, global = true)]
-    format: OutputFormat,
-
-    /// Write the complete result to a file instead of stdout.
-    #[arg(long, value_name = "PATH", global = true)]
-    output: Option<PathBuf>,
-
-    #[command(subcommand)]
-    command: Commands,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
-enum OutputFormat {
-    Human,
-    Json,
-}
-
-#[derive(Debug, Subcommand)]
-enum Commands {
-    /// Convert between TIDAS JSON and eILCD XML.
-    Convert,
-    /// Import supported external LCA formats into TIDAS.
-    Import,
-    /// Export database records and external documents as a package.
-    Export,
-    /// Validate TIDAS JSON or eILCD/ILCD XML.
-    Validate,
-    /// Build and verify deterministic release packages.
-    Release,
-    /// Inspect and validate packaged methodology rulesets.
-    Ruleset,
-    /// Print binary, contract, asset, and XML engine fingerprints.
-    Version,
-}
-
-impl Commands {
-    const fn name(&self) -> &'static str {
-        match self {
-            Self::Convert => "convert",
-            Self::Import => "import",
-            Self::Export => "export",
-            Self::Validate => "validate",
-            Self::Release => "release",
-            Self::Ruleset => "ruleset",
-            Self::Version => "version",
-        }
-    }
-}
-
 fn main() -> ExitCode {
-    let cli = match Cli::try_parse() {
+    let cli = match Cli::try_parse_checked() {
         Ok(cli) => cli,
-        Err(error) => {
-            let kind = error.kind();
-            let code = if matches!(kind, ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) {
-                ExitClass::Success
-            } else {
-                ExitClass::Usage
-            };
-            if let Err(print_error) = error.print() {
-                eprintln!("failed to print CLI guidance: {print_error}");
-                return ExitCode::from(ExitClass::Io.code());
-            }
-            return ExitCode::from(code.code());
-        }
+        Err(error) => return print_clap_error(&error),
     };
 
-    let report = match run(&cli) {
-        Ok(report) => report,
-        Err(error) => {
-            eprintln!("tidas failed before producing a result: {error}");
-            return ExitCode::from(ExitClass::Internal.code());
-        }
-    };
+    if let Some(shell) = cli.completion {
+        return match args::write_completion(shell, &mut std::io::stdout().lock()) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(error) => {
+                eprintln!("failed to write {shell} completion script: {error}");
+                ExitCode::from(ExitClass::Io.code())
+            }
+        };
+    }
+
+    let command = cli
+        .command
+        .expect("checked CLI always has a command unless completion was requested");
+    let execution = ExecutionContext::from_cli(&cli);
+    let report = match execution.install_cancellation_handler() {
+        Ok(()) => dispatch(command, &execution),
+        Err(error) => OperationReportV1::failed(
+            command.name(),
+            ExitClass::Internal,
+            "cancellation_handler_unavailable",
+            format!("Failed to install the process cancellation handler: {error}"),
+        ),
+    }
+    .with_invocation(execution.invocation.clone());
+
     let exit_class = report.exit_class;
-    match render(&cli, &report) {
+    match output::render(&cli, &report) {
         Ok(()) => ExitCode::from(exit_class.code()),
         Err(error) => {
-            eprintln!("tidas failed to render its result: {error}");
+            eprintln!("tidas failed to render its report: {error}");
             ExitCode::from(ExitClass::Io.code())
         }
     }
 }
 
-fn run(cli: &Cli) -> Result<OperationReportV1, Box<dyn std::error::Error>> {
-    if matches!(cli.command, Commands::Version) {
-        let mut report = OperationReportV1::succeeded("version");
-        report.summary.insert(
-            "binary_version".to_owned(),
-            serde_json::json!(env!("CARGO_PKG_VERSION")),
-        );
-        report.summary.insert(
-            "asset_fingerprint".to_owned(),
-            serde_json::json!(asset_fingerprint()?),
-        );
-        report.summary.insert(
-            "asset_count".to_owned(),
-            serde_json::json!(bundled_assets().len()),
-        );
-        report.summary.insert(
-            "xml_engine".to_owned(),
-            serde_json::to_value(engine_decision())?,
-        );
-        report.next_actions.push(
-            "Run `tidas --help` to inspect the final command tree; functional slices are tracked under tidas-tools#117."
-                .to_owned(),
-        );
-        return Ok(report);
-    }
-
-    Ok(OperationReportV1::unavailable(
-        cli.command.name(),
-        format!(
-            "Follow the `{}` Rust migration child Issue linked from tidas-tools#117.",
-            cli.command.name()
-        ),
-    ))
-}
-
-fn render(cli: &Cli, report: &OperationReportV1) -> io::Result<()> {
-    let bytes = match cli.format {
-        OutputFormat::Json => report.to_canonical_json_line().map_err(io::Error::other)?,
-        OutputFormat::Human => human_report(report).into_bytes(),
-    };
-    if let Some(path) = &cli.output {
-        write_atomic(path, &bytes)?;
-        let mut stderr = io::stderr().lock();
-        writeln!(
-            stderr,
-            "wrote {} result to {}",
-            report.command,
-            path.display()
-        )?;
+fn print_clap_error(error: &clap::Error) -> ExitCode {
+    let kind = error.kind();
+    let code = if matches!(kind, ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) {
+        ExitClass::Success
     } else {
-        io::stdout().lock().write_all(&bytes)?;
+        ExitClass::Usage
+    };
+    if let Err(print_error) = error.print() {
+        eprintln!("failed to print CLI guidance: {print_error}");
+        return ExitCode::from(ExitClass::Io.code());
     }
-    Ok(())
+    ExitCode::from(code.code())
 }
 
-fn human_report(report: &OperationReportV1) -> String {
-    let mut output = format!("tidas {}\n\nSummary:\n", report.command);
-    writeln!(&mut output, "- status: {:?}", report.status)
-        .expect("writing to a String cannot fail");
-    writeln!(&mut output, "- completeness: {:?}", report.completeness)
-        .expect("writing to a String cannot fail");
-    for (key, value) in &report.summary {
-        writeln!(&mut output, "- {key}: {value}").expect("writing to a String cannot fail");
+fn dispatch(command: Commands, execution: &ExecutionContext) -> OperationReportV1 {
+    if execution.cancellation.is_cancelled() {
+        return OperationReportV1::cancelled(command.name());
     }
-    for diagnostic in &report.diagnostics {
-        writeln!(&mut output, "- {}: {}", diagnostic.code, diagnostic.message)
-            .expect("writing to a String cannot fail");
+
+    match command {
+        Commands::Version => version_report(execution),
+        other => OperationReportV1::unavailable(
+            other.name(),
+            format!(
+                "Follow the `{}` Rust migration child Issue linked from tidas-tools#117.",
+                other.name().as_str()
+            ),
+        ),
     }
-    if !report.next_actions.is_empty() {
-        output.push_str("\nNext:\n");
-        for action in &report.next_actions {
-            writeln!(&mut output, "- {action}").expect("writing to a String cannot fail");
+}
+
+fn version_report(execution: &ExecutionContext) -> OperationReportV1 {
+    let mut report = OperationReportV1::succeeded(CommandNameV1::Version);
+    report.summary.insert(
+        "binary_version".to_owned(),
+        serde_json::json!(env!("CARGO_PKG_VERSION")),
+    );
+    report.summary.insert(
+        "operation_report_schema".to_owned(),
+        serde_json::json!(OPERATION_REPORT_SCHEMA_V1),
+    );
+    report.summary.insert(
+        "invocation_context_schema".to_owned(),
+        serde_json::json!(INVOCATION_CONTEXT_SCHEMA_V1),
+    );
+    report
+        .summary
+        .insert("command_count".to_owned(), serde_json::json!(7));
+    report.summary.insert(
+        "memory_budget_bytes".to_owned(),
+        serde_json::json!(execution.memory_budget.limit()),
+    );
+    report.summary.insert(
+        "asset_count".to_owned(),
+        serde_json::json!(bundled_assets().len()),
+    );
+    match asset_fingerprint() {
+        Ok(fingerprint) => {
+            report.summary.insert(
+                "asset_fingerprint".to_owned(),
+                serde_json::json!(fingerprint),
+            );
+        }
+        Err(error) => {
+            return OperationReportV1::failed(
+                CommandNameV1::Version,
+                ExitClass::Internal,
+                "asset_fingerprint_failed",
+                error.to_string(),
+            );
         }
     }
-    output
-}
-
-fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
-    let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidInput, "output path needs a file name")
-        })?;
-    let temporary = path.with_file_name(format!(".{file_name}.tmp"));
-    fs::write(&temporary, bytes)?;
-    fs::rename(temporary, path)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn clap_contract_is_internally_consistent() {
-        Cli::command().debug_assert();
-    }
-
-    #[test]
-    fn only_the_final_command_names_are_registered() {
-        let command = Cli::command();
-        let names: Vec<_> = command
-            .get_subcommands()
-            .map(clap::Command::get_name)
-            .collect();
-        assert_eq!(
-            names,
-            [
-                "convert", "import", "export", "validate", "release", "ruleset", "version"
-            ]
-        );
-        for legacy in [
-            "tidas-convert",
-            "tidas-import",
-            "tidas-export",
-            "tidas-validate",
-            "tidas-release-tool",
-        ] {
-            assert!(!names.contains(&legacy));
+    match serde_json::to_value(engine_decision()) {
+        Ok(decision) => {
+            report.summary.insert("xml_engine".to_owned(), decision);
+        }
+        Err(error) => {
+            return OperationReportV1::failed(
+                CommandNameV1::Version,
+                ExitClass::Internal,
+                "xml_engine_contract_failed",
+                error.to_string(),
+            );
         }
     }
-
-    #[test]
-    fn human_output_is_result_first_and_next_action_last() {
-        let report =
-            OperationReportV1::unavailable("validate", "Run the tracked validation slice.");
-        let output = human_report(&report);
-        assert!(output.starts_with("tidas validate\n\nSummary:"));
-        assert!(output.ends_with("- Run the tracked validation slice.\n"));
-    }
+    report.next_actions.push(
+        "Run `tidas --help` to inspect the stable command tree; functional slices are tracked under tidas-tools#117."
+            .to_owned(),
+    );
+    report
 }

--- a/crates/tidas-cli/src/output.rs
+++ b/crates/tidas-cli/src/output.rs
@@ -1,0 +1,122 @@
+use std::fmt::Write as _;
+use std::fs;
+use std::io::{self, Write};
+use std::path::Path;
+
+use tidas_contracts::OperationReportV1;
+
+use crate::args::{Cli, OutputFormat};
+
+pub fn render(cli: &Cli, report: &OperationReportV1) -> io::Result<()> {
+    let bytes = match cli.format {
+        OutputFormat::Json => report.to_canonical_json_line().map_err(io::Error::other)?,
+        OutputFormat::Human => human_report(report).into_bytes(),
+    };
+    if let Some(path) = &cli.report {
+        write_atomic(path, &bytes)?;
+        writeln!(
+            io::stderr().lock(),
+            "wrote {} report to {}",
+            report.command.as_str(),
+            path.display()
+        )?;
+    } else {
+        io::stdout().lock().write_all(&bytes)?;
+    }
+    Ok(())
+}
+
+fn human_report(report: &OperationReportV1) -> String {
+    let mut output = format!(
+        "tidas {}\n\nSummary:\n- status: {}\n- exit class: {}\n- completeness: {}\n",
+        report.command.as_str(),
+        enum_name(report.status),
+        enum_name(report.exit_class),
+        enum_name(report.completeness),
+    );
+    for (key, value) in &report.summary {
+        writeln!(&mut output, "- {key}: {}", human_value(value))
+            .expect("writing to a String cannot fail");
+    }
+    for diagnostic in &report.diagnostics {
+        writeln!(&mut output, "- {}: {}", diagnostic.code, diagnostic.message)
+            .expect("writing to a String cannot fail");
+    }
+    if let Some(invocation) = &report.invocation {
+        output.push_str("\nRuntime:\n");
+        writeln!(
+            &mut output,
+            "- memory budget: {} bytes",
+            invocation.memory_budget_bytes
+        )
+        .expect("writing to a String cannot fail");
+        writeln!(
+            &mut output,
+            "- queue capacity: {}",
+            invocation.queue_capacity
+        )
+        .expect("writing to a String cannot fail");
+        writeln!(
+            &mut output,
+            "- config source: {}",
+            enum_name(invocation.config_source)
+        )
+        .expect("writing to a String cannot fail");
+    }
+    if !report.artifacts.is_empty() {
+        output.push_str("\nArtifacts:\n");
+        for artifact in &report.artifacts {
+            writeln!(&mut output, "- {} ({})", artifact.path, artifact.media_type)
+                .expect("writing to a String cannot fail");
+        }
+    }
+    if !report.next_actions.is_empty() {
+        output.push_str("\nNext:\n");
+        for action in &report.next_actions {
+            writeln!(&mut output, "- {action}").expect("writing to a String cannot fail");
+        }
+    }
+    output
+}
+
+fn enum_name<T: serde::Serialize>(value: T) -> String {
+    serde_json::to_value(value)
+        .ok()
+        .and_then(|encoded| encoded.as_str().map(str::to_owned))
+        .unwrap_or_else(|| "unknown".to_owned())
+}
+
+fn human_value(value: &serde_json::Value) -> String {
+    value
+        .as_str()
+        .map_or_else(|| value.to_string(), str::to_owned)
+}
+
+fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "report path needs a file name")
+        })?;
+    let temporary = path.with_file_name(format!(".{file_name}.tmp"));
+    fs::write(&temporary, bytes)?;
+    fs::rename(temporary, path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidas_contracts::{CommandNameV1, OperationReportV1};
+
+    #[test]
+    fn human_output_is_result_first_and_next_action_last() {
+        let report = OperationReportV1::unavailable(
+            CommandNameV1::Validate,
+            "Run the tracked validation slice.",
+        );
+        let output = human_report(&report);
+        assert!(output.starts_with("tidas validate\n\nSummary:"));
+        assert!(output.ends_with("- Run the tracked validation slice.\n"));
+    }
+}

--- a/crates/tidas-cli/tests/cli_contract.rs
+++ b/crates/tidas-cli/tests/cli_contract.rs
@@ -1,13 +1,35 @@
+use std::fs;
 use std::process::Command;
 
+use tidas_contracts::{CommandNameV1, DiagnosticV1, OperationReportV1};
+
+const TIDAS_ENVIRONMENT: &[&str] = &[
+    "TIDAS_CONFIG",
+    "TIDAS_LOG",
+    "TIDAS_PROGRESS",
+    "TIDAS_MEMORY_BUDGET_MIB",
+    "TIDAS_QUEUE_CAPACITY",
+];
+
 fn tidas() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_tidas"))
+    let mut command = Command::new(env!("CARGO_BIN_EXE_tidas"));
+    for variable in TIDAS_ENVIRONMENT {
+        command.env_remove(variable);
+    }
+    command
+}
+
+fn json_output(args: &[&str]) -> (std::process::Output, serde_json::Value) {
+    let output = tidas().args(args).output().unwrap();
+    let payload = serde_json::from_slice(&output.stdout).unwrap();
+    (output, payload)
 }
 
 #[test]
-fn help_exposes_only_the_unified_command_tree() {
+fn help_exposes_the_unified_command_and_runtime_contract() {
     let output = tidas().arg("--help").output().unwrap();
     assert!(output.status.success());
+    assert!(output.stderr.is_empty());
     let stdout = String::from_utf8(output.stdout).unwrap();
     for command in [
         "convert", "import", "export", "validate", "release", "ruleset", "version",
@@ -17,7 +39,22 @@ fn help_exposes_only_the_unified_command_tree() {
             "{command} missing from:\n{stdout}"
         );
     }
+    for option in [
+        "--format",
+        "--report",
+        "--config",
+        "--log-level",
+        "--progress",
+        "--memory-budget-mib",
+        "--queue-capacity",
+        "--completion",
+    ] {
+        assert!(stdout.contains(option), "{option} missing from:\n{stdout}");
+    }
+    assert!(stdout.contains("No configuration file is loaded implicitly"));
+    assert!(stdout.contains("Stdout contains only"));
     for legacy in [
+        "\n  help ",
         "tidas-convert",
         "tidas-import",
         "tidas-export",
@@ -29,7 +66,23 @@ fn help_exposes_only_the_unified_command_tree() {
 }
 
 #[test]
-fn version_json_is_stable_and_parseable() {
+fn every_product_command_has_discoverable_help() {
+    for command in [
+        "convert", "import", "export", "validate", "release", "ruleset", "version",
+    ] {
+        let output = tidas().args([command, "--help"]).output().unwrap();
+        assert!(output.status.success(), "{command}");
+        assert!(output.stderr.is_empty(), "{command}");
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(
+            stdout.contains(&format!("Usage: tidas {command}")),
+            "{stdout}"
+        );
+    }
+}
+
+#[test]
+fn version_json_is_stable_parseable_and_context_complete() {
     let first = tidas()
         .args(["version", "--format", "json"])
         .output()
@@ -41,30 +94,238 @@ fn version_json_is_stable_and_parseable() {
     assert!(first.status.success());
     assert!(first.stderr.is_empty());
     assert_eq!(first.stdout, second.stdout);
+    let typed: OperationReportV1 = serde_json::from_slice(&first.stdout).unwrap();
+    assert_eq!(typed.command, CommandNameV1::Version);
     let payload: serde_json::Value = serde_json::from_slice(&first.stdout).unwrap();
     assert_eq!(payload["schema_version"], "tidas.operation-report.v1");
+    assert_eq!(
+        payload["invocation"]["schema_version"],
+        "tidas.invocation-context.v1"
+    );
     assert_eq!(payload["exit_class"], "success");
+    assert_eq!(payload["invocation"]["config_source"], "none");
+    assert_eq!(
+        payload["invocation"]["memory_budget_bytes"],
+        512 * 1024 * 1024
+    );
+    assert_eq!(payload["invocation"]["queue_capacity"], 256);
+    assert_eq!(
+        payload["invocation"]["input_policy"],
+        "explicit-path-or-dash"
+    );
+    assert_eq!(payload["invocation"]["report_destination"], "stdout");
+    assert_eq!(payload["invocation"]["diagnostic_destination"], "stderr");
     assert!(payload["summary"]["asset_count"].as_u64().unwrap() >= 79);
 }
 
 #[test]
-fn unmigrated_command_fails_without_python_fallback() {
+fn cli_options_override_environment_and_environment_overrides_defaults() {
     let output = tidas()
-        .args(["validate", "--format", "json"])
+        .env("TIDAS_CONFIG", "environment.toml")
+        .env("TIDAS_LOG", "info")
+        .env("TIDAS_PROGRESS", "always")
+        .env("TIDAS_MEMORY_BUDGET_MIB", "256")
+        .env("TIDAS_QUEUE_CAPACITY", "32")
+        .args([
+            "version",
+            "--format",
+            "json",
+            "--config",
+            "command.toml",
+            "--log-level",
+            "debug",
+            "--progress",
+            "never",
+            "--memory-budget-mib",
+            "384",
+            "--queue-capacity",
+            "48",
+        ])
         .output()
         .unwrap();
-    assert_eq!(output.status.code(), Some(69));
-    assert!(output.stderr.is_empty());
+    assert!(output.status.success());
     let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(payload["exit_class"], "unavailable");
-    assert_eq!(payload["completeness"], "not-started");
+    let invocation = &payload["invocation"];
+    assert_eq!(invocation["config_source"], "cli");
+    assert_eq!(invocation["config_path"], "command.toml");
+    assert_eq!(invocation["log_level"], "debug");
+    assert_eq!(invocation["progress_mode"], "never");
+    assert_eq!(invocation["progress_enabled"], false);
+    assert_eq!(invocation["memory_budget_bytes"], 384 * 1024 * 1024);
+    assert_eq!(invocation["queue_capacity"], 48);
+
+    let (_, environment_payload) = json_output(&["version", "--format", "json"]);
+    assert_eq!(environment_payload["invocation"]["config_source"], "none");
+}
+
+#[test]
+fn environment_config_is_explicitly_reported() {
+    let output = tidas()
+        .env("TIDAS_CONFIG", "environment.toml")
+        .args(["version", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["invocation"]["config_source"], "environment");
+    assert_eq!(payload["invocation"]["config_path"], "environment.toml");
+}
+
+#[test]
+fn report_file_keeps_stdout_clean_and_records_the_destination() {
+    let directory = tempfile::tempdir().unwrap();
+    let report_path = directory.path().join("version.json");
+    let output = tidas()
+        .args([
+            "version",
+            "--format",
+            "json",
+            "--report",
+            report_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8(output.stderr)
+            .unwrap()
+            .contains("wrote version report")
+    );
+    let payload: serde_json::Value =
+        serde_json::from_slice(&fs::read(report_path).unwrap()).unwrap();
+    assert_eq!(payload["invocation"]["report_destination"], "file");
+}
+
+#[test]
+fn completion_scripts_are_deterministic_and_do_not_add_a_product_command() {
+    for shell in ["bash", "elvish", "fish", "powershell", "zsh"] {
+        let first = tidas().args(["--completion", shell]).output().unwrap();
+        let second = tidas().args(["--completion", shell]).output().unwrap();
+        assert!(first.status.success(), "{shell}");
+        assert!(first.stderr.is_empty(), "{shell}");
+        assert_eq!(first.stdout, second.stdout, "{shell}");
+        assert!(!first.stdout.is_empty(), "{shell}");
+    }
+}
+
+#[test]
+fn unavailable_commands_return_a_machine_report_without_python_fallback() {
+    for command in [
+        "convert", "import", "export", "validate", "release", "ruleset",
+    ] {
+        let (output, payload) = json_output(&[command, "--format", "json"]);
+        assert_eq!(output.status.code(), Some(69), "{command}");
+        assert!(output.stderr.is_empty(), "{command}");
+        assert_eq!(payload["command"], command);
+        assert_eq!(payload["exit_class"], "unavailable");
+        assert_eq!(payload["completeness"], "not-started");
+        assert_eq!(payload["diagnostics"][0]["code"], "feature_not_migrated");
+    }
 }
 
 #[test]
 fn malformed_usage_is_actionable_and_uses_the_usage_exit_class() {
-    let output = tidas().arg("unknown").output().unwrap();
-    assert_eq!(output.status.code(), Some(64));
-    let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("unrecognized subcommand"));
-    assert!(stderr.contains("--help"));
+    for args in [
+        vec![],
+        vec!["unknown"],
+        vec!["--memory-budget-mib", "0", "version"],
+        vec!["--queue-capacity", "0", "version"],
+        vec!["--completion", "bash", "version"],
+        vec!["--completion", "bash", "--report", "completion.txt"],
+    ] {
+        let output = tidas().args(args).output().unwrap();
+        assert_eq!(output.status.code(), Some(64));
+        let stderr = String::from_utf8(output.stderr).unwrap();
+        assert!(stderr.contains("Usage:") || stderr.contains("try '--help'"));
+    }
+}
+
+#[test]
+fn io_failures_use_the_io_exit_class() {
+    let directory = tempfile::tempdir().unwrap();
+    let missing_parent = directory.path().join("missing").join("report.json");
+    let output = tidas()
+        .args([
+            "version",
+            "--format",
+            "json",
+            "--report",
+            missing_parent.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(74));
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8(output.stderr)
+            .unwrap()
+            .contains("failed to render its report")
+    );
+}
+
+#[test]
+fn migration_parity_fixture_matches_the_rust_surface() {
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/cli-parity-v1.json")).unwrap();
+    assert_eq!(fixture["schema_version"], "tidas.cli-parity.v1");
+    for case in fixture["command_cases"].as_array().unwrap() {
+        let args: Vec<_> = case["rust_args"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_str().unwrap())
+            .collect();
+        let output = tidas().args(args).output().unwrap();
+        let expected_exit_code =
+            i32::try_from(case["expected_exit_code"].as_i64().unwrap()).unwrap();
+        assert_eq!(
+            output.status.code(),
+            Some(expected_exit_code),
+            "{}",
+            case["name"]
+        );
+        if let Some(exit_class) = case["expected_exit_class"].as_str() {
+            let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+            assert_eq!(payload["exit_class"], exit_class, "{}", case["name"]);
+            assert_eq!(
+                payload["completeness"], case["expected_completeness"],
+                "{}",
+                case["name"]
+            );
+        }
+    }
+    for case in fixture["contract_cases"].as_array().unwrap() {
+        let report = OperationReportV1::completed_with_issues(
+            CommandNameV1::Validate,
+            DiagnosticV1::new(
+                case["diagnostic_code"].as_str().unwrap(),
+                "The frozen Python oracle reported a data issue.",
+            ),
+        );
+        let payload: serde_json::Value =
+            serde_json::from_slice(&report.to_canonical_json_line().unwrap()).unwrap();
+        assert_eq!(payload["command"], case["command"], "{}", case["name"]);
+        assert_eq!(
+            payload["status"], case["expected_status"],
+            "{}",
+            case["name"]
+        );
+        assert_eq!(
+            payload["exit_class"], case["expected_exit_class"],
+            "{}",
+            case["name"]
+        );
+        assert_eq!(
+            payload["completeness"], case["expected_completeness"],
+            "{}",
+            case["name"]
+        );
+        assert_eq!(
+            report.exit_class.code(),
+            u8::try_from(case["expected_exit_code"].as_u64().unwrap()).unwrap(),
+            "{}",
+            case["name"]
+        );
+    }
 }

--- a/crates/tidas-cli/tests/cli_contract.rs
+++ b/crates/tidas-cli/tests/cli_contract.rs
@@ -74,8 +74,9 @@ fn every_product_command_has_discoverable_help() {
         assert!(output.status.success(), "{command}");
         assert!(output.stderr.is_empty(), "{command}");
         let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(stdout.contains("Usage:"), "{stdout}");
         assert!(
-            stdout.contains(&format!("Usage: tidas {command}")),
+            stdout.contains(&format!(" {command} [OPTIONS]")),
             "{stdout}"
         );
     }

--- a/crates/tidas-cli/tests/fixtures/cli-parity-v1.json
+++ b/crates/tidas-cli/tests/fixtures/cli-parity-v1.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "tidas.cli-parity.v1",
+  "purpose": "Freeze Python-era semantic expectations while the unified Rust CLI replaces the legacy entry points. Arguments are intentionally the new Rust surface; parity is semantic, not command-name or flag-layout compatibility.",
+  "command_cases": [
+    {
+      "name": "successful deterministic introspection",
+      "python_oracle": "Legacy describe/version-style commands returned machine-readable tool and asset identity without changing data.",
+      "rust_args": ["version", "--format", "json"],
+      "expected_exit_code": 0,
+      "expected_exit_class": "success",
+      "expected_completeness": "complete"
+    },
+    {
+      "name": "known function not yet migrated",
+      "python_oracle": "A known tool family is distinguishable from malformed invocation; migration never silently falls back to Python.",
+      "rust_args": ["validate", "--format", "json"],
+      "expected_exit_code": 69,
+      "expected_exit_class": "unavailable",
+      "expected_completeness": "not-started"
+    },
+    {
+      "name": "malformed invocation",
+      "python_oracle": "Malformed command input exits non-zero and prints actionable usage guidance.",
+      "rust_args": ["unknown"],
+      "expected_exit_code": 64,
+      "expected_exit_class": null,
+      "expected_completeness": null
+    }
+  ],
+  "contract_cases": [
+    {
+      "name": "completed validation with data warnings",
+      "python_oracle": "Legacy validation distinguished completed data findings from protocol or runtime failure.",
+      "command": "validate",
+      "diagnostic_code": "fixture_warning",
+      "expected_status": "completed-with-issues",
+      "expected_exit_code": 2,
+      "expected_exit_class": "data-issues",
+      "expected_completeness": "complete"
+    }
+  ]
+}

--- a/crates/tidas-contracts/src/lib.rs
+++ b/crates/tidas-contracts/src/lib.rs
@@ -7,8 +7,36 @@ use thiserror::Error;
 
 pub const OPERATION_REPORT_SCHEMA_V1: &str = "tidas.operation-report.v1";
 pub const DIAGNOSTIC_SCHEMA_V1: &str = "tidas.diagnostic.v1";
+pub const INVOCATION_CONTEXT_SCHEMA_V1: &str = "tidas.invocation-context.v1";
 pub const OPERATION_REPORT_JSON_SCHEMA_V1: &str =
     include_str!("../../../contracts/operation-report.v1.schema.json");
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CommandNameV1 {
+    Convert,
+    Import,
+    Export,
+    Validate,
+    Release,
+    Ruleset,
+    Version,
+}
+
+impl CommandNameV1 {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Convert => "convert",
+            Self::Import => "import",
+            Self::Export => "export",
+            Self::Validate => "validate",
+            Self::Release => "release",
+            Self::Ruleset => "ruleset",
+            Self::Version => "version",
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -54,6 +82,67 @@ pub enum Completeness {
     NotStarted,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ConfigSourceV1 {
+    None,
+    Environment,
+    Cli,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LogLevelV1 {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProgressModeV1 {
+    Auto,
+    Never,
+    Always,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReportDestinationV1 {
+    Stdout,
+    File,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum InputPolicyV1 {
+    ExplicitPathOrDash,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DiagnosticDestinationV1 {
+    Stderr,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InvocationContextV1 {
+    pub schema_version: String,
+    pub config_source: ConfigSourceV1,
+    pub config_path: Option<String>,
+    pub log_level: LogLevelV1,
+    pub progress_mode: ProgressModeV1,
+    pub progress_enabled: bool,
+    pub memory_budget_bytes: u64,
+    pub queue_capacity: usize,
+    pub input_policy: InputPolicyV1,
+    pub report_destination: ReportDestinationV1,
+    pub diagnostic_destination: DiagnosticDestinationV1,
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ArtifactRefV1 {
@@ -90,10 +179,12 @@ impl DiagnosticV1 {
 #[serde(deny_unknown_fields)]
 pub struct OperationReportV1 {
     pub schema_version: String,
-    pub command: String,
+    pub command: CommandNameV1,
     pub status: OperationStatus,
     pub exit_class: ExitClass,
     pub completeness: Completeness,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invocation: Option<InvocationContextV1>,
     pub summary: BTreeMap<String, serde_json::Value>,
     pub diagnostics: Vec<DiagnosticV1>,
     pub artifacts: Vec<ArtifactRefV1>,
@@ -102,13 +193,14 @@ pub struct OperationReportV1 {
 
 impl OperationReportV1 {
     #[must_use]
-    pub fn succeeded(command: impl Into<String>) -> Self {
+    pub fn succeeded(command: CommandNameV1) -> Self {
         Self {
             schema_version: OPERATION_REPORT_SCHEMA_V1.to_owned(),
-            command: command.into(),
+            command,
             status: OperationStatus::Succeeded,
             exit_class: ExitClass::Success,
             completeness: Completeness::Complete,
+            invocation: None,
             summary: BTreeMap::new(),
             diagnostics: Vec::new(),
             artifacts: Vec::new(),
@@ -117,7 +209,7 @@ impl OperationReportV1 {
     }
 
     #[must_use]
-    pub fn unavailable(command: impl Into<String>, next_action: impl Into<String>) -> Self {
+    pub fn unavailable(command: CommandNameV1, next_action: impl Into<String>) -> Self {
         let mut report = Self::succeeded(command);
         report.status = OperationStatus::Failed;
         report.exit_class = ExitClass::Unavailable;
@@ -128,6 +220,49 @@ impl OperationReportV1 {
         ));
         report.next_actions.push(next_action.into());
         report
+    }
+
+    #[must_use]
+    pub fn completed_with_issues(command: CommandNameV1, diagnostic: DiagnosticV1) -> Self {
+        let mut report = Self::succeeded(command);
+        report.status = OperationStatus::CompletedWithIssues;
+        report.exit_class = ExitClass::DataIssues;
+        report.diagnostics.push(diagnostic);
+        report
+    }
+
+    #[must_use]
+    pub fn failed(
+        command: CommandNameV1,
+        exit_class: ExitClass,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        let mut report = Self::succeeded(command);
+        report.status = OperationStatus::Failed;
+        report.exit_class = exit_class;
+        report.completeness = Completeness::NotStarted;
+        report.diagnostics.push(DiagnosticV1::new(code, message));
+        report
+    }
+
+    #[must_use]
+    pub fn cancelled(command: CommandNameV1) -> Self {
+        let mut report = Self::failed(
+            command,
+            ExitClass::Cancelled,
+            "operation_cancelled",
+            "The operation was cancelled before completion.",
+        );
+        report.status = OperationStatus::Cancelled;
+        report.completeness = Completeness::Partial;
+        report
+    }
+
+    #[must_use]
+    pub fn with_invocation(mut self, invocation: InvocationContextV1) -> Self {
+        self.invocation = Some(invocation);
+        self
     }
 
     pub fn to_canonical_json_line(&self) -> Result<Vec<u8>, ContractError> {
@@ -169,7 +304,7 @@ mod tests {
 
     #[test]
     fn canonical_json_is_repeatable_and_lf_terminated() {
-        let mut report = OperationReportV1::succeeded("version");
+        let mut report = OperationReportV1::succeeded(CommandNameV1::Version);
         report.summary.insert("b".to_owned(), serde_json::json!(2));
         report.summary.insert("a".to_owned(), serde_json::json!(1));
 
@@ -190,6 +325,7 @@ mod tests {
             "status": "succeeded",
             "exit_class": "success",
             "completeness": "complete",
+            "invocation": null,
             "summary": {},
             "diagnostics": [],
             "artifacts": [],
@@ -211,6 +347,55 @@ mod tests {
             schema["$defs"]["diagnostic"]["properties"]["schema_version"]["const"],
             DIAGNOSTIC_SCHEMA_V1
         );
+        assert_eq!(
+            schema["$defs"]["invocation"]["properties"]["schema_version"]["const"],
+            INVOCATION_CONTEXT_SCHEMA_V1
+        );
+        assert_eq!(
+            schema["properties"]["command"]["enum"]
+                .as_array()
+                .map(Vec::len),
+            Some(7)
+        );
+        assert!(
+            !schema["required"]
+                .as_array()
+                .unwrap()
+                .contains(&serde_json::json!("invocation")),
+            "invocation remains additive for pre-#119 v1 embedders"
+        );
         assert_eq!(schema["additionalProperties"], false);
+    }
+
+    #[test]
+    fn command_names_are_the_seven_product_commands() {
+        let names = [
+            CommandNameV1::Convert,
+            CommandNameV1::Import,
+            CommandNameV1::Export,
+            CommandNameV1::Validate,
+            CommandNameV1::Release,
+            CommandNameV1::Ruleset,
+            CommandNameV1::Version,
+        ]
+        .map(CommandNameV1::as_str);
+        assert_eq!(
+            names,
+            [
+                "convert", "import", "export", "validate", "release", "ruleset", "version"
+            ]
+        );
+    }
+
+    #[test]
+    fn completed_with_issues_is_complete_but_nonzero() {
+        let report = OperationReportV1::completed_with_issues(
+            CommandNameV1::Validate,
+            DiagnosticV1::new("fixture_warning", "The oracle reported a data issue."),
+        );
+        assert_eq!(report.status, OperationStatus::CompletedWithIssues);
+        assert_eq!(report.exit_class, ExitClass::DataIssues);
+        assert_eq!(report.completeness, Completeness::Complete);
+        assert_eq!(report.exit_class.code(), 2);
     }
 }

--- a/docs/agents/cli-contract.md
+++ b/docs/agents/cli-contract.md
@@ -1,0 +1,159 @@
+---
+title: Unified tidas CLI Contract
+docType: contract
+scope: repo
+status: active
+authoritative: true
+owner: tidas-tools
+language: en
+whenToUse:
+  - when adding or changing a tidas command, global option, output mode, exit class, or completion script
+  - when a downstream system parses tidas JSON or invokes the executable
+  - when deciding whether a behavior belongs in the CLI adapter or a reusable domain crate
+whenToUpdate:
+  - when the public command tree, invocation context, configuration precedence, output channels, or runtime controls change
+checkPaths:
+  - docs/agents/cli-contract.md
+  - Cargo.toml
+  - Cargo.lock
+  - crates/tidas-cli/**
+  - crates/tidas-contracts/**
+  - crates/tidas-runtime/**
+  - contracts/**
+  - README.md
+  - README_CN.md
+lastReviewedAt: 2026-07-25
+lastReviewedCommit: 8e0a5e39342403c8b38da530ff3c776fd729765e
+lastReviewedNote: "Issue #119 defines the unified command, invocation, output, completion, cancellation, and bounded-runtime contract."
+related:
+  - ../../AGENTS.md
+  - ../../.docpact/config.yaml
+  - ./repo-architecture.md
+  - ./repo-validation.md
+  - ../../contracts/operation-report.v1.schema.json
+---
+
+# Unified `tidas` CLI Contract
+
+## Product surface
+
+The product ships one executable, `tidas`, with exactly seven top-level
+commands:
+
+- `convert`
+- `import`
+- `export`
+- `validate`
+- `release`
+- `ruleset`
+- `version`
+
+Shell completion generation is a global action, not an eighth command:
+
+```bash
+tidas --completion bash > tidas.bash
+```
+
+The old Python executable names are not aliases. An incomplete Rust functional
+slice returns `unavailable` (69) and never invokes Python.
+
+## Adapter boundary
+
+`crates/tidas-cli` owns parsing, configuration selection, invocation context,
+process cancellation wiring, output routing, help, and completions. It does
+not own conversion, import, export, validation, release, or ruleset domain
+logic. Functional commands receive a cancellation token, an explicit memory
+budget, a bounded queue capacity, and typed inputs before calling reusable
+domain crates.
+
+## Configuration precedence
+
+The deterministic precedence order is:
+
+1. explicit command-line option
+2. matching `TIDAS_*` environment variable
+3. documented built-in default
+
+The runtime never searches the current directory or a home directory for an
+implicit configuration file. `--config <PATH>` overrides `TIDAS_CONFIG`.
+Configuration selection is recorded in `tidas.invocation-context.v1`.
+
+| Option | Environment | Default |
+| --- | --- | --- |
+| `--config <PATH>` | `TIDAS_CONFIG` | none |
+| `--log-level <LEVEL>` | `TIDAS_LOG` | `warn` |
+| `--progress <MODE>` | `TIDAS_PROGRESS` | `auto` |
+| `--memory-budget-mib <MIB>` | `TIDAS_MEMORY_BUDGET_MIB` | `512` |
+| `--queue-capacity <COUNT>` | `TIDAS_QUEUE_CAPACITY` | `256` |
+
+Zero memory budgets and queue capacities are usage errors.
+
+## Streams and files
+
+- stdin is used only when a future functional command explicitly receives `-`
+  in a documented input option; it is never selected implicitly.
+- stdout contains exactly one human report, one canonical JSON report, or one
+  completion script.
+- logs, progress, diagnostics outside a completed report, and file-write
+  confirmations use stderr.
+- `--report <PATH>` writes the complete report to a temporary sibling and then
+  renames it into place; stdout remains empty.
+- future command-owned large artifacts use command-specific `--output` options,
+  so the global report path intentionally uses `--report`.
+- JSON mode never mixes logs, banners, or progress with stdout.
+
+`--progress auto` enables progress only for human output attached to a terminal.
+No current placeholder command emits progress.
+
+## Machine contracts
+
+`tidas.operation-report.v1` is the F3 envelope for every completed command
+dispatch. Its optional `invocation` member is
+`tidas.invocation-context.v1` and records:
+
+- configuration source and selected path
+- log and progress policy
+- resolved progress enablement
+- memory budget in bytes
+- bounded queue capacity
+- explicit-path-or-dash input policy
+- report and diagnostic destinations
+
+The report envelope, command names, diagnostics, artifacts, completeness, and
+exit classes are F3 versioned contracts. The ordered `summary` object remains
+an F2 extension point while individual domain slices are still discovering
+their stable projections. Fields may be added compatibly; removal or semantic
+change requires a new schema version.
+
+Canonical JSON is UTF-8, LF-terminated, deterministic for identical inputs,
+and contains no implicit timestamps, locale values, or unordered collections.
+
+## Exit classes
+
+| Class | Code | Meaning |
+| --- | ---: | --- |
+| `success` | 0 | operation completed successfully |
+| `data-issues` | 2 | operation completed and found domain data issues |
+| `usage` | 64 | command syntax or option value is invalid |
+| `unavailable` | 69 | known Rust function is not yet available |
+| `internal` | 70 | invariant, setup, or internal serialization failed |
+| `io` | 74 | report or required I/O failed |
+| `cancelled` | 130 | shared cancellation token stopped the operation |
+
+Clap usage/help text is written to stderr for malformed invocation. Successful
+help, version flags, and completion generation exit zero.
+
+## Validation contract
+
+Public CLI changes must prove:
+
+- exactly seven top-level product commands and no legacy aliases
+- help for the root and every product command
+- deterministic completions for Bash, Elvish, Fish, PowerShell, and Zsh
+- configuration precedence and invocation-context fields
+- clean stdout for JSON, report-file, and completion modes
+- deterministic repeated JSON
+- all affected exit classes
+- migration parity fixtures whose semantics are sourced from the frozen Python
+  oracle without preserving legacy command names or flag layouts
+- Rust 1.88 fmt, clippy, tests, and the five-platform CI matrix

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -33,10 +33,11 @@ checkPaths:
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-25
 lastReviewedCommit: 1dd24944f3f076864121b7cb3eda7f3e184099e5
-lastReviewedNote: "Issue #118 establishes the Rust foundation, executable-asset lock, and XML portability boundary for the staged #117 migration."
+lastReviewedNote: "Issue #119 adds the stable unified CLI invocation, stream, completion, and bounded-runtime adapter contract."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
+  - ./cli-contract.md
   - ./repo-validation.md
   - ../../README.md
 ---
@@ -57,6 +58,7 @@ until all #117 exit gates pass.
 | `crates/tidas-assets` | offline executable-asset embedding, classification, integrity checking, and fingerprinting |
 | `crates/tidas-xml` | strict streaming XML inspection plus the compatibility boundary to XSD/XSLT engines |
 | `crates/tidas-cli` | the single `tidas` binary, final command tree, output routing, and thin domain dispatch |
+| `docs/agents/cli-contract.md` | authoritative command, configuration precedence, stream, completion, invocation-context, and exit behavior |
 | `contracts/**` | checked-in JSON Schema for stable machine contracts |
 | `assets/asset-lock.v1.json` | exact path, kind, byte length, and SHA-256 ownership lock for every executable asset |
 | `.gitattributes` | LF checkout contract for byte-identical assets and machine contracts on every platform |
@@ -70,6 +72,13 @@ The command tree is fixed to `convert`, `import`, `export`, `validate`,
 `release`, `ruleset`, and `version`. No old executable alias or Python fallback
 is present. Until a domain slice lands, its Rust command returns the stable
 `unavailable` exit class (69).
+
+The CLI records the resolved configuration source, log/progress policy, memory
+budget, queue capacity, and I/O policy in `tidas.invocation-context.v1`.
+Configuration never depends on an implicit working-directory file. Completion
+scripts are generated with `tidas --completion <shell>` without adding another
+product command. See `docs/agents/cli-contract.md` for the authoritative public
+behavior.
 
 ## Stable contract policy
 
@@ -109,7 +118,7 @@ Review note, 2026-07-17: Issue #112 remains inside the existing validation and r
 | Path group | Role |
 | --- | --- |
 | `Cargo.toml`, `Cargo.lock`, `crates/**` | Rust workspace and final product implementation |
-| `contracts/**` | stable machine-readable Rust contract schemas |
+| `contracts/**` | stable machine-readable Rust report, invocation, asset-lock, and spool contract schemas |
 | `assets/asset-lock.v1.json` | deterministic executable-asset ownership and integrity lock |
 | `.gitattributes` | cross-platform LF checkout normalization for hashed inputs |
 | `migration/**` | tracked migration inventory and ownership decisions |

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-25
 lastReviewedCommit: 1dd24944f3f076864121b7cb3eda7f3e184099e5
-lastReviewedNote: "Issue #118 adds Rust format/lint/test, asset-lock, XML spike, CLI contract, and five-platform CI proof while retaining the Python oracle gate."
+lastReviewedNote: "Issue #119 adds CLI help/completion/configuration/output-channel/parity contract proof while retaining the five-platform Rust and Python oracle gates."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -72,7 +72,7 @@ be removed only by the final #126 cutover.
 
 | Change type | Minimum local proof | Additional proof when risk is higher | Notes |
 | --- | --- | --- | --- |
-| Rust workspace, shared contracts, or CLI adapter | asset lock; Rust fmt/clippy/test; `cargo run -p tidas-cli --bin tidas -- --help`; deterministic `tidas --format json version` comparison | exercise structured usage failure and every affected exit class; validate JSON against the checked-in schema | The CLI remains thin and incomplete commands fail `unavailable` without invoking Python. |
+| Rust workspace, shared contracts, or CLI adapter | asset lock; Rust fmt/clippy/test; root and command help; deterministic `tidas --format json version` and completion comparisons | exercise configuration precedence, report-file/stdout separation, completion shells, migration parity fixture, structured usage failure, and every affected exit class; validate JSON against the checked-in schema | The CLI remains thin, follows `docs/agents/cli-contract.md`, and incomplete commands fail `unavailable` without invoking Python. |
 | `tidas-runtime` large-data primitives | Rust fmt/clippy/test including bounded queue, cancellation, memory-budget, and streaming spool tests | local large-package benchmark with elapsed time and peak RSS; never start on a Worker server | The target package is intentionally outside Git and issue counts must not cause linear memory growth. |
 | `tidas-assets`, `.gitattributes`, or executable assets | asset-lock check, Rust tests, Python schema lock, full pytest; verify `git check-attr eol` returns `lf` for representative JSON/XSD/XSL files | regenerate the asset lock only after intentional review; compare asset fingerprint twice | The Rust asset lock covers more executable inputs than the legacy paired-schema lock; LF checkout and both lock gates remain during migration. |
 | `tidas-xml` or native dependency workflow | focused `cargo test -p tidas-xml`; full Rust checks; all five CI matrix jobs | representative production XSD/XSLT fixtures; controlled static release-link proof and resolver security tests | `quick-xml` is the streaming reader; libxml2/libxslt native calls are serialized. |


### PR DESCRIPTION
Closes tiangong-lca/tidas-tools#119

## Summary
- Finalize the single tidas command surface, global runtime options, deterministic shell completion generation, and thin domain dispatch.
- Add the versioned invocation context to canonical operation reports while preserving the ordered summary map as an additive domain extension point.

## Key Decisions
- Keep exactly seven top-level product commands; expose completion as a global action and disable clap's implicit help subcommand.
- Use CLI > TIDAS_* environment > built-in default precedence with no implicit current-directory configuration.
- Reserve stdout for a report or completion script, use --report for durable envelopes, and leave command-specific --output paths available to future domain crates.

## Validation
- Rust 1.88 fmt, clippy -D warnings, and all workspace tests passed, including 11 CLI integration tests and 36 Rust tests total.
- Operation-report JSON Schema validation, deterministic help/version/completion probes, asset lock, and docpact strict/staged gates passed.
- Frozen Python oracle gates passed: 18 schema pairs, Black 57 files unchanged, and 168 pytest tests.

## Risks / Rollback
- The new invocation member is optional in operation-report.v1 for additive compatibility; CLI outputs always populate it. Domain commands remain unavailable/69 until #120-#124 land.

## Follow-ups
- Implement native validation in #120 and the remaining functional slices in #121-#124; packaging and cutover remain #125-#126.

## Workspace Integration
- Workspace Integration stays Pending until the qualified Rust release and lca-workspace#485 cutover.