### PR TITLE
release: request tidas v0.1.1 publication

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-27"
-lastReviewedCommit: "6a0db19c3a7c8f92c2ee455ae83a158c5a3f91e1"
+lastReviewedCommit: "522c4e86f6d6934fed3f2e0940cb3c46cf7569d6"
 # Native Rust domain ownership includes bounded conversion, import, export,
 # release packaging, validation, references, rulesets, assets, runtime, and
 # the thin unified CLI.

--- a/.github/releases/v0.1.1.json
+++ b/.github/releases/v0.1.1.json
@@ -1,0 +1,5 @@
+{
+  "request_schema": "tidas.release-request.v1",
+  "version": "0.1.1",
+  "target": "522c4e86f6d6934fed3f2e0940cb3c46cf7569d6"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ checkPaths:
   - scripts/validate-release-request.sh
   - scripts/sync-rust-package-assets.sh
 lastReviewedAt: 2026-07-27
-lastReviewedCommit: 6a0db19c3a7c8f92c2ee455ae83a158c5a3f91e1
+lastReviewedCommit: 522c4e86f6d6934fed3f2e0940cb3c46cf7569d6
 lastReviewedNote: "Reviewed for Issue #142 phase 1: the exact v0.1.1 Rust version set, repository-private tidas-dist boundary, five supported native targets, and release-request separation preserve repo ownership and delivery gates."
 related:
   - .docpact/config.yaml

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ checkPaths:
   - scripts/validate-release-request.sh
   - scripts/sync-rust-package-assets.sh
   - .github/workflows/**
-lastReviewedAt: 2026-07-26
-lastReviewedCommit: eed5ed2
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: 522c4e86f6d6934fed3f2e0940cb3c46cf7569d6
 lastReviewedNote: "Issue #138 makes a reviewed append-only Release Request PR the authorization for an exact native tag and release dispatch."
 related:
   - AGENTS.md

--- a/README_CN.md
+++ b/README_CN.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/test-release-request.sh
   - scripts/validate-release-request.sh
   - scripts/sync-rust-package-assets.sh
-lastReviewedAt: 2026-07-26
-lastReviewedCommit: eed5ed2
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: 522c4e86f6d6934fed3f2e0940cb3c46cf7569d6
 lastReviewedNote: "Issue #138 将经过评审、只追加的 Release Request PR 设为精确 native tag 与 release dispatch 的授权入口。"
 related:
   - AGENTS.md

--- a/docs/agents/cli-contract.md
+++ b/docs/agents/cli-contract.md
@@ -27,7 +27,7 @@ checkPaths:
   - README.md
   - README_CN.md
 lastReviewedAt: 2026-07-27
-lastReviewedCommit: 6a0db19c3a7c8f92c2ee455ae83a158c5a3f91e1
+lastReviewedCommit: 522c4e86f6d6934fed3f2e0940cb3c46cf7569d6
 lastReviewedNote: "Reviewed for Issue #142 phase 1: the v0.1.1 exact version-set preparation does not change the seven-command, report, output-channel, or exit contract."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -39,7 +39,7 @@ checkPaths:
   - scripts/validate-release-request.sh
   - scripts/sync-rust-package-assets.sh
 lastReviewedAt: 2026-07-27
-lastReviewedCommit: 6a0db19c3a7c8f92c2ee455ae83a158c5a3f91e1
+lastReviewedCommit: 522c4e86f6d6934fed3f2e0940cb3c46cf7569d6
 lastReviewedNote: "Issue #142 phase 1 prepares the exact v0.1.1 Rust set while keeping tidas-dist private and deferring the immutable Release Request until the preparation merge commit exists."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -41,7 +41,7 @@ checkPaths:
   - scripts/validate-release-request.sh
   - scripts/sync-rust-package-assets.sh
 lastReviewedAt: 2026-07-27
-lastReviewedCommit: 6a0db19c3a7c8f92c2ee455ae83a158c5a3f91e1
+lastReviewedCommit: 522c4e86f6d6934fed3f2e0940cb3c46cf7569d6
 lastReviewedNote: "Issue #142 phase 1 requires Rust 1.88 product gates, Cargo 1.94 public-set qualification, release-request tamper tests, deterministic package smoke, and the five-platform PR matrix without publication credentials."
 related:
   - ../../AGENTS.md


### PR DESCRIPTION
## Summary
- Add the immutable v0.1.1 Release Request bound to exact canonical-main commit `522c4e86f6d6934fed3f2e0940cb3c46cf7569d6`.
- Record docpact review evidence for the unchanged release, architecture, validation, CLI, and user-guide contracts required by the request path.

Refs #142

## Immutable preflight
- `origin/main` was exactly `522c4e86f6d6934fed3f2e0940cb3c46cf7569d6` before branch creation.
- Remote `v0.1.1` tag, GitHub Release, existing request file/PR/branch, and all 12 public crates.io 0.1.1 versions were absent.
- The request is append-only and its target Cargo workspace version is exactly 0.1.1.

## Validation
- `scripts/validate-release-request.sh .github/releases/v0.1.1.json HEAD`
- `scripts/test-release-request.sh` plus Bash syntax checks
- actionlint for release-request and rust-release workflows
- docpact strict config, routed review evidence, staged/base-head enforce lint
- executable asset lock
- Rust fmt, workspace/all-target Clippy with warnings denied, and workspace/all-target tests
- Python schema lock, Black, and 169 pytest cases
- PR-event audit: Release Request validation has read-only contents permission and no secret reference; tag authorization is gated to a push on `main`; crates.io token and publication jobs are tag-only

## Scope and safety
- The only product change is `.github/releases/v0.1.1.json`; other touched lines are docpact `lastReviewedAt/Commit` evidence only.
- This PR does not create a tag, dispatch a workflow, read `CARGO_REGISTRY_TOKEN`, publish crates/artifacts/GitHub Release, merge itself, update the root pointer, or change CLI #211 / Foundry #51.
- Windows ARM64 remains unsupported. Workspace Integration remains Pending.

## After review
- Merging this PR is the immutable publication authorization. Actual crates.io, five-platform artifact, checksum, SBOM, attestation, and GitHub Release verification remain open in #142.