### PR TITLE
feat: build reproducible native tidas distributions

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-26"
-lastReviewedCommit: "9908cab"
+lastReviewedCommit: "84dc90f"
 # Native Rust domain ownership includes bounded conversion, import, export,
 # release packaging, validation, references, rulesets, assets, runtime, and
 # the thin unified CLI.
@@ -55,6 +55,16 @@ ownership:
           - src/tidas_tools/package_versions.py
           - src/tidas_tools/release.py
       ownerRepo: tidas-tools
+    - id: native-distribution
+      paths:
+        include:
+          - LICENSE
+          - crates/tidas-dist/**
+          - packaging/**
+          - scripts/install.sh
+          - scripts/install.ps1
+          - .github/workflows/rust-release.yml
+      ownerRepo: tidas-tools
     - id: packaged-assets
       paths:
         include:
@@ -92,6 +102,7 @@ coverage:
     - AGENTS.md
     - README.md
     - README_CN.md
+    - LICENSE
     - .gitattributes
     - .docpact/config.yaml
     - docs/agents/cli-contract.md
@@ -100,6 +111,7 @@ coverage:
     - Cargo.toml
     - Cargo.lock
     - crates/**
+    - packaging/**
     - contracts/**
     - assets/**
     - pyproject.toml
@@ -116,10 +128,13 @@ coverage:
     - src/tidas_tools/tidas/**
     - src/tidas_tools/eilcd/**
     - scripts/schema_lock.py
+    - scripts/install.sh
+    - scripts/install.ps1
     - tests/**
     - test_data/**
     - .github/workflows/ci.yml
     - .github/workflows/rust-ci.yml
+    - .github/workflows/rust-release.yml
     - .github/workflows/ai-doc-lint.yml
     - .github/workflows/dispatch-tidas-sdk-sync.yml
     - .github/workflows/python-package-deploy.yml
@@ -235,6 +250,14 @@ routing:
         - src/tidas_tools/validate.py
         - src/tidas_tools/tidas/**
         - src/tidas_tools/eilcd/**
+    native-distribution:
+      paths:
+        - LICENSE
+        - crates/tidas-dist/**
+        - packaging/**
+        - scripts/install.sh
+        - scripts/install.ps1
+        - .github/workflows/rust-release.yml
     packaged-assets:
       paths:
         - assets/**
@@ -252,6 +275,11 @@ routing:
         - Cargo.toml
         - Cargo.lock
         - .github/workflows/rust-ci.yml
+        - .github/workflows/rust-release.yml
+        - crates/tidas-dist/**
+        - packaging/**
+        - scripts/install.sh
+        - scripts/install.ps1
         - pyproject.toml
         - .github/workflows/python-package-deploy.yml
     proof:
@@ -266,11 +294,14 @@ routing:
         - migration/**
         - pyproject.toml
         - scripts/schema_lock.py
+        - scripts/install.sh
+        - scripts/install.ps1
         - src/tidas_tools/**
         - tests/**
         - test_data/**
         - .github/workflows/ci.yml
         - .github/workflows/rust-ci.yml
+        - .github/workflows/rust-release.yml
         - .github/workflows/dispatch-tidas-sdk-sync.yml
         - .github/workflows/python-package-deploy.yml
     repo-docs:
@@ -282,6 +313,7 @@ routing:
         - .docpact/config.yaml
         - docs/agents/cli-contract.md
         - docs/agents/**
+        - packaging/README.md
         - migration/**
     root-integration:
       paths:
@@ -296,6 +328,7 @@ docInventory:
     - docs/agents/cli-contract.md
     - docs/agents/repo-validation.md
     - docs/agents/repo-architecture.md
+    - packaging/README.md
     - migration/python-to-rust-owners.md
 
 repo:
@@ -431,6 +464,8 @@ rules:
         kind: automation
       - path: .github/workflows/rust-ci.yml
         kind: automation
+      - path: .github/workflows/rust-release.yml
+        kind: release-automation
       - path: .github/workflows/dispatch-tidas-sdk-sync.yml
         kind: automation
       - path: .github/workflows/python-package-deploy.yml
@@ -445,6 +480,36 @@ rules:
       - path: docs/agents/repo-architecture.md
         mode: review_or_update
     reason: Test, fixture, release, and downstream dispatch changes affect future tooling validation and SDK refresh routing.
+  - id: tidas-tools-native-distribution-contract
+    scope: repo
+    repo: tidas-tools
+    triggers:
+      - path: LICENSE
+        kind: release-license
+      - path: crates/tidas-dist/**
+        kind: distribution-tooling
+      - path: packaging/**
+        kind: package-manager
+      - path: scripts/install.sh
+        kind: installer
+      - path: scripts/install.ps1
+        kind: installer
+      - path: .github/workflows/rust-release.yml
+        kind: release-automation
+    requiredDocs:
+      - path: AGENTS.md
+        mode: review_or_update
+      - path: .docpact/config.yaml
+        mode: review_or_update
+      - path: docs/agents/repo-validation.md
+        mode: review_or_update
+      - path: docs/agents/repo-architecture.md
+        mode: review_or_update
+      - path: README.md
+        mode: review_or_update
+      - path: README_CN.md
+        mode: review_or_update
+    reason: Native release artifacts, installers, and package-manager metadata must preserve one cross-platform, checksum-bound product distribution contract.
   - id: tidas-tools-doc-maintenance-contract
     scope: repo
     repo: tidas-tools

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,0 +1,380 @@
+name: Native Rust Release
+
+on:
+  pull_request:
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - crates/**
+      - assets/**
+      - LICENSE
+      - packaging/**
+      - scripts/install.sh
+      - scripts/install.ps1
+      - .github/workflows/rust-release.yml
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  VCPKG_COMMIT: 40f3c709db80acf154ac4b17a1f83c564ebd022e
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x86_64
+            runner: ubuntu-24.04
+            family: linux
+            target: x86_64-unknown-linux-gnu
+            vcpkg-triplet: x64-linux
+            executable: target/release/tidas
+          - name: Linux ARM64
+            runner: ubuntu-24.04-arm
+            family: linux
+            target: aarch64-unknown-linux-gnu
+            vcpkg-triplet: arm64-linux
+            executable: target/release/tidas
+          - name: macOS Intel
+            runner: macos-15-intel
+            family: macos
+            target: x86_64-apple-darwin
+            vcpkg-triplet: x64-osx
+            executable: target/release/tidas
+          - name: macOS Apple Silicon
+            runner: macos-15
+            family: macos
+            target: aarch64-apple-darwin
+            vcpkg-triplet: arm64-osx
+            executable: target/release/tidas
+          - name: Windows x86_64
+            runner: windows-2025
+            family: windows
+            target: x86_64-pc-windows-msvc
+            vcpkg-triplet: x64-windows-static-md
+            executable: target/release/tidas.exe
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
+        with:
+          toolchain: 1.88.0
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: native-release-${{ matrix.target }}
+
+      - name: Install pinned native XML dependencies
+        if: matrix.family != 'windows'
+        shell: bash
+        env:
+          TRIPLET: ${{ matrix.vcpkg-triplet }}
+        run: |
+          if [ "${{ matrix.family }}" = "linux" ]; then
+            sudo apt-get update
+            sudo apt-get install --yes pkg-config
+          else
+            brew install pkg-config
+          fi
+          git clone --filter=blob:none https://github.com/microsoft/vcpkg.git "$RUNNER_TEMP/vcpkg"
+          git -C "$RUNNER_TEMP/vcpkg" checkout "$VCPKG_COMMIT"
+          "$RUNNER_TEMP/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
+          "$RUNNER_TEMP/vcpkg/vcpkg" install \
+            --triplet "$TRIPLET" \
+            --x-manifest-root="$GITHUB_WORKSPACE/packaging/vcpkg"
+          {
+            echo "PKG_CONFIG_PATH=$RUNNER_TEMP/vcpkg/installed/$TRIPLET/lib/pkgconfig"
+            echo "LIBXML2_STATIC=1"
+            echo "LIBXSLT_STATIC=1"
+          } >> "$GITHUB_ENV"
+
+      - name: Install pinned native XML dependencies
+        if: matrix.family == 'windows'
+        shell: pwsh
+        env:
+          TRIPLET: ${{ matrix.vcpkg-triplet }}
+        run: |
+          git clone --filter=blob:none https://github.com/microsoft/vcpkg.git "$env:RUNNER_TEMP\vcpkg"
+          git -C "$env:RUNNER_TEMP\vcpkg" checkout $env:VCPKG_COMMIT
+          & "$env:RUNNER_TEMP\vcpkg\bootstrap-vcpkg.bat" -disableMetrics
+          & "$env:RUNNER_TEMP\vcpkg\vcpkg.exe" install `
+            --triplet $env:TRIPLET `
+            --x-manifest-root="$env:GITHUB_WORKSPACE\packaging\vcpkg"
+          "VCPKG_ROOT=$env:RUNNER_TEMP\vcpkg" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "VCPKGRS_TRIPLET=$env:TRIPLET" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Build exact native binary
+        shell: bash
+        run: |
+          SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)"
+          export SOURCE_DATE_EPOCH
+          echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH" >> "$GITHUB_ENV"
+          cargo build --locked --release -p tidas-cli --bin tidas
+
+      - name: Reject non-system runtime libraries
+        if: matrix.family == 'linux'
+        shell: bash
+        env:
+          EXECUTABLE: ${{ matrix.executable }}
+        run: |
+          dependencies="$(ldd "$EXECUTABLE")"
+          printf '%s\n' "$dependencies"
+          if printf '%s\n' "$dependencies" | grep -E 'libxml2|libxslt|libexslt|vcpkg|/home/runner'; then
+            echo "::error::release executable retains a build-machine native dependency"
+            exit 1
+          fi
+
+      - name: Reject non-system runtime libraries
+        if: matrix.family == 'macos'
+        shell: bash
+        env:
+          EXECUTABLE: ${{ matrix.executable }}
+        run: |
+          dependencies="$(otool -L "$EXECUTABLE")"
+          printf '%s\n' "$dependencies"
+          if printf '%s\n' "$dependencies" | grep -E 'libxml2|libxslt|libexslt'; then
+            echo "::error::release executable did not statically link the pinned XML toolchain"
+            exit 1
+          fi
+          if printf '%s\n' "$dependencies" | tail -n +2 | grep -Ev '^[[:space:]]+(/usr/lib/|/System/Library/)'; then
+            echo "::error::release executable retains a non-system native dependency"
+            exit 1
+          fi
+
+      - name: Package twice and verify exact bytes
+        id: package-unix
+        if: matrix.family != 'windows'
+        shell: bash
+        env:
+          EXECUTABLE: ${{ matrix.executable }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          version="$(cargo run --locked --release -p tidas-dist -- version)"
+          cargo run --locked --release -p tidas-dist -- package \
+            --binary "$EXECUTABLE" --license LICENSE --target "$TARGET" --output-dir dist/first
+          cargo run --locked --release -p tidas-dist -- package \
+            --binary "$EXECUTABLE" --license LICENSE --target "$TARGET" --output-dir dist/second
+          archive="tidas-v${version}-${TARGET}.tar.gz"
+          cmp "dist/first/$archive" "dist/second/$archive"
+          cmp "dist/first/$archive.sha256" "dist/second/$archive.sha256"
+          cargo run --locked --release -p tidas-dist -- verify \
+            --archive "dist/first/$archive" \
+            --checksum "dist/first/$archive.sha256" \
+            --target "$TARGET" --smoke
+          mkdir -p dist/upload
+          cp "dist/first/$archive" "dist/first/$archive.sha256" dist/upload/
+          echo "archive=dist/upload/$archive" >> "$GITHUB_OUTPUT"
+          echo "archive-name=$archive" >> "$GITHUB_OUTPUT"
+
+      - name: Package twice and verify exact bytes
+        id: package-windows
+        if: matrix.family == 'windows'
+        shell: pwsh
+        env:
+          EXECUTABLE: ${{ matrix.executable }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          $Version = cargo run --locked --release -p tidas-dist -- version
+          cargo run --locked --release -p tidas-dist -- package `
+            --binary $env:EXECUTABLE --license LICENSE --target $env:TARGET --output-dir dist/first
+          cargo run --locked --release -p tidas-dist -- package `
+            --binary $env:EXECUTABLE --license LICENSE --target $env:TARGET --output-dir dist/second
+          $Archive = "tidas-v$Version-$env:TARGET.zip"
+          $FirstHash = (Get-FileHash -Algorithm SHA256 "dist/first/$Archive").Hash
+          $SecondHash = (Get-FileHash -Algorithm SHA256 "dist/second/$Archive").Hash
+          if ($FirstHash -ne $SecondHash) { throw "Repeated archive bytes differ." }
+          if ((Get-Content -Raw "dist/first/$Archive.sha256") -ne (Get-Content -Raw "dist/second/$Archive.sha256")) {
+            throw "Repeated checksum sidecars differ."
+          }
+          cargo run --locked --release -p tidas-dist -- verify `
+            --archive "dist/first/$Archive" `
+            --checksum "dist/first/$Archive.sha256" `
+            --target $env:TARGET --smoke
+          New-Item -ItemType Directory -Force dist/upload | Out-Null
+          Copy-Item "dist/first/$Archive", "dist/first/$Archive.sha256" -Destination dist/upload
+          "archive=dist/upload/$Archive" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "archive-name=$Archive" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Smoke in a clean Linux container
+        if: matrix.family == 'linux'
+        shell: bash
+        env:
+          ARCHIVE_NAME: ${{ steps.package-unix.outputs.archive-name }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          version="$(cargo run --locked --release -p tidas-dist -- version)"
+          docker run --rm \
+            --volume "$PWD/dist/upload:/release:ro" \
+            ubuntu:24.04 \
+            bash -c "mkdir /tmp/tidas && tar -xzf /release/$ARCHIVE_NAME -C /tmp/tidas && /tmp/tidas/tidas-v$version-$TARGET/bin/tidas --format json version && /tmp/tidas/tidas-v$version-$TARGET/bin/tidas --format json ruleset"
+
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: ${{ steps.package-unix.outputs.archive || steps.package-windows.outputs.archive }}
+          format: spdx-json
+          output-file: dist/upload/${{ steps.package-unix.outputs.archive-name || steps.package-windows.outputs.archive-name }}.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+          dependency-snapshot: false
+
+      - name: Attest build provenance
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: ${{ steps.package-unix.outputs.archive || steps.package-windows.outputs.archive }}
+
+      - name: Attest SPDX SBOM
+        if: github.event_name != 'pull_request'
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: ${{ steps.package-unix.outputs.archive || steps.package-windows.outputs.archive }}
+          sbom-path: dist/upload/${{ steps.package-unix.outputs.archive-name || steps.package-windows.outputs.archive-name }}.spdx.json
+
+      - name: Upload qualified artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tidas-${{ matrix.target }}
+          path: dist/upload/*
+          if-no-files-found: error
+          retention-days: 14
+
+  aggregate:
+    name: Aggregate release set
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
+        with:
+          toolchain: 1.88.0
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: tidas-*
+          path: dist/artifacts
+          merge-multiple: true
+
+      - name: Verify complete immutable artifact set
+        shell: bash
+        run: |
+          find dist/artifacts -maxdepth 1 -name '*.sha256' -type f -print0 \
+            | sort -z \
+            | xargs -0 cat > dist/artifacts/SHA256SUMS
+          checksum_count="$(wc -l < dist/artifacts/SHA256SUMS | tr -d ' ')"
+          if [ "$checksum_count" -ne 5 ]; then
+            echo "::error::expected five release checksums, found $checksum_count"
+            exit 1
+          fi
+          cd dist/artifacts
+          sha256sum --check SHA256SUMS
+
+      - name: Validate release tag against Cargo version
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          version="$(cargo run --locked --release -p tidas-dist -- version)"
+          if [ "$GITHUB_REF_NAME" != "v$version" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match Cargo workspace version $version"
+            exit 1
+          fi
+
+      - name: Generate package-manager metadata from the same checksums
+        shell: bash
+        run: |
+          version="$(cargo run --locked --release -p tidas-dist -- version)"
+          cargo run --locked --release -p tidas-dist -- metadata \
+            --release-base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/v${version}" \
+            --artifacts-dir dist/artifacts \
+            --output-dir dist/package-metadata
+          ruby -c dist/package-metadata/homebrew/tidas.rb
+
+      - name: Assemble release set
+        shell: bash
+        run: |
+          mkdir -p dist/release
+          cp dist/artifacts/* dist/release/
+          cp scripts/install.sh scripts/install.ps1 dist/release/
+          cp -R dist/package-metadata dist/release/
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tidas-release-set
+          path: dist/release/**
+          if-no-files-found: error
+          retention-days: 14
+
+  validate-winget:
+    name: Validate Winget metadata
+    needs: aggregate
+    runs-on: windows-2025
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: tidas-release-set
+          path: dist/release
+      - name: Validate manifests
+        shell: pwsh
+        run: winget validate dist/release/package-metadata/winget
+
+  publish:
+    name: Publish immutable GitHub Release
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - aggregate
+      - validate-winget
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: tidas-release-set
+          path: dist/release
+
+      - name: Refuse to mutate an existing release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::release $GITHUB_REF_NAME already exists and is immutable"
+            exit 1
+          fi
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          prerelease=()
+          if printf '%s' "$GITHUB_REF_NAME" | grep -q -- '-'; then
+            prerelease=(--prerelease)
+          fi
+          mapfile -d '' assets < <(find dist/release -type f -print0 | sort -z)
+          gh release create "$GITHUB_REF_NAME" \
+            "${assets[@]}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --generate-notes \
+            --title "tidas $GITHUB_REF_NAME" \
+            "${prerelease[@]}"

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -72,8 +72,6 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
-        with:
-          toolchain: 1.88.0
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
@@ -96,7 +94,8 @@ jobs:
           "$RUNNER_TEMP/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
           "$RUNNER_TEMP/vcpkg/vcpkg" install \
             --triplet "$TRIPLET" \
-            --x-manifest-root="$GITHUB_WORKSPACE/packaging/vcpkg"
+            --x-manifest-root="$GITHUB_WORKSPACE/packaging/vcpkg" \
+            --x-install-root="$RUNNER_TEMP/vcpkg/installed"
           {
             echo "PKG_CONFIG_PATH=$RUNNER_TEMP/vcpkg/installed/$TRIPLET/lib/pkgconfig"
             echo "LIBXML2_STATIC=1"
@@ -114,7 +113,8 @@ jobs:
           & "$env:RUNNER_TEMP\vcpkg\bootstrap-vcpkg.bat" -disableMetrics
           & "$env:RUNNER_TEMP\vcpkg\vcpkg.exe" install `
             --triplet $env:TRIPLET `
-            --x-manifest-root="$env:GITHUB_WORKSPACE\packaging\vcpkg"
+            --x-manifest-root="$env:GITHUB_WORKSPACE\packaging\vcpkg" `
+            --x-install-root="$env:RUNNER_TEMP\vcpkg\installed"
           "VCPKG_ROOT=$env:RUNNER_TEMP\vcpkg" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "VCPKGRS_TRIPLET=$env:TRIPLET" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
@@ -264,8 +264,6 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
-        with:
-          toolchain: 1.88.0
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ checkPaths:
   - crates/**
   - contracts/**
   - assets/**
+  - packaging/**
   - migration/**
   - pyproject.toml
   - src/tidas_tools/**
@@ -37,9 +38,11 @@ checkPaths:
   - scripts/schema_lock.py
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
+  - scripts/install.sh
+  - scripts/install.ps1
 lastReviewedAt: 2026-07-26
-lastReviewedCommit: 9908cab
-lastReviewedNote: "Reviewed for Issue #124: native release control is owned by tidas-release behind the thin unified CLI; frozen Python remains parity evidence only."
+lastReviewedCommit: 84dc90f
+lastReviewedNote: "Reviewed for Issue #125: native binary distribution is owned by tidas-dist and the five-platform release workflow; frozen Python remains parity evidence only."
 related:
   - .docpact/config.yaml
   - docs/agents/cli-contract.md
@@ -107,6 +110,8 @@ Keep these entry-level facts in `AGENTS.md`. Use `README.md`, `README_CN.md`, an
 - stdout is reserved for one report or completion script; logs, progress, and file-write confirmations use stderr
 - canonical Rust checks: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace --all-targets`
 - executable asset lock: `cargo run -p tidas-assets --bin tidas-asset-lock -- check`
+- deterministic native distribution: `cargo run --locked -p tidas-dist -- package --binary <tidas-binary> --license LICENSE --target <target-triple> --output-dir <dir>`
+- initial native artifact matrix: Linux x86_64/ARM64, macOS Intel/Apple Silicon, and Windows x86_64; Windows ARM64 is a separately tracked second phase
 - migration-oracle package manager and runner: `uv`
 - routine branch base: `main`
 - routine PR base: `main`
@@ -134,6 +139,7 @@ At a human-readable level, this repo owns:
 - native bidirectional conversion, deterministic envelope sidecars, atomic publication, and `tidas.conversion-report.v1` under `crates/tidas-conversion`, `contracts/conversion-report.v1.schema.json`, and `tests/fixtures/conversion_v1/**`
 - native external-format detection/import, disk-backed canonicalization, deterministic TIDAS/ILCD publication, process bundles, mapping CSV, and import reports under `crates/tidas-import` and `contracts/import-*.v1.schema.json`
 - native exact release closure, schema-ordered ILCD derivation, validation and semantic round-trip gates, and four deterministic package publication under `crates/tidas-release` and `contracts/release-report.v1.schema.json`
+- deterministic executable archives, checksum verification, package-manager metadata, and packaged smoke proof under `crates/tidas-dist`, `packaging/**`, `scripts/install.*`, and `.github/workflows/rust-release.yml`
 - stable machine contracts under `contracts/**`
 - the complete executable asset inventory in `assets/asset-lock.v1.json`
 - the Python-to-Rust owner inventory under `migration/**`
@@ -145,7 +151,7 @@ At a human-readable level, this repo owns:
 - validator-private projection indexes under `src/tidas_tools/validation_indexes/**`
 - packaged TIDAS schemas and methodologies under `src/tidas_tools/tidas/**`
 - packaged eILCD schemas and stylesheets under `src/tidas_tools/eilcd/**`
-- tests and automation under `tests/**`, `scripts/schema_lock.py`, `.github/workflows/ci.yml`, `.github/workflows/dispatch-tidas-sdk-sync.yml`, and `.github/workflows/python-package-deploy.yml`
+- tests and automation under `tests/**`, `scripts/**`, `.github/workflows/ci.yml`, `.github/workflows/rust-release.yml`, `.github/workflows/dispatch-tidas-sdk-sync.yml`, and `.github/workflows/python-package-deploy.yml`
 - `README.md`, `README_CN.md`, `docs/agents/**`, `.docpact/**`, and `.github/workflows/ai-doc-lint.yml` for repo-local governance and retained docs
 
 This repo does not own:
@@ -182,6 +188,8 @@ Route those tasks to:
 - `assets/asset-lock.v1.json` is the integrity authority for executable schemas, methodologies, rulesets, indexes, XSD, XSLT, and XML reference assets
 - `.gitattributes` forces executable assets, machine contracts, source, and governed docs to LF so byte hashes are identical on Windows, macOS, and Linux
 - native libxml2/libxslt access is serialized until thread-safety is independently proved; production XSLT must fail closed on external resource resolution
+- native release archives must derive from one exact binary, use pinned static libxml2/libxslt inputs, carry fixed archive metadata and SHA-256, and pass packaged-binary smoke probes without a development toolchain
+- GitHub Release publication must be tag/version exact and refuse mutation of an existing release; Homebrew and Winget metadata must use the same archive checksums and must not rebuild the binary
 - Python remains frozen until functional parity, deterministic contracts, local performance/RSS targets, cross-platform artifacts, and downstream cutovers all pass; then #126 removes every active Python implementation/install/invocation path
 - do not treat the public docs site as the executable upstream for packaged schemas and methodologies
 - packaged assets under `src/tidas_tools/**` are executable tooling inputs, not just reference docs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,6 +671,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,6 +2410,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2489,6 +2510,22 @@ dependencies = [
  "tidas-assets",
  "tidas-runtime",
  "walkdir",
+]
+
+[[package]]
+name = "tidas-dist"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "flate2",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -3287,6 +3324,16 @@ dependencies = [
  "der",
  "spki",
  "tls_codec",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/tidas-cli",
   "crates/tidas-conversion",
   "crates/tidas-contracts",
+  "crates/tidas-dist",
   "crates/tidas-export",
   "crates/tidas-import",
   "crates/tidas-references",
@@ -42,6 +43,7 @@ regex = "1.12.3"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.149"
 sha2 = "0.11.0"
+tar = "0.4.44"
 tempfile = "3.27.0"
 thiserror = "2.0.19"
 tokio = { version = "1.49.0", features = ["fs", "io-util", "macros", "rt-multi-thread", "sync", "time"] }
@@ -60,3 +62,7 @@ pedantic = { level = "deny", priority = -1 }
 module_name_repetitions = "allow"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
+
+[profile.release]
+lto = "thin"
+strip = "symbols"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 TianGong LCA
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,36 @@
+---
+title: tidas-tools README
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: tidas-tools
+language: en
+whenToUse:
+  - when you need English user-facing CLI examples, native installation, or basic development commands
+whenToUpdate:
+  - when English CLI examples, installation, development commands, or release notes change
+checkPaths:
+  - README.md
+  - AGENTS.md
+  - .docpact/config.yaml
+  - docs/agents/**
+  - Cargo.toml
+  - crates/**
+  - packaging/**
+  - scripts/install.*
+  - .github/workflows/**
+lastReviewedAt: 2026-07-26
+lastReviewedCommit: 84dc90f
+lastReviewedNote: "Issue #125 documents five-platform native artifacts, reproducible archives, checksums, SBOM/attestation, installers, and package-manager metadata."
+related:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - docs/agents/repo-validation.md
+  - docs/agents/repo-architecture.md
+  - README_CN.md
+---
+
 # TianGong TIDAS Tools User Guide
 
 [![PyPI](https://img.shields.io/pypi/v/tidas-tools.svg)][pypi status]
@@ -18,7 +51,8 @@ machine and invocation contracts, bounded runtime primitives, executable-asset
 integrity lock, XML/XSD/XSLT portability boundary, the unified CLI adapter,
 and native TIDAS/ILCD validation, reference extraction, batch evidence,
 ruleset inspection, bidirectional TIDAS/eILCD conversion, external-format
-import, database export, and deterministic release control:
+import, database export, deterministic release control, and reproducible native
+distribution:
 
 ```bash
 cargo build --workspace
@@ -43,6 +77,7 @@ cargo run -p tidas-cli --bin tidas -- release build-packages \
 cargo run -p tidas-cli --bin tidas -- ruleset --format json
 cargo run -p tidas-cli --bin tidas -- --completion bash > tidas.bash
 cargo run -p tidas-assets --bin tidas-asset-lock -- check
+cargo run -p tidas-dist -- version
 ```
 
 The final command tree is `convert`, `import`, `export`, `validate`, `release`,
@@ -91,6 +126,33 @@ diagnostics, and report-file confirmations use stderr. Use `--report <PATH>`
 to persist the report without occupying stdout. The default accounted memory
 budget is 512 MiB and the default bounded queue capacity is 256. The normative
 contract is [docs/agents/cli-contract.md](docs/agents/cli-contract.md).
+
+## Native distribution
+
+The native release workflow qualifies one exact `tidas` binary for Linux
+x86_64/ARM64, macOS Intel/Apple Silicon, and Windows x86_64. It builds every
+archive twice, compares the bytes, verifies SHA-256, runs packaged `version`,
+help, JSON `version`, and `ruleset` probes, generates an SPDX SBOM, and creates
+GitHub OIDC provenance/SBOM attestations. Pinned static libxml2/libxslt inputs
+keep the archives independent of Homebrew, vcpkg, Python, Java, Node.js, or a
+development toolchain at runtime.
+
+After a native version is published, install an explicit immutable version:
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSLO \
+  https://raw.githubusercontent.com/tiangong-lca/tidas-tools/main/scripts/install.sh
+sh install.sh --version 0.1.0 --prefix "$HOME/.local"
+```
+
+```powershell
+.\scripts\install.ps1 -Version 0.1.0
+```
+
+Every GitHub Release also carries generated Homebrew formula and Winget
+manifests that reference the same archive hashes. External tap creation or a
+Winget community submission is a separate publication approval; those paths
+never rebuild the executable. Windows ARM64 is a tracked second-phase target.
 
 The Python package described below is feature-frozen and remains temporarily
 available as an internal golden/parity oracle. It is not the final product and

--- a/README_CN.md
+++ b/README_CN.md
@@ -19,13 +19,15 @@ checkPaths:
   - crates/**
   - contracts/**
   - assets/**
+  - packaging/**
   - migration/**
   - pyproject.toml
   - src/tidas_tools/**
   - .github/workflows/**
+  - scripts/install.*
 lastReviewedAt: 2026-07-26
-lastReviewedCommit: 9908cab
-lastReviewedNote: "Issue #124 将原生 release action tree、精确闭包、语义 round-trip 与原子四包发布写入当前用户指南。"
+lastReviewedCommit: 84dc90f
+lastReviewedNote: "Issue #125 将五平台原生制品、可复现归档、校验和、SBOM/attestation、安装器与包管理元数据写入当前用户指南。"
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -51,7 +53,8 @@ Rust 可执行文件 `tidas`。
 当前 Rust 实现已经建立 Cargo workspace、稳定机器与 invocation 契约、有界运行时
 基础设施、可执行资产完整性锁、XML/XSD/XSLT 跨平台边界、最终统一 CLI 适配层，
 以及原生 TIDAS/ILCD 校验、引用提取、batch 证据、ruleset 检查、双向
-TIDAS/eILCD 转换、外部格式导入、数据库导出与确定性 release control：
+TIDAS/eILCD 转换、外部格式导入、数据库导出、确定性 release control 与可复现
+原生分发：
 
 ```bash
 cargo build --workspace
@@ -76,6 +79,7 @@ cargo run -p tidas-cli --bin tidas -- release build-packages \
 cargo run -p tidas-cli --bin tidas -- ruleset --format json
 cargo run -p tidas-cli --bin tidas -- --completion bash > tidas.bash
 cargo run -p tidas-assets --bin tidas-asset-lock -- check
+cargo run -p tidas-dist -- version
 ```
 
 最终命令树固定为 `convert`、`import`、`export`、`validate`、`release`、
@@ -113,6 +117,31 @@ final evidence hash。
 日志、进度、诊断与报告落盘确认写入 stderr。使用 `--report <PATH>` 可在不占用
 stdout 的情况下持久化报告。默认计入内存预算为 512 MiB，有界队列容量为 256。
 规范契约见 [docs/agents/cli-contract.md](docs/agents/cli-contract.md)。
+
+## 原生分发
+
+原生 release workflow 从同一个精确的 `tidas` binary 构建并验证 Linux
+x86_64/ARM64、macOS Intel/Apple Silicon 与 Windows x86_64 制品。每个平台均
+重复构建归档并逐字节比较，验证 SHA-256，执行打包后的 `version`、help、JSON
+`version` 与 `ruleset` 探针，并生成 SPDX SBOM 和 GitHub OIDC
+provenance/SBOM attestation。固定版本且静态链接的 libxml2/libxslt 使运行时
+不依赖 Homebrew、vcpkg、Python、Java、Node.js 或开发工具链。
+
+原生版本发布后，可安装明确且不可变的版本：
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSLO \
+  https://raw.githubusercontent.com/tiangong-lca/tidas-tools/main/scripts/install.sh
+sh install.sh --version 0.1.0 --prefix "$HOME/.local"
+```
+
+```powershell
+.\scripts\install.ps1 -Version 0.1.0
+```
+
+每个 GitHub Release 同时携带由相同归档哈希生成的 Homebrew formula 与 Winget
+manifests。创建外部 tap 或提交 Winget community 需要单独批准，且这些路径绝不
+重新构建 executable。Windows ARM64 是明确跟踪的第二阶段目标。
 
 下文记录的 Python 包已经 feature freeze，只在迁移期间作为内部 golden/parity
 oracle。它不是最终产品，旧可执行文件名和参数布局不会保留。只有 Rust 功能语义、

--- a/crates/tidas-dist/Cargo.toml
+++ b/crates/tidas-dist/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "tidas-dist"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[[bin]]
+name = "tidas-dist"
+path = "src/main.rs"
+
+[dependencies]
+clap.workspace = true
+flate2.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+tar.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+walkdir.workspace = true
+zip.workspace = true
+
+[lints]
+workspace = true

--- a/crates/tidas-dist/src/lib.rs
+++ b/crates/tidas-dist/src/lib.rs
@@ -561,6 +561,8 @@ end
 fn winget_version_manifest(version: &str) -> String {
     format!(
         r"# Generated from the exact tidas release archive; do not hand-edit.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
 PackageIdentifier: TianGong.Tidas
 PackageVersion: {version}
 DefaultLocale: en-US
@@ -573,6 +575,8 @@ ManifestVersion: 1.10.0
 fn winget_installer_manifest(version: &str, url: &str, sha256: &str) -> String {
     format!(
         r"# Generated from the exact tidas release archive; do not hand-edit.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
 PackageIdentifier: TianGong.Tidas
 PackageVersion: {version}
 InstallerType: zip
@@ -593,6 +597,8 @@ ManifestVersion: 1.10.0
 fn winget_locale_manifest(version: &str) -> String {
     format!(
         r"# Generated from the exact tidas release archive; do not hand-edit.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
 PackageIdentifier: TianGong.Tidas
 PackageVersion: {version}
 PackageLocale: en-US
@@ -713,13 +719,28 @@ mod tests {
         let formula = fs::read_to_string(output.join("homebrew/tidas.rb")).unwrap();
         assert!(formula.contains("aarch64-apple-darwin"));
         assert!(formula.contains(&format!("{:064x}", 1)));
+        let winget_version = fs::read_to_string(output.join("winget/TianGong.Tidas.yaml")).unwrap();
+        assert!(
+            winget_version
+                .contains("$schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json")
+        );
         let winget =
             fs::read_to_string(output.join("winget/TianGong.Tidas.installer.yaml")).unwrap();
+        assert!(
+            winget.contains("$schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json")
+        );
         assert!(winget.contains("Architecture: x64"));
         assert!(
             winget
                 .contains("RelativeFilePath: tidas-v0.1.0-x86_64-pc-windows-msvc\\bin\\tidas.exe")
         );
         assert!(winget.contains(&format!("{:064x}", 5)));
+        let winget_locale =
+            fs::read_to_string(output.join("winget/TianGong.Tidas.locale.en-US.yaml")).unwrap();
+        assert!(
+            winget_locale.contains(
+                "$schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json"
+            )
+        );
     }
 }

--- a/crates/tidas-dist/src/lib.rs
+++ b/crates/tidas-dist/src/lib.rs
@@ -105,6 +105,7 @@ pub fn package(request: &PackageRequest<'_>) -> Result<DistributionArtifactV1, D
     let staged_binary = root.join("bin").join(binary_name);
     fs::create_dir_all(staged_binary.parent().expect("binary has parent"))?;
     fs::copy(request.binary, &staged_binary)?;
+    #[cfg(unix)]
     set_executable(&staged_binary)?;
 
     let license_dir = root.join("share").join("licenses").join("tidas");
@@ -276,11 +277,6 @@ fn executable_name(target: &str) -> &'static str {
 fn set_executable(path: &Path) -> Result<(), DistError> {
     use std::os::unix::fs::PermissionsExt;
     fs::set_permissions(path, fs::Permissions::from_mode(0o755))?;
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn set_executable(_path: &Path) -> Result<(), DistError> {
     Ok(())
 }
 

--- a/crates/tidas-dist/src/lib.rs
+++ b/crates/tidas-dist/src/lib.rs
@@ -1,0 +1,729 @@
+//! Deterministic native distribution archives and package-manager metadata.
+//!
+//! This crate is an internal release tool. It never rebuilds the product
+//! binary: every archive, checksum, installer manifest, and package-manager
+//! record is derived from the exact `tidas` executable supplied by the caller.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+use flate2::Compression;
+use flate2::GzBuilder;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+use walkdir::WalkDir;
+use zip::CompressionMethod;
+use zip::write::SimpleFileOptions;
+
+const COPY_BUFFER_BYTES: usize = 1024 * 1024;
+const WINDOWS_TARGET: &str = "x86_64-pc-windows-msvc";
+const REQUIRED_TARGETS: [&str; 5] = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    WINDOWS_TARGET,
+];
+
+#[derive(Debug, thiserror::Error)]
+pub enum DistError {
+    #[error("unsupported release target: {0}")]
+    UnsupportedTarget(String),
+    #[error("release input is not a regular file: {0}")]
+    MissingInput(PathBuf),
+    #[error("unsafe archive member path: {0}")]
+    UnsafePath(PathBuf),
+    #[error("archive does not contain the expected manifest")]
+    MissingManifest,
+    #[error("archive manifest does not match target/version: expected {expected}, found {found}")]
+    ManifestMismatch { expected: String, found: String },
+    #[error("archive checksum mismatch: expected {expected}, found {found}")]
+    ChecksumMismatch { expected: String, found: String },
+    #[error("packaged tidas smoke command failed: {0}")]
+    SmokeFailed(String),
+    #[error("missing checksum for release artifact: {0}")]
+    MissingChecksum(String),
+    #[error("invalid checksum line: {0}")]
+    InvalidChecksum(String),
+    #[error("distribution size overflow")]
+    SizeOverflow,
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Zip(#[from] zip::result::ZipError),
+    #[error(transparent)]
+    Walk(#[from] walkdir::Error),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DistributionManifestV1 {
+    pub schema_version: String,
+    pub product: String,
+    pub version: String,
+    pub target: String,
+    pub executable: String,
+    pub self_contained_native_xml: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct DistributionArtifactV1 {
+    pub schema_version: String,
+    pub archive: PathBuf,
+    pub checksum_file: PathBuf,
+    pub sha256: String,
+    pub bytes: u64,
+    pub target: String,
+    pub version: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct PackageRequest<'a> {
+    pub binary: &'a Path,
+    pub license: &'a Path,
+    pub target: &'a str,
+    pub version: &'a str,
+    pub output_dir: &'a Path,
+}
+
+pub fn package(request: &PackageRequest<'_>) -> Result<DistributionArtifactV1, DistError> {
+    validate_target(request.target)?;
+    require_file(request.binary)?;
+    require_file(request.license)?;
+    fs::create_dir_all(request.output_dir)?;
+
+    let root_name = archive_root(request.version, request.target);
+    let staging = tempfile::tempdir_in(request.output_dir)?;
+    let root = staging.path().join(&root_name);
+    let binary_name = executable_name(request.target);
+    let staged_binary = root.join("bin").join(binary_name);
+    fs::create_dir_all(staged_binary.parent().expect("binary has parent"))?;
+    fs::copy(request.binary, &staged_binary)?;
+    set_executable(&staged_binary)?;
+
+    let license_dir = root.join("share").join("licenses").join("tidas");
+    fs::create_dir_all(&license_dir)?;
+    fs::copy(request.license, license_dir.join("LICENSE"))?;
+
+    let manifest = DistributionManifestV1 {
+        schema_version: "tidas.distribution-manifest.v1".to_owned(),
+        product: "tidas".to_owned(),
+        version: request.version.to_owned(),
+        target: request.target.to_owned(),
+        executable: format!("bin/{binary_name}"),
+        self_contained_native_xml: true,
+    };
+    let mut manifest_bytes = serde_json::to_vec_pretty(&manifest)?;
+    manifest_bytes.push(b'\n');
+    fs::write(root.join("distribution-manifest.json"), manifest_bytes)?;
+
+    let archive_name = archive_name(request.version, request.target);
+    let archive = request.output_dir.join(&archive_name);
+    if request.target == WINDOWS_TARGET {
+        write_zip(staging.path(), &archive)?;
+    } else {
+        write_tar_gz(staging.path(), &archive)?;
+    }
+    let bytes = fs::metadata(&archive)?.len();
+    let sha256 = sha256_file(&archive)?;
+    let checksum_file = request.output_dir.join(format!("{archive_name}.sha256"));
+    fs::write(&checksum_file, format!("{sha256}  {archive_name}\n"))?;
+
+    Ok(DistributionArtifactV1 {
+        schema_version: "tidas.distribution-artifact.v1".to_owned(),
+        archive,
+        checksum_file,
+        sha256,
+        bytes,
+        target: request.target.to_owned(),
+        version: request.version.to_owned(),
+    })
+}
+
+pub fn verify(
+    archive: &Path,
+    checksum_file: &Path,
+    expected_target: &str,
+    expected_version: &str,
+    smoke: bool,
+) -> Result<DistributionManifestV1, DistError> {
+    validate_target(expected_target)?;
+    require_file(archive)?;
+    require_file(checksum_file)?;
+    verify_checksum(archive, checksum_file)?;
+
+    let extracted = TempDir::new()?;
+    if expected_target == WINDOWS_TARGET {
+        extract_zip(archive, extracted.path())?;
+    } else {
+        extract_tar_gz(archive, extracted.path())?;
+    }
+    let root = extracted
+        .path()
+        .join(archive_root(expected_version, expected_target));
+    let manifest_path = root.join("distribution-manifest.json");
+    if !manifest_path.is_file() {
+        return Err(DistError::MissingManifest);
+    }
+    let manifest: DistributionManifestV1 = serde_json::from_slice(&fs::read(&manifest_path)?)?;
+    if manifest.target != expected_target || manifest.version != expected_version {
+        return Err(DistError::ManifestMismatch {
+            expected: format!("{expected_version}/{expected_target}"),
+            found: format!("{}/{}", manifest.version, manifest.target),
+        });
+    }
+    let executable = root.join(&manifest.executable);
+    require_file(&executable)?;
+    if smoke {
+        run_smoke(&executable)?;
+    }
+    Ok(manifest)
+}
+
+pub fn render_package_metadata(
+    version: &str,
+    release_base_url: &str,
+    artifacts_dir: &Path,
+    output_dir: &Path,
+) -> Result<Vec<PathBuf>, DistError> {
+    fs::create_dir_all(output_dir)?;
+    let checksums = release_checksums(version, artifacts_dir)?;
+    let formula_dir = output_dir.join("homebrew");
+    fs::create_dir_all(&formula_dir)?;
+    let formula_path = formula_dir.join("tidas.rb");
+    fs::write(
+        &formula_path,
+        homebrew_formula(version, release_base_url, &checksums),
+    )?;
+
+    let winget_dir = output_dir.join("winget");
+    fs::create_dir_all(&winget_dir)?;
+    let windows_archive = archive_name(version, WINDOWS_TARGET);
+    let windows_sha = checksums
+        .get(WINDOWS_TARGET)
+        .ok_or_else(|| DistError::MissingChecksum(windows_archive.clone()))?;
+    let version_path = winget_dir.join("TianGong.Tidas.yaml");
+    let installer_path = winget_dir.join("TianGong.Tidas.installer.yaml");
+    let locale_path = winget_dir.join("TianGong.Tidas.locale.en-US.yaml");
+    fs::write(&version_path, winget_version_manifest(version))?;
+    fs::write(
+        &installer_path,
+        winget_installer_manifest(
+            version,
+            &format!("{release_base_url}/{windows_archive}"),
+            windows_sha,
+        ),
+    )?;
+    fs::write(&locale_path, winget_locale_manifest(version))?;
+
+    Ok(vec![
+        formula_path,
+        version_path,
+        installer_path,
+        locale_path,
+    ])
+}
+
+#[must_use]
+pub fn supported_targets() -> &'static [&'static str] {
+    &REQUIRED_TARGETS
+}
+
+fn validate_target(target: &str) -> Result<(), DistError> {
+    if REQUIRED_TARGETS.contains(&target) {
+        Ok(())
+    } else {
+        Err(DistError::UnsupportedTarget(target.to_owned()))
+    }
+}
+
+fn require_file(path: &Path) -> Result<(), DistError> {
+    if path.is_file() {
+        Ok(())
+    } else {
+        Err(DistError::MissingInput(path.to_path_buf()))
+    }
+}
+
+fn archive_root(version: &str, target: &str) -> String {
+    format!("tidas-v{version}-{target}")
+}
+
+fn archive_name(version: &str, target: &str) -> String {
+    let extension = if target == WINDOWS_TARGET {
+        "zip"
+    } else {
+        "tar.gz"
+    };
+    format!("{}.{extension}", archive_root(version, target))
+}
+
+fn executable_name(target: &str) -> &'static str {
+    if target == WINDOWS_TARGET {
+        "tidas.exe"
+    } else {
+        "tidas"
+    }
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<(), DistError> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<(), DistError> {
+    Ok(())
+}
+
+fn collect_files(root: &Path) -> Result<Vec<(String, PathBuf, u32)>, DistError> {
+    let mut files = Vec::new();
+    for entry in WalkDir::new(root).follow_links(false) {
+        let entry = entry?;
+        if entry.file_type().is_symlink()
+            || (!entry.file_type().is_file() && !entry.file_type().is_dir())
+        {
+            return Err(DistError::UnsafePath(entry.path().to_path_buf()));
+        }
+        if entry.file_type().is_dir() {
+            continue;
+        }
+        let relative = entry
+            .path()
+            .strip_prefix(root)
+            .map_err(|_| DistError::UnsafePath(entry.path().to_path_buf()))?;
+        validate_relative(relative)?;
+        let name = portable(relative)?;
+        let mode = if name.ends_with("/bin/tidas") || name.ends_with("/bin/tidas.exe") {
+            0o755
+        } else {
+            0o644
+        };
+        files.push((name, entry.path().to_path_buf(), mode));
+    }
+    files.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(files)
+}
+
+fn write_zip(root: &Path, output: &Path) -> Result<(), DistError> {
+    let file = File::create(output)?;
+    let mut writer = zip::ZipWriter::new(file);
+    let files = collect_files(root)?;
+    let mut buffer = vec![0_u8; COPY_BUFFER_BYTES];
+    for (name, path, mode) in files {
+        let options = SimpleFileOptions::default()
+            .compression_method(CompressionMethod::Deflated)
+            .compression_level(Some(9))
+            .last_modified_time(zip::DateTime::default())
+            .unix_permissions(mode);
+        writer.start_file(name, options)?;
+        copy_file(&path, &mut writer, &mut buffer)?;
+    }
+    let finished = writer.finish()?;
+    finished.sync_all()?;
+    Ok(())
+}
+
+fn write_tar_gz(root: &Path, output: &Path) -> Result<(), DistError> {
+    let file = File::create(output)?;
+    let gzip = GzBuilder::new().mtime(0).write(file, Compression::best());
+    let mut writer = tar::Builder::new(gzip);
+    writer.mode(tar::HeaderMode::Deterministic);
+    let files = collect_files(root)?;
+    for (name, path, mode) in files {
+        let metadata = fs::metadata(&path)?;
+        let mut header = tar::Header::new_gnu();
+        header.set_size(metadata.len());
+        header.set_mode(mode);
+        header.set_uid(0);
+        header.set_gid(0);
+        header.set_mtime(0);
+        header.set_cksum();
+        let mut source = File::open(path)?;
+        writer.append_data(&mut header, name, &mut source)?;
+    }
+    let gzip = writer.into_inner()?;
+    let finished = gzip.finish()?;
+    finished.sync_all()?;
+    Ok(())
+}
+
+fn copy_file<W: Write>(path: &Path, writer: &mut W, buffer: &mut [u8]) -> Result<(), DistError> {
+    let mut source = File::open(path)?;
+    loop {
+        let read = source.read(buffer)?;
+        if read == 0 {
+            break;
+        }
+        writer.write_all(&buffer[..read])?;
+    }
+    Ok(())
+}
+
+fn validate_relative(path: &Path) -> Result<(), DistError> {
+    if path.as_os_str().is_empty()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(DistError::UnsafePath(path.to_path_buf()));
+    }
+    Ok(())
+}
+
+fn portable(path: &Path) -> Result<String, DistError> {
+    path.components()
+        .map(|component| {
+            component
+                .as_os_str()
+                .to_str()
+                .map(ToOwned::to_owned)
+                .ok_or_else(|| DistError::UnsafePath(path.to_path_buf()))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(|parts| parts.join("/"))
+}
+
+fn sha256_file(path: &Path) -> Result<String, DistError> {
+    let mut file = File::open(path)?;
+    let mut buffer = vec![0_u8; COPY_BUFFER_BYTES];
+    let mut hasher = Sha256::new();
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hex(hasher.finalize()))
+}
+
+fn verify_checksum(archive: &Path, checksum_file: &Path) -> Result<(), DistError> {
+    let file_name = archive
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| DistError::UnsafePath(archive.to_path_buf()))?;
+    let line = fs::read_to_string(checksum_file)?;
+    let (expected, listed_name) = line
+        .trim()
+        .split_once("  ")
+        .ok_or_else(|| DistError::InvalidChecksum(line.clone()))?;
+    if listed_name != file_name || expected.len() != 64 {
+        return Err(DistError::InvalidChecksum(line));
+    }
+    let found = sha256_file(archive)?;
+    if expected == found {
+        Ok(())
+    } else {
+        Err(DistError::ChecksumMismatch {
+            expected: expected.to_owned(),
+            found,
+        })
+    }
+}
+
+fn extract_zip(archive: &Path, output: &Path) -> Result<(), DistError> {
+    let mut reader = zip::ZipArchive::new(File::open(archive)?)?;
+    for index in 0..reader.len() {
+        let mut member = reader.by_index(index)?;
+        let relative = member
+            .enclosed_name()
+            .ok_or_else(|| DistError::UnsafePath(PathBuf::from(member.name())))?
+            .clone();
+        let destination = output.join(relative);
+        if member.is_dir() {
+            fs::create_dir_all(&destination)?;
+            continue;
+        }
+        fs::create_dir_all(destination.parent().expect("archive file has parent"))?;
+        let mut file = File::create(destination)?;
+        std::io::copy(&mut member, &mut file)?;
+    }
+    Ok(())
+}
+
+fn extract_tar_gz(archive: &Path, output: &Path) -> Result<(), DistError> {
+    let reader = flate2::read::GzDecoder::new(File::open(archive)?);
+    let mut archive = tar::Archive::new(reader);
+    archive.unpack(output)?;
+    Ok(())
+}
+
+fn run_smoke(executable: &Path) -> Result<(), DistError> {
+    for arguments in [
+        vec!["--version"],
+        vec!["--help"],
+        vec!["--format", "json", "version"],
+        vec!["--format", "json", "ruleset"],
+    ] {
+        let output = Command::new(executable).args(&arguments).output()?;
+        if !output.status.success() {
+            return Err(DistError::SmokeFailed(format!(
+                "{} {} (status {}; stderr: {})",
+                executable.display(),
+                arguments.join(" "),
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+        if output.stdout.is_empty() {
+            return Err(DistError::SmokeFailed(format!(
+                "{} {} produced empty stdout",
+                executable.display(),
+                arguments.join(" ")
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn release_checksums(
+    version: &str,
+    artifacts_dir: &Path,
+) -> Result<BTreeMap<String, String>, DistError> {
+    let mut checksums = BTreeMap::new();
+    for target in REQUIRED_TARGETS {
+        let archive = archive_name(version, target);
+        let checksum_path = artifacts_dir.join(format!("{archive}.sha256"));
+        let line = fs::read_to_string(&checksum_path)
+            .map_err(|_| DistError::MissingChecksum(archive.clone()))?;
+        let (sha256, listed_name) = line
+            .trim()
+            .split_once("  ")
+            .ok_or_else(|| DistError::InvalidChecksum(line.clone()))?;
+        if listed_name != archive || sha256.len() != 64 {
+            return Err(DistError::InvalidChecksum(line));
+        }
+        checksums.insert(target.to_owned(), sha256.to_owned());
+    }
+    Ok(checksums)
+}
+
+fn homebrew_formula(
+    version: &str,
+    release_base_url: &str,
+    checksums: &BTreeMap<String, String>,
+) -> String {
+    let url = |target: &str| format!("{release_base_url}/{}", archive_name(version, target));
+    let sha = |target: &str| checksums.get(target).expect("all targets were validated");
+    format!(
+        r##"class Tidas < Formula
+  desc "Cross-platform TIDAS conversion, import, export, validation, and release CLI"
+  homepage "https://github.com/tiangong-lca/tidas-tools"
+  version "{version}"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "{mac_arm_url}"
+      sha256 "{mac_arm_sha}"
+    else
+      url "{mac_x64_url}"
+      sha256 "{mac_x64_sha}"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "{linux_arm_url}"
+      sha256 "{linux_arm_sha}"
+    else
+      url "{linux_x64_url}"
+      sha256 "{linux_x64_sha}"
+    end
+  end
+
+  def install
+    bin.install "bin/tidas"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{{bin}}/tidas --version")
+    assert_match "\"status\":\"succeeded\"", shell_output("#{{bin}}/tidas --format json version")
+  end
+end
+"##,
+        mac_arm_url = url("aarch64-apple-darwin"),
+        mac_arm_sha = sha("aarch64-apple-darwin"),
+        mac_x64_url = url("x86_64-apple-darwin"),
+        mac_x64_sha = sha("x86_64-apple-darwin"),
+        linux_arm_url = url("aarch64-unknown-linux-gnu"),
+        linux_arm_sha = sha("aarch64-unknown-linux-gnu"),
+        linux_x64_url = url("x86_64-unknown-linux-gnu"),
+        linux_x64_sha = sha("x86_64-unknown-linux-gnu"),
+    )
+}
+
+fn winget_version_manifest(version: &str) -> String {
+    format!(
+        r"# Generated from the exact tidas release archive; do not hand-edit.
+PackageIdentifier: TianGong.Tidas
+PackageVersion: {version}
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0
+"
+    )
+}
+
+fn winget_installer_manifest(version: &str, url: &str, sha256: &str) -> String {
+    format!(
+        r"# Generated from the exact tidas release archive; do not hand-edit.
+PackageIdentifier: TianGong.Tidas
+PackageVersion: {version}
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: tidas-v{version}-x86_64-pc-windows-msvc\bin\tidas.exe
+    PortableCommandAlias: tidas
+Installers:
+  - Architecture: x64
+    InstallerUrl: {url}
+    InstallerSha256: {sha256}
+ManifestType: installer
+ManifestVersion: 1.10.0
+"
+    )
+}
+
+fn winget_locale_manifest(version: &str) -> String {
+    format!(
+        r"# Generated from the exact tidas release archive; do not hand-edit.
+PackageIdentifier: TianGong.Tidas
+PackageVersion: {version}
+PackageLocale: en-US
+Publisher: TianGong LCA
+PackageName: tidas
+License: MIT
+ShortDescription: Cross-platform TIDAS conversion, import, export, validation, and release CLI.
+PackageUrl: https://github.com/tiangong-lca/tidas-tools
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0
+"
+    )
+}
+
+fn hex(digest: impl AsRef<[u8]>) -> String {
+    let bytes = digest.as_ref();
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut output, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_binary(path: &Path) {
+        fs::write(path, b"native tidas fixture\n").unwrap();
+    }
+
+    #[test]
+    fn archives_and_checksums_are_byte_repeatable() {
+        let temporary = tempfile::tempdir().unwrap();
+        let binary = temporary.path().join("tidas");
+        let license = temporary.path().join("LICENSE");
+        fake_binary(&binary);
+        fs::write(&license, b"MIT\n").unwrap();
+        let first_dir = temporary.path().join("first");
+        let second_dir = temporary.path().join("second");
+        let first = package(&PackageRequest {
+            binary: &binary,
+            license: &license,
+            target: "x86_64-unknown-linux-gnu",
+            version: "0.1.0",
+            output_dir: &first_dir,
+        })
+        .unwrap();
+        let second = package(&PackageRequest {
+            binary: &binary,
+            license: &license,
+            target: "x86_64-unknown-linux-gnu",
+            version: "0.1.0",
+            output_dir: &second_dir,
+        })
+        .unwrap();
+        assert_eq!(first.sha256, second.sha256);
+        assert_eq!(
+            fs::read(first.archive).unwrap(),
+            fs::read(second.archive).unwrap()
+        );
+        assert_eq!(
+            fs::read(first.checksum_file).unwrap(),
+            fs::read(second.checksum_file).unwrap()
+        );
+    }
+
+    #[test]
+    fn verifier_rejects_checksum_drift_before_extraction() {
+        let temporary = tempfile::tempdir().unwrap();
+        let binary = temporary.path().join("tidas.exe");
+        let license = temporary.path().join("LICENSE");
+        fake_binary(&binary);
+        fs::write(&license, b"MIT\n").unwrap();
+        let artifact = package(&PackageRequest {
+            binary: &binary,
+            license: &license,
+            target: WINDOWS_TARGET,
+            version: "0.1.0",
+            output_dir: temporary.path(),
+        })
+        .unwrap();
+        let mut bytes = fs::read(&artifact.archive).unwrap();
+        bytes[0] ^= 1;
+        fs::write(&artifact.archive, bytes).unwrap();
+        assert!(matches!(
+            verify(
+                &artifact.archive,
+                &artifact.checksum_file,
+                WINDOWS_TARGET,
+                "0.1.0",
+                false
+            ),
+            Err(DistError::ChecksumMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn metadata_uses_the_five_exact_archive_checksums() {
+        let temporary = tempfile::tempdir().unwrap();
+        for (index, target) in REQUIRED_TARGETS.iter().enumerate() {
+            let archive = archive_name("0.1.0", target);
+            fs::write(
+                temporary.path().join(format!("{archive}.sha256")),
+                format!("{:064x}  {archive}\n", index + 1),
+            )
+            .unwrap();
+        }
+        let output = temporary.path().join("metadata");
+        let paths = render_package_metadata(
+            "0.1.0",
+            "https://example.invalid/v0.1.0",
+            temporary.path(),
+            &output,
+        )
+        .unwrap();
+        assert_eq!(paths.len(), 4);
+        let formula = fs::read_to_string(output.join("homebrew/tidas.rb")).unwrap();
+        assert!(formula.contains("aarch64-apple-darwin"));
+        assert!(formula.contains(&format!("{:064x}", 1)));
+        let winget =
+            fs::read_to_string(output.join("winget/TianGong.Tidas.installer.yaml")).unwrap();
+        assert!(winget.contains("Architecture: x64"));
+        assert!(
+            winget
+                .contains("RelativeFilePath: tidas-v0.1.0-x86_64-pc-windows-msvc\\bin\\tidas.exe")
+        );
+        assert!(winget.contains(&format!("{:064x}", 5)));
+    }
+}

--- a/crates/tidas-dist/src/main.rs
+++ b/crates/tidas-dist/src/main.rs
@@ -1,0 +1,101 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use tidas_dist::{PackageRequest, package, render_package_metadata, verify};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "tidas-dist",
+    about = "Internal deterministic distribution builder for the native tidas CLI"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Print the workspace release version.
+    Version,
+    /// Build one deterministic platform archive and checksum.
+    Package {
+        #[arg(long)]
+        binary: PathBuf,
+        #[arg(long)]
+        license: PathBuf,
+        #[arg(long)]
+        target: String,
+        #[arg(long)]
+        output_dir: PathBuf,
+    },
+    /// Verify checksum, archive contract, and optionally run packaged smoke probes.
+    Verify {
+        #[arg(long)]
+        archive: PathBuf,
+        #[arg(long)]
+        checksum: PathBuf,
+        #[arg(long)]
+        target: String,
+        #[arg(long)]
+        smoke: bool,
+    },
+    /// Generate Homebrew and Winget metadata from the five exact archive checksums.
+    Metadata {
+        #[arg(long)]
+        release_base_url: String,
+        #[arg(long)]
+        artifacts_dir: PathBuf,
+        #[arg(long)]
+        output_dir: PathBuf,
+    },
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), tidas_dist::DistError> {
+    let version = env!("CARGO_PKG_VERSION");
+    match Cli::parse().command {
+        Commands::Version => println!("{version}"),
+        Commands::Package {
+            binary,
+            license,
+            target,
+            output_dir,
+        } => {
+            let artifact = package(&PackageRequest {
+                binary: &binary,
+                license: &license,
+                target: &target,
+                version,
+                output_dir: &output_dir,
+            })?;
+            println!("{}", serde_json::to_string(&artifact)?);
+        }
+        Commands::Verify {
+            archive,
+            checksum,
+            target,
+            smoke,
+        } => {
+            let manifest = verify(&archive, &checksum, &target, version, smoke)?;
+            println!("{}", serde_json::to_string(&manifest)?);
+        }
+        Commands::Metadata {
+            release_base_url,
+            artifacts_dir,
+            output_dir,
+        } => {
+            for path in
+                render_package_metadata(version, &release_base_url, &artifacts_dir, &output_dir)?
+            {
+                println!("{}", path.display());
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/tidas-dist/tests/cli_contract.rs
+++ b/crates/tidas-dist/tests/cli_contract.rs
@@ -1,0 +1,97 @@
+use std::fs;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn command() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_tidas-dist"))
+}
+
+#[test]
+fn migration_fixture_keeps_python_as_oracle_but_only_tidas_as_product() {
+    let fixture: Value =
+        serde_json::from_str(include_str!("fixtures/distribution-migration-v1.json")).unwrap();
+    assert_eq!(fixture["schema_version"], "tidas.distribution-migration.v1");
+    assert_eq!(
+        fixture["rust_product"]["executables"],
+        serde_json::json!(["tidas"])
+    );
+    assert_eq!(
+        fixture["rust_product"]["runtime_languages"],
+        serde_json::json!([])
+    );
+    assert_eq!(
+        fixture["decisions"]["legacy_entrypoint_compatibility"],
+        false
+    );
+    assert_eq!(fixture["decisions"]["python_wrapper"], false);
+    assert!(fixture["rust_product"]["warning_exit_code"].is_null());
+}
+
+#[test]
+fn cli_success_malformed_input_determinism_and_exit_codes_are_stable() {
+    let temporary = tempfile::tempdir().unwrap();
+    let binary = temporary.path().join("tidas");
+    let license = temporary.path().join("LICENSE");
+    fs::write(&binary, b"native fixture\n").unwrap();
+    fs::write(&license, b"MIT\n").unwrap();
+    let first = temporary.path().join("first");
+    let second = temporary.path().join("second");
+
+    for output_dir in [&first, &second] {
+        let output = command()
+            .args([
+                "package",
+                "--binary",
+                binary.to_str().unwrap(),
+                "--license",
+                license.to_str().unwrap(),
+                "--target",
+                "x86_64-unknown-linux-gnu",
+                "--output-dir",
+                output_dir.to_str().unwrap(),
+            ])
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(0));
+        let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(report["schema_version"], "tidas.distribution-artifact.v1");
+    }
+
+    let archive = "tidas-v0.1.0-x86_64-unknown-linux-gnu.tar.gz";
+    assert_eq!(
+        fs::read(first.join(archive)).unwrap(),
+        fs::read(second.join(archive)).unwrap()
+    );
+
+    let verified = command()
+        .args([
+            "verify",
+            "--archive",
+            first.join(archive).to_str().unwrap(),
+            "--checksum",
+            first.join(format!("{archive}.sha256")).to_str().unwrap(),
+            "--target",
+            "x86_64-unknown-linux-gnu",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(verified.status.code(), Some(0));
+
+    let malformed = command()
+        .args([
+            "package",
+            "--binary",
+            binary.to_str().unwrap(),
+            "--license",
+            license.to_str().unwrap(),
+            "--target",
+            "windows-arm64-not-yet-supported",
+            "--output-dir",
+            temporary.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(malformed.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&malformed.stderr).contains("unsupported release target"));
+}

--- a/crates/tidas-dist/tests/fixtures/distribution-migration-v1.json
+++ b/crates/tidas-dist/tests/fixtures/distribution-migration-v1.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "tidas.distribution-migration.v1",
+  "python_oracle": {
+    "role": "semantic golden oracle only",
+    "distribution": "wheel and source distribution",
+    "legacy_executables": [
+      "tidas-convert",
+      "tidas-import",
+      "tidas-export",
+      "tidas-validate",
+      "tidas-release-tool"
+    ]
+  },
+  "rust_product": {
+    "distribution": "native archive",
+    "executables": [
+      "tidas"
+    ],
+    "runtime_languages": [],
+    "success_exit_code": 0,
+    "malformed_distribution_exit_code": 1,
+    "warning_exit_code": null
+  },
+  "decisions": {
+    "legacy_entrypoint_compatibility": false,
+    "python_wrapper": false,
+    "warning_policy": "distribution verification is fail-closed; no warning completion class exists",
+    "semantic_parity_evidence": "the repository-wide frozen Python suite remains mandatory while packaged Rust smoke compares source-built and extracted behavior"
+  }
+}

--- a/docs/agents/cli-contract.md
+++ b/docs/agents/cli-contract.md
@@ -27,8 +27,8 @@ checkPaths:
   - README.md
   - README_CN.md
 lastReviewedAt: 2026-07-26
-lastReviewedCommit: 9908cab
-lastReviewedNote: "Reviewed for Issue #124 native release: added the action tree, bounded release report, atomic four-package publication, and exit classification."
+lastReviewedCommit: 84dc90f
+lastReviewedNote: "Reviewed for Issue #125 native distribution: the packaged executable preserves the existing seven-command, output, and exit contract without adding an installer command."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,6 +22,7 @@ checkPaths:
   - crates/**
   - contracts/**
   - assets/**
+  - packaging/**
   - migration/**
   - pyproject.toml
   - src/tidas_tools/**
@@ -31,9 +32,11 @@ checkPaths:
   - scripts/schema_lock.py
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
+  - scripts/install.sh
+  - scripts/install.ps1
 lastReviewedAt: 2026-07-26
-lastReviewedCommit: 9908cab
-lastReviewedNote: "Issue #124 adds the native release owner for exact closure, schema-ordered ILCD derivation, semantic round-trip, and atomic four-package publication."
+lastReviewedCommit: 84dc90f
+lastReviewedNote: "Issue #125 adds deterministic executable distribution, pinned static XML dependencies, five-platform qualification, attestations, installers, and package-manager metadata."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -60,6 +63,7 @@ until all #117 exit gates pass.
 | `crates/tidas-import` | bounded external-format detection/parsing, disk-backed canonical storage, deterministic TIDAS/ILCD publication, process bundles, expert mapping CSV, and import reports |
 | `crates/tidas-export` | repeatable-read PostgreSQL extraction, TIDAS/eILCD serialization, version normalization, S3-compatible streaming, and deterministic atomic ZIP publication |
 | `crates/tidas-release` | exact UUID/version release closure, schema-ordered ILCD derivation, native validation and semantic round-trip gates, and four deterministic ZIPs |
+| `crates/tidas-dist` | deterministic native executable archives, SHA-256 verification, packaged smoke probes, and Homebrew/Winget metadata rendered from the same artifact set |
 | `crates/tidas-references` | side-effect-free, version-preserving reference extraction, role classification, and malformed-reference contracts |
 | `crates/tidas-rulesets` | schema-validated methodology/ruleset catalog, referential integrity, selection, and deterministic fingerprinting |
 | `crates/tidas-validation` | offline TIDAS JSON and ILCD/XSD validation, semantic indexes, batch protocol, deterministic traversal, and bounded issue/event spooling |
@@ -76,8 +80,9 @@ import lives in `tidas-import`; native database/package export lives in
 `tidas-export`; and the complete validation domain lives in
 `tidas-validation`, with packaged methodology metadata isolated in
 `tidas-rulesets` and reusable reference extraction isolated in
-`tidas-references`. Native release control lives in `tidas-release`. The CLI
-crate must not absorb domain logic.
+`tidas-references`. Native data-release control lives in `tidas-release`;
+executable distribution lives in `tidas-dist`. The CLI crate must not absorb
+domain or distribution logic.
 
 The command tree is fixed to `convert`, `import`, `export`, `validate`,
 `release`, `ruleset`, and `version`. No old executable alias or Python fallback
@@ -217,7 +222,8 @@ the logical issue-stream hash, and the asset/engine handshake.
 - native XSD/XSLT calls are serialized behind one process-wide lock because the
   Rust wrapper does not establish safe concurrent schema use.
 - development builds dynamically resolve system libraries; release packaging
-  must use controlled, pinned native libraries and record their versions.
+  uses the pinned vcpkg baseline with static libxml2/libxslt and rejects
+  build-machine runtime library paths before packaging.
 - production transforms must install a fail-closed resolver before untrusted
   input is accepted; network and arbitrary filesystem resolution are not part
   of the product contract.
@@ -233,6 +239,7 @@ Review note, 2026-07-17: Issue #112 remains inside the existing validation and r
 | Path group | Role |
 | --- | --- |
 | `Cargo.toml`, `Cargo.lock`, `crates/**` | Rust workspace and final product implementation |
+| `crates/tidas-dist`, `packaging/**`, `scripts/install.*` | deterministic executable archives, checksum-first installers, and generated Homebrew/Winget metadata |
 | `contracts/**` | stable machine-readable Rust report, invocation, conversion, import, export, release, asset-lock, and spool contract schemas |
 | `assets/asset-lock.v1.json` | deterministic executable-asset ownership and integrity lock |
 | `.gitattributes` | cross-platform LF checkout normalization for hashed inputs |
@@ -258,6 +265,7 @@ Review note, 2026-07-17: Issue #112 remains inside the existing validation and r
 | `.github/workflows/ci.yml` | manual-dispatch remote reproduction of schema-lock and local tests |
 | `.github/workflows/dispatch-tidas-sdk-sync.yml` | downstream SDK refresh dispatch contract |
 | `.github/workflows/python-package-deploy.yml` | `main` version-bump and tag-driven PyPI publish workflow with a release test gate |
+| `.github/workflows/rust-release.yml` | five-platform native artifact qualification, SPDX SBOM, GitHub OIDC attestations, clean runtime smoke, metadata validation, and immutable tag publication |
 
 ## Frozen Python oracle families
 
@@ -315,8 +323,19 @@ Foundry gates without moving gate execution logic into this repository.
 
 ## Release And Dispatch Architecture
 
-- `main` pushes whose `pyproject.toml` project version changes create the matching `v<version>` tag and publish `tidas-tools`
-- manual `v<version>` tag pushes and workflow-dispatch runs for existing release tags remain recovery/backfill paths
+- `.github/workflows/rust-release.yml` builds Linux x86_64/ARM64, macOS
+  Intel/Apple Silicon, and Windows x86_64 from one tag/commit and one pinned
+  native dependency baseline
+- every platform archive is built twice and compared byte-for-byte, verified
+  by its SHA-256 sidecar, smoke-tested after extraction, scanned into an SPDX
+  SBOM, and attested through GitHub OIDC/Sigstore
+- tag publication requires `v<workspace-version>`, refuses to modify an
+  existing GitHub Release, and publishes only the already-qualified archives
+- `tidas-dist metadata` renders Homebrew and Winget manifests from those exact
+  checksum sidecars; external tap creation and Winget community submission
+  remain separately approved publication actions
+- the transitional Python workflow remains active only until #126 removes the
+  frozen oracle and PyPI release path
 - changes under packaged English schema, Chinese schema, and methodology paths can dispatch downstream SDK refresh workflows
 - `.github/workflows/rust-ci.yml` exercises Linux x86_64/ARM64, macOS
   Intel/Apple Silicon, and Windows x86_64; Windows ARM64 is a tracked

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,6 +22,7 @@ checkPaths:
   - crates/**
   - contracts/**
   - assets/**
+  - packaging/**
   - migration/**
   - pyproject.toml
   - src/tidas_tools/**
@@ -33,9 +34,11 @@ checkPaths:
   - scripts/schema_lock.py
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
+  - scripts/install.sh
+  - scripts/install.ps1
 lastReviewedAt: 2026-07-26
-lastReviewedCommit: 9908cab
-lastReviewedNote: "Issue #124 adds native release closure, conversion, round-trip, deterministic four-package, cancellation, contract, and bounded-memory proof requirements."
+lastReviewedCommit: 84dc90f
+lastReviewedNote: "Issue #125 adds native executable archive reproducibility, static dependency, SBOM/attestation, installer, package-manager, and clean-runtime proof requirements."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -78,6 +81,7 @@ be removed only by the final #126 cutover.
 | `tidas-import` or `tidas import` | detect and import EcoSpold 1/2, SimaPro CSV, openLCA JSON-LD, openLCA process XLSX, and ILCD; replay frozen Python semantic fixtures; validate TIDAS and requested ILCD; compare package, mapping, and process-bundle hashes across repeated runs and different source roots; prove malformed input, `.zolca`, cancellation, memory-budget, exit-class, and atomic-publication behavior | exercise large exchange streams and issue spools locally; record wall time and peak RSS; confirm source-relative identifiers and gzip bytes are cross-platform deterministic | Canonical entities and exchanges stay disk-backed; issues stream to JSONL; requested outputs are validated before one atomic commit. |
 | `tidas-export` or `tidas export` | replay Python package-version golden cases; focused crate and CLI tests; validate `tidas.export-report.v1`; prove secret redaction, unsafe-path failure, cancellation, memory budget, skipped-document warning, full version suffixes, deterministic ZIP bytes, and atomic replacement | run disposable local PostgreSQL and S3-compatible fixtures twice; compare archive membership/hash/bytes; run a large local record set with wall time and peak RSS | Database reads use a repeatable-read snapshot and bounded queue; object bodies stream by chunk; never begin connector or scale tests on a Worker server. |
 | `tidas-release` or `tidas release` | replay the frozen Python closure/order/round-trip cases; validate `tidas.release-report.v1`; prove missing/inexact references fail closed, standalone contains unit closure, native TIDAS/ILCD validation, four stored ZIPs, fixed metadata, repeatable bytes, cancellation, memory budget, bounded report samples, and atomic whole-directory publication | run the local 237 MiB package twice; record wall time and peak RSS; compare all four archive hashes and membership; keep this local until the target is met | The release layer consumes finalized UUID/version decisions, never assigns them, and never invokes Python. |
+| `tidas-dist`, native installers, package metadata, or Rust release automation | focused `tidas-dist` fmt/clippy/tests; package the local release binary twice and compare archive/checksum bytes; verify and run packaged `version`, help, JSON `version`, and `ruleset`; `bash -n scripts/install.sh`; actionlint; strict docpact | all five release jobs; Linux clean-container execution; macOS runtime dependency inspection; Windows packaged smoke and `winget validate`; SPDX SBOM generation; provenance/SBOM attestation on canonical dispatch/tag | Archives must derive from the supplied binary, pinned static XML libraries, fixed metadata, and the same SHA-256 values used by installers, Homebrew, and Winget. No public tag or external package-manager submission is required to review the pipeline. |
 | `tidas-validation` native package paths | focused crate and CLI tests; compile all eight JSON schemas and all used ILCD roots offline; compare frozen Python parity fixtures; validate issue, summary, describe, and batch payloads against checked-in schemas | run the local 237 MiB benchmark twice with wall time and peak RSS; prove cancellation, XSD import resolution, semantic index parity, and deterministic spool bytes/hash | Issue details must stream or be discarded, never accumulate in the operation report. |
 | `tidas-rulesets` or `tidas ruleset` | schema validation, unique id/reference tests, warning/blocker preservation, catalog and selected-profile CLI probes | compare catalog fingerprint twice and confirm unknown ids use the usage exit class | Packaged methodology metadata remains executable, integrity-locked input; gate execution still belongs to its consumers. |
 | `tidas-references` pure extraction | replay the frozen Python golden cases byte-for-structure; validate every result/edge/issue against the checked-in schema; prove role vocabulary and input failures are closed | exercise repeated/cyclic occurrences, invalid UUID/version/type/id, URI aliases, and explicit-versus-omitted versions | Extraction preserves source constraints and defects but never performs target lookup, visibility, winner selection, or closure. |

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,25 @@
+# Native package-manager metadata
+
+`tidas-dist metadata` generates Homebrew and Winget manifests from the
+SHA-256 sidecars of the same five archives published by the release workflow.
+The package-manager paths never rebuild `tidas`.
+
+For a completed `v0.1.0` artifact set:
+
+```bash
+cargo run --locked -p tidas-dist -- metadata \
+  --release-base-url \
+  https://github.com/tiangong-lca/tidas-tools/releases/download/v0.1.0 \
+  --artifacts-dir dist/artifacts \
+  --output-dir dist/package-metadata
+```
+
+The output is:
+
+- `homebrew/tidas.rb`, ready to copy into an approved `homebrew-*` tap;
+- the three `winget/TianGong.Tidas*.yaml` manifests, ready for `winget
+  validate` and a separately approved community submission.
+
+The release workflow validates and uploads these generated files with every
+tag. Creating an external tap repository or submitting to `microsoft/winget-pkgs`
+is intentionally a separate, human-approved publication action.

--- a/packaging/vcpkg/vcpkg.json
+++ b/packaging/vcpkg/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "tidas-native-release-dependencies",
+  "version-string": "0.1.0",
+  "builtin-baseline": "40f3c709db80acf154ac4b17a1f83c564ebd022e",
+  "dependencies": [
+    "libxslt"
+  ]
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,61 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Version,
+
+    [string]$Destination = "$env:LOCALAPPDATA\Programs\tidas\bin",
+
+    [string]$Repository = "tiangong-lca/tidas-tools"
+)
+
+$ErrorActionPreference = "Stop"
+$Version = $Version.TrimStart("v")
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    throw "Version must be an explicit immutable release version."
+}
+
+if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -ne "X64") {
+    throw "The initial release supports Windows x86_64 only. Windows ARM64 is tracked separately."
+}
+
+$Target = "x86_64-pc-windows-msvc"
+$Archive = "tidas-v$Version-$Target.zip"
+$BaseUrl = "https://github.com/$Repository/releases/download/v$Version"
+$Temporary = Join-Path ([System.IO.Path]::GetTempPath()) ("tidas-install-" + [guid]::NewGuid())
+
+try {
+    New-Item -ItemType Directory -Path $Temporary | Out-Null
+    $ArchivePath = Join-Path $Temporary $Archive
+    $ChecksumPath = "$ArchivePath.sha256"
+    Invoke-WebRequest -UseBasicParsing -Uri "$BaseUrl/$Archive" -OutFile $ArchivePath
+    Invoke-WebRequest -UseBasicParsing -Uri "$BaseUrl/$Archive.sha256" -OutFile $ChecksumPath
+
+    $ChecksumLine = (Get-Content -Raw $ChecksumPath).Trim()
+    $Parts = $ChecksumLine -split "\s+", 2
+    if ($Parts.Count -ne 2 -or $Parts[1] -ne $Archive) {
+        throw "Checksum file does not name $Archive."
+    }
+    $Actual = (Get-FileHash -Algorithm SHA256 $ArchivePath).Hash.ToLowerInvariant()
+    if ($Actual -ne $Parts[0].ToLowerInvariant()) {
+        throw "SHA-256 mismatch for $Archive."
+    }
+
+    $Extracted = Join-Path $Temporary "extracted"
+    Expand-Archive -LiteralPath $ArchivePath -DestinationPath $Extracted
+    $Source = Join-Path $Extracted "tidas-v$Version-$Target\bin\tidas.exe"
+    if (-not (Test-Path -LiteralPath $Source -PathType Leaf)) {
+        throw "Verified archive does not contain bin\tidas.exe."
+    }
+
+    New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+    $Installed = Join-Path $Destination "tidas.exe"
+    Copy-Item -LiteralPath $Source -Destination $Installed -Force
+    & $Installed --version
+    Write-Output "Installed verified tidas v$Version to $Installed"
+    Write-Output "Add $Destination to PATH if it is not already present."
+}
+finally {
+    if (Test-Path -LiteralPath $Temporary) {
+        Remove-Item -LiteralPath $Temporary -Recurse -Force
+    }
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+set -eu
+
+REPOSITORY="${TIDAS_INSTALL_REPOSITORY:-tiangong-lca/tidas-tools}"
+PREFIX="${TIDAS_INSTALL_PREFIX:-/usr/local}"
+VERSION=""
+
+usage() {
+  echo "usage: install.sh --version <VERSION> [--prefix <DIR>]" >&2
+  echo "example: install.sh --version 0.1.0 --prefix \"\$HOME/.local\"" >&2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      [ "$#" -ge 2 ] || {
+        usage
+        exit 2
+      }
+      VERSION="${2#v}"
+      shift 2
+      ;;
+    --prefix)
+      [ "$#" -ge 2 ] || {
+        usage
+        exit 2
+      }
+      PREFIX="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$VERSION" ]; then
+  echo "error: --version is required; installers never resolve an implicit mutable latest release" >&2
+  usage
+  exit 2
+fi
+
+case "$(uname -s)" in
+  Linux) OS="unknown-linux-gnu" ;;
+  Darwin) OS="apple-darwin" ;;
+  *)
+    echo "error: unsupported operating system: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64|amd64) ARCH="x86_64" ;;
+  arm64|aarch64) ARCH="aarch64" ;;
+  *)
+    echo "error: unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+TARGET="${ARCH}-${OS}"
+ARCHIVE="tidas-v${VERSION}-${TARGET}.tar.gz"
+BASE_URL="https://github.com/${REPOSITORY}/releases/download/v${VERSION}"
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tidas-install.XXXXXX")"
+trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
+
+curl --fail --location --proto '=https' --tlsv1.2 \
+  --output "$TEMP_DIR/$ARCHIVE" "$BASE_URL/$ARCHIVE"
+curl --fail --location --proto '=https' --tlsv1.2 \
+  --output "$TEMP_DIR/$ARCHIVE.sha256" "$BASE_URL/$ARCHIVE.sha256"
+
+EXPECTED="$(awk -v file="$ARCHIVE" '$2 == file { print $1 }' "$TEMP_DIR/$ARCHIVE.sha256")"
+if [ -z "$EXPECTED" ]; then
+  echo "error: checksum file does not name $ARCHIVE" >&2
+  exit 1
+fi
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL="$(sha256sum "$TEMP_DIR/$ARCHIVE" | awk '{ print $1 }')"
+elif command -v shasum >/dev/null 2>&1; then
+  ACTUAL="$(shasum -a 256 "$TEMP_DIR/$ARCHIVE" | awk '{ print $1 }')"
+else
+  echo "error: sha256sum or shasum is required to verify the release" >&2
+  exit 1
+fi
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+  echo "error: SHA-256 mismatch for $ARCHIVE" >&2
+  exit 1
+fi
+
+tar -xzf "$TEMP_DIR/$ARCHIVE" -C "$TEMP_DIR"
+SOURCE="$TEMP_DIR/tidas-v${VERSION}-${TARGET}/bin/tidas"
+if [ ! -x "$SOURCE" ]; then
+  echo "error: verified archive does not contain bin/tidas" >&2
+  exit 1
+fi
+
+mkdir -p "$PREFIX/bin"
+install -m 0755 "$SOURCE" "$PREFIX/bin/tidas"
+"$PREFIX/bin/tidas" --version
+echo "installed verified tidas v${VERSION} to $PREFIX/bin/tidas"


### PR DESCRIPTION
Closes #125

## Summary
- Add the internal tidas-dist Rust crate for byte-stable native archives, SHA-256 verification, packaged smoke probes, and Homebrew/Winget metadata derived from one artifact set.
- Add a five-platform GitHub Actions release pipeline with pinned static libxml2/libxslt, repeat-build comparison, clean Linux container smoke, SPDX SBOMs, GitHub OIDC provenance/SBOM attestations, and immutable tag publication.
- Add checksum-first POSIX and PowerShell installers plus English/Chinese user and agent guidance.

## Key Decisions
- Keep data release orchestration in tidas-release and executable distribution in tidas-dist; the public CLI remains one tidas binary with seven commands.
- Package-manager metadata consumes the exact archive checksums and never rebuilds tidas; external Homebrew tap creation and Winget community submission remain separately approved actions.
- Distribution verification is fail-closed, so this slice has no warning completion exit class; the migration fixture records Python as semantic oracle only and forbids legacy/Python product entry points.

## Validation
- Local macOS release binary packaged twice byte-for-byte with SHA-256 48315e1f070e805c309efc4c4f7dce069ae78321b6f374f79cca7ac8d9f3658f; extracted version/help/JSON version/ruleset smoke passed.
- cargo fmt --all --check; cargo clippy --locked --workspace --all-targets -- -D warnings; cargo test --locked --workspace --all-targets; asset lock passed.
- schema lock, Black, and all 168 frozen Python oracle tests passed locally and again in the pre-push gate.
- actionlint v1.7.12, bash -n, strict docpact config, and staged enforced docpact lint passed.
- GitHub Actions passed Rust CI plus the native release matrix on Linux x86_64/ARM64, macOS Intel/Apple Silicon, and Windows x86_64; aggregate checksum/metadata checks and the Windows Winget validator also passed.

## Risks / Rollback
- All five platform artifact jobs are qualified on this PR. OIDC provenance and SBOM attestations intentionally run only on a canonical dispatch/tag, so the first approved release tag remains the final production attestation proof; no tag or public GitHub Release is created by this PR.

## Follow-ups
- Windows ARM64 is explicitly tracked as #134 (Backlog/P2/v0.2).
- Before the first public candidate, bump the Cargo workspace to the approved v0.1.0-rc.1 version/tag and separately approve any external tap or Winget submission.

## Workspace Integration
- Workspace Integration remains Pending until this PR is merged and the qualified native release is included in the root cutover.
