### PR TITLE
chore: prepare exact v0.1.1 Rust release set

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-27"
-lastReviewedCommit: "30ebe5df9c53d958f01393517867e7f0b2455943"
+lastReviewedCommit: "6a0db19c3a7c8f92c2ee455ae83a158c5a3f91e1"
 # Native Rust domain ownership includes bounded conversion, import, export,
 # release packaging, validation, references, rulesets, assets, runtime, and
 # the thin unified CLI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ checkPaths:
   - scripts/validate-release-request.sh
   - scripts/sync-rust-package-assets.sh
 lastReviewedAt: 2026-07-27
-lastReviewedCommit: 30ebe5df9c53d958f01393517867e7f0b2455943
-lastReviewedNote: "Reviewed for Issue #140: typed Flow normalization, import preflight, versioned elementary taxonomy extension, full flow-property fidelity, and dual-language schema locks preserve repo ownership and validation boundaries."
+lastReviewedCommit: 6a0db19c3a7c8f92c2ee455ae83a158c5a3f91e1
+lastReviewedNote: "Reviewed for Issue #142 phase 1: the exact v0.1.1 Rust version set, repository-private tidas-dist boundary, five supported native targets, and release-request separation preserve repo ownership and delivery gates."
 related:
   - .docpact/config.yaml
   - docs/agents/cli-contract.md
@@ -121,7 +121,7 @@ Keep these entry-level facts in `AGENTS.md`. Use `README.md`, `README_CN.md`, an
 - crates.io package gate: `scripts/publish-crates.sh check`
 - source installation package: `cargo install tidas --version <version> --locked`
 - all public Rust crates use the same exact workspace version; `tidas-dist` is never published
-- initial native artifact matrix: Linux x86_64/ARM64, macOS Intel/Apple Silicon, and Windows x86_64; Windows ARM64 is a separately tracked second phase
+- supported native artifact matrix: Linux x86_64/ARM64, macOS Intel/Apple Silicon, and Windows x86_64; Windows ARM64 is not supported
 - migration-oracle package manager and runner: `uv`
 - routine branch base: `main`
 - routine PR base: `main`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,7 +2455,7 @@ dependencies = [
 
 [[package]]
 name = "tidas"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-assets"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "include_dir",
  "serde",
@@ -2489,7 +2489,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-contracts"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2498,7 +2498,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-conversion"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "jsonschema",
  "quick-xml",
@@ -2514,7 +2514,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-dist"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "flate2",
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-export"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "futures-util",
  "jsonschema",
@@ -2553,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-import"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bigdecimal",
  "encoding_rs",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-references"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "jsonschema",
  "serde",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-release"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "jsonschema",
  "serde",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-rulesets"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "jsonschema",
  "noyalib",
@@ -2618,7 +2618,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-runtime"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "crossbeam-channel",
  "serde",
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-validation"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "jsonschema",
  "quick-xml",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-xml"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "libxml",
  "libxslt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ libxslt development dependencies can install the unified executable from
 source:
 
 ```bash
-cargo install tidas --version 0.1.0 --locked
+cargo install tidas --version 0.1.1 --locked
 ```
 
 All public workspace crates use the exact same version so Cargo cannot combine
@@ -172,17 +172,17 @@ After a native version is published, install an explicit immutable version:
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSLO \
   https://raw.githubusercontent.com/tiangong-lca/tidas-tools/main/scripts/install.sh
-sh install.sh --version 0.1.0 --prefix "$HOME/.local"
+sh install.sh --version 0.1.1 --prefix "$HOME/.local"
 ```
 
 ```powershell
-.\scripts\install.ps1 -Version 0.1.0
+.\scripts\install.ps1 -Version 0.1.1
 ```
 
 Every GitHub Release also carries generated Homebrew formula and Winget
 manifests that reference the same archive hashes. External tap creation or a
 Winget community submission is a separate publication approval; those paths
-never rebuild the executable. Windows ARM64 is a tracked second-phase target.
+never rebuild the executable. Windows ARM64 is not supported.
 
 The Python package described below is feature-frozen and remains temporarily
 available as an internal golden/parity oracle. It is not the final product and

--- a/README_CN.md
+++ b/README_CN.md
@@ -139,7 +139,7 @@ provenance/SBOM attestation。固定版本且静态链接的 libxml2/libxslt 使
 libxml2/libxslt 开发依赖的开发者，也可从源码安装唯一的统一 executable：
 
 ```bash
-cargo install tidas --version 0.1.0 --locked
+cargo install tidas --version 0.1.1 --locked
 ```
 
 全部公开 workspace crates 使用完全相同的精确版本，避免 Cargo 混用不兼容的领域
@@ -158,16 +158,16 @@ tag，再显式从该 tag dispatch 原生 release workflow，使 artifact proven
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSLO \
   https://raw.githubusercontent.com/tiangong-lca/tidas-tools/main/scripts/install.sh
-sh install.sh --version 0.1.0 --prefix "$HOME/.local"
+sh install.sh --version 0.1.1 --prefix "$HOME/.local"
 ```
 
 ```powershell
-.\scripts\install.ps1 -Version 0.1.0
+.\scripts\install.ps1 -Version 0.1.1
 ```
 
 每个 GitHub Release 同时携带由相同归档哈希生成的 Homebrew formula 与 Winget
 manifests。创建外部 tap 或提交 Winget community 需要单独批准，且这些路径绝不
-重新构建 executable。Windows ARM64 是明确跟踪的第二阶段目标。
+重新构建 executable。Windows ARM64 不受支持。
 
 下文记录的 Python 包已经 feature freeze，只在迁移期间作为内部 golden/parity
 oracle。它不是最终产品，旧可执行文件名和参数布局不会保留。只有 Rust 功能语义、

--- a/crates/tidas-cli/Cargo.toml
+++ b/crates/tidas-cli/Cargo.toml
@@ -22,16 +22,16 @@ clap_complete.workspace = true
 ctrlc.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tidas-assets = { version = "=0.1.0", path = "../.." }
-tidas-conversion = { version = "=0.1.0", path = "../tidas-conversion" }
-tidas-contracts = { version = "=0.1.0", path = "../tidas-contracts" }
-tidas-export = { version = "=0.1.0", path = "../tidas-export" }
-tidas-import = { version = "=0.1.0", path = "../tidas-import" }
-tidas-release = { version = "=0.1.0", path = "../tidas-release" }
-tidas-runtime = { version = "=0.1.0", path = "../tidas-runtime" }
-tidas-rulesets = { version = "=0.1.0", path = "../tidas-rulesets" }
-tidas-validation = { version = "=0.1.0", path = "../tidas-validation" }
-tidas-xml = { version = "=0.1.0", path = "../tidas-xml" }
+tidas-assets = { version = "=0.1.1", path = "../.." }
+tidas-conversion = { version = "=0.1.1", path = "../tidas-conversion" }
+tidas-contracts = { version = "=0.1.1", path = "../tidas-contracts" }
+tidas-export = { version = "=0.1.1", path = "../tidas-export" }
+tidas-import = { version = "=0.1.1", path = "../tidas-import" }
+tidas-release = { version = "=0.1.1", path = "../tidas-release" }
+tidas-runtime = { version = "=0.1.1", path = "../tidas-runtime" }
+tidas-rulesets = { version = "=0.1.1", path = "../tidas-rulesets" }
+tidas-validation = { version = "=0.1.1", path = "../tidas-validation" }
+tidas-xml = { version = "=0.1.1", path = "../tidas-xml" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/tidas-conversion/Cargo.toml
+++ b/crates/tidas-conversion/Cargo.toml
@@ -19,8 +19,8 @@ serde_json = { workspace = true, features = ["arbitrary_precision"] }
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tidas-assets = { version = "=0.1.0", path = "../.." }
-tidas-runtime = { version = "=0.1.0", path = "../tidas-runtime" }
+tidas-assets = { version = "=0.1.1", path = "../.." }
+tidas-runtime = { version = "=0.1.1", path = "../tidas-runtime" }
 walkdir.workspace = true
 
 [dev-dependencies]

--- a/crates/tidas-dist/tests/cli_contract.rs
+++ b/crates/tidas-dist/tests/cli_contract.rs
@@ -58,17 +58,20 @@ fn cli_success_malformed_input_determinism_and_exit_codes_are_stable() {
         assert_eq!(report["schema_version"], "tidas.distribution-artifact.v1");
     }
 
-    let archive = "tidas-v0.1.0-x86_64-unknown-linux-gnu.tar.gz";
+    let archive = format!(
+        "tidas-v{}-x86_64-unknown-linux-gnu.tar.gz",
+        env!("CARGO_PKG_VERSION")
+    );
     assert_eq!(
-        fs::read(first.join(archive)).unwrap(),
-        fs::read(second.join(archive)).unwrap()
+        fs::read(first.join(&archive)).unwrap(),
+        fs::read(second.join(&archive)).unwrap()
     );
 
     let verified = command()
         .args([
             "verify",
             "--archive",
-            first.join(archive).to_str().unwrap(),
+            first.join(&archive).to_str().unwrap(),
             "--checksum",
             first.join(format!("{archive}.sha256")).to_str().unwrap(),
             "--target",
@@ -86,7 +89,7 @@ fn cli_success_malformed_input_determinism_and_exit_codes_are_stable() {
             "--license",
             license.to_str().unwrap(),
             "--target",
-            "windows-arm64-not-yet-supported",
+            "windows-arm64-unsupported",
             "--output-dir",
             temporary.path().to_str().unwrap(),
         ])

--- a/crates/tidas-export/Cargo.toml
+++ b/crates/tidas-export/Cargo.toml
@@ -21,8 +21,8 @@ serde_json = { workspace = true, features = ["preserve_order"] }
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tidas-conversion = { version = "=0.1.0", path = "../tidas-conversion" }
-tidas-runtime = { version = "=0.1.0", path = "../tidas-runtime" }
+tidas-conversion = { version = "=0.1.1", path = "../tidas-conversion" }
+tidas-runtime = { version = "=0.1.1", path = "../tidas-runtime" }
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-postgres-rustls.workspace = true

--- a/crates/tidas-import/Cargo.toml
+++ b/crates/tidas-import/Cargo.toml
@@ -22,10 +22,10 @@ serde_json = { workspace = true, features = ["arbitrary_precision", "preserve_or
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tidas-assets = { version = "=0.1.0", path = "../.." }
-tidas-conversion = { version = "=0.1.0", path = "../tidas-conversion" }
-tidas-runtime = { version = "=0.1.0", path = "../tidas-runtime" }
-tidas-validation = { version = "=0.1.0", path = "../tidas-validation" }
+tidas-assets = { version = "=0.1.1", path = "../.." }
+tidas-conversion = { version = "=0.1.1", path = "../tidas-conversion" }
+tidas-runtime = { version = "=0.1.1", path = "../tidas-runtime" }
+tidas-validation = { version = "=0.1.1", path = "../tidas-validation" }
 uuid.workspace = true
 walkdir.workspace = true
 zip.workspace = true

--- a/crates/tidas-release/Cargo.toml
+++ b/crates/tidas-release/Cargo.toml
@@ -18,16 +18,16 @@ serde_json = { workspace = true, features = ["preserve_order"] }
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tidas-assets = { version = "=0.1.0", path = "../.." }
-tidas-conversion = { version = "=0.1.0", path = "../tidas-conversion" }
-tidas-runtime = { version = "=0.1.0", path = "../tidas-runtime" }
-tidas-validation = { version = "=0.1.0", path = "../tidas-validation" }
+tidas-assets = { version = "=0.1.1", path = "../.." }
+tidas-conversion = { version = "=0.1.1", path = "../tidas-conversion" }
+tidas-runtime = { version = "=0.1.1", path = "../tidas-runtime" }
+tidas-validation = { version = "=0.1.1", path = "../tidas-validation" }
 walkdir.workspace = true
 zip.workspace = true
 
 [dev-dependencies]
 jsonschema.workspace = true
-tidas-import = { version = "=0.1.0", path = "../tidas-import" }
+tidas-import = { version = "=0.1.1", path = "../tidas-import" }
 
 [lints]
 workspace = true

--- a/crates/tidas-rulesets/Cargo.toml
+++ b/crates/tidas-rulesets/Cargo.toml
@@ -19,7 +19,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-tidas-assets = { version = "=0.1.0", path = "../.." }
+tidas-assets = { version = "=0.1.1", path = "../.." }
 
 [lints]
 workspace = true

--- a/crates/tidas-validation/Cargo.toml
+++ b/crates/tidas-validation/Cargo.toml
@@ -20,10 +20,10 @@ serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tidas-assets = { version = "=0.1.0", path = "../.." }
-tidas-runtime = { version = "=0.1.0", path = "../tidas-runtime" }
-tidas-rulesets = { version = "=0.1.0", path = "../tidas-rulesets" }
-tidas-xml = { version = "=0.1.0", path = "../tidas-xml" }
+tidas-assets = { version = "=0.1.1", path = "../.." }
+tidas-runtime = { version = "=0.1.1", path = "../tidas-runtime" }
+tidas-rulesets = { version = "=0.1.1", path = "../tidas-rulesets" }
+tidas-xml = { version = "=0.1.1", path = "../tidas-xml" }
 walkdir.workspace = true
 
 [lints]

--- a/docs/agents/cli-contract.md
+++ b/docs/agents/cli-contract.md
@@ -26,9 +26,9 @@ checkPaths:
   - contracts/**
   - README.md
   - README_CN.md
-lastReviewedAt: 2026-07-26
-lastReviewedCommit: 9053f3bcdd1aa692c3ae56fbcda8566d373fccdc
-lastReviewedNote: "Reviewed for Issue #138 merge-gated v0.1.0 release authorization: release automation does not change the seven-command, output, or exit contract."
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: 6a0db19c3a7c8f92c2ee455ae83a158c5a3f91e1
+lastReviewedNote: "Reviewed for Issue #142 phase 1: the v0.1.1 exact version-set preparation does not change the seven-command, report, output-channel, or exit contract."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -38,9 +38,9 @@ checkPaths:
   - scripts/test-release-request.sh
   - scripts/validate-release-request.sh
   - scripts/sync-rust-package-assets.sh
-lastReviewedAt: 2026-07-26
-lastReviewedCommit: eed5ed2
-lastReviewedNote: "Issue #138 makes an append-only Release Request PR the reviewed authorization for an exact tag and tag-context release dispatch."
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: 6a0db19c3a7c8f92c2ee455ae83a158c5a3f91e1
+lastReviewedNote: "Issue #142 phase 1 prepares the exact v0.1.1 Rust set while keeping tidas-dist private and deferring the immutable Release Request until the preparation merge commit exists."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -378,8 +378,7 @@ Foundry gates without moving gate execution logic into this repository.
   frozen oracle and PyPI release path
 - changes under packaged English schema, Chinese schema, and methodology paths can dispatch downstream SDK refresh workflows
 - `.github/workflows/rust-ci.yml` exercises Linux x86_64/ARM64, macOS
-  Intel/Apple Silicon, and Windows x86_64; Windows ARM64 is a tracked
-  second-phase target
+  Intel/Apple Silicon, and Windows x86_64; Windows ARM64 is not supported
 
 This dispatch path is part of the repo architecture, not just a convenience automation.
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -40,9 +40,9 @@ checkPaths:
   - scripts/test-release-request.sh
   - scripts/validate-release-request.sh
   - scripts/sync-rust-package-assets.sh
-lastReviewedAt: 2026-07-26
-lastReviewedCommit: eed5ed2
-lastReviewedNote: "Issue #138 adds secret-free Release Request validation, exact target/tag checks, and merge-only tag-context release dispatch."
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: 6a0db19c3a7c8f92c2ee455ae83a158c5a3f91e1
+lastReviewedNote: "Issue #142 phase 1 requires Rust 1.88 product gates, Cargo 1.94 public-set qualification, release-request tamper tests, deterministic package smoke, and the five-platform PR matrix without publication credentials."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/packaging/vcpkg/vcpkg.json
+++ b/packaging/vcpkg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidas-native-release-dependencies",
-  "version-string": "0.1.0",
+  "version-string": "0.1.1",
   "builtin-baseline": "40f3c709db80acf154ac4b17a1f83c564ebd022e",
   "dependencies": [
     "libxslt"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -15,7 +15,7 @@ if ([string]::IsNullOrWhiteSpace($Version)) {
 }
 
 if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -ne "X64") {
-    throw "The initial release supports Windows x86_64 only. Windows ARM64 is tracked separately."
+    throw "The supported Windows release target is x86_64 only. Windows ARM64 is not supported."
 }
 
 $Target = "x86_64-pc-windows-msvc"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@ VERSION=""
 
 usage() {
   echo "usage: install.sh --version <VERSION> [--prefix <DIR>]" >&2
-  echo "example: install.sh --version 0.1.0 --prefix \"\$HOME/.local\"" >&2
+  echo "example: install.sh --version 0.1.1 --prefix \"\$HOME/.local\"" >&2
 }
 
 while [ "$#" -gt 0 ]; do


### PR DESCRIPTION
## Summary
- Phase 1 of #142: advance all public Rust crates and the unified tidas CLI to the exact 0.1.1 workspace version.
- Synchronize Cargo.lock, exact internal dependency edges, vcpkg/native installer metadata, and supported-platform documentation.

## Key Decisions
- Keep tidas-dist repository-private while version-synchronizing it for deterministic artifact naming.
- Keep the immutable v0.1.0 request/tamper fixtures and completed artifact example unchanged; do not create the v0.1.1 Release Request until this PR has an exact merge commit.
- Support Linux x86_64/ARM64, macOS Intel/Apple Silicon, and Windows x86_64; Windows ARM64 is unsupported.

## Validation
- Rust 1.88: cargo fmt, denied-warnings workspace Clippy, and all workspace/all-target tests passed.
- Cargo 1.94: sync-rust-package-assets and publish-crates check qualified the exact 12-crate dependency order with package verification, local-registry resolution, checksums, and credential-free dry-run.
- Deterministic native package smoke passed on macOS Apple Silicon: repeated archive/checksum bytes matched, packaged version/ruleset probes passed, and cargo install reported 0.1.1.
- Python oracle: schema lock, Black, and 169 pytest cases passed; release-request tamper tests, actionlint, strict docpact config, and base/head docpact gate passed.
- PR qualification passed on Linux x86_64/ARM64, macOS Intel/Apple Silicon, and Windows x86_64 in both Rust CI and Native Rust Release; aggregate checksums/package metadata and Winget validation passed, while tag-only publication jobs were skipped.

## Risks / Rollback
- Rollback is one commit revert; this phase creates no tag, Release Request, registry upload, GitHub Release, external package-manager submission, or production mutation.

## Follow-ups
- After this preparation PR merges, use its exact merge commit to prepare the separately reviewed immutable v0.1.1 Release Request. Actual tag/publication remains a later phase of #142.

## Workspace Integration
- Workspace integration remains Pending until the release train completes; this PR does not update the lca-workspace submodule pointer.