### PR TITLE
fix: bound schema validation diagnostics

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,9 +1,9 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-27"
-lastReviewedCommit: "f7a56243cfc6d38114dac396893889e748c68c88"
-# Issue #126 makes the Cargo workspace, top-level executable assets, unified
-# CLI, native distribution, and Rust-only proof paths the active architecture.
+lastReviewedAt: "2026-07-28"
+lastReviewedCommit: "0d3170f3f4af0f25a63be49ff63585af1b53f76b"
+# Reviewed for Issue #146: validation and Worker protocol changes remain routed
+# through the existing Rust product/runtime contracts and proof paths.
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/**
   - .github/workflows/**
   - .githooks/pre-push
-lastReviewedAt: 2026-07-27
-lastReviewedCommit: f7a56243cfc6d38114dac396893889e748c68c88
-lastReviewedNote: "Issue #126 makes the Rust workspace and unified tidas executable the only active implementation, CI, release, and development path."
+lastReviewedAt: 2026-07-28
+lastReviewedCommit: 0d3170f3f4af0f25a63be49ff63585af1b53f76b
+lastReviewedNote: "Reviewed for Issue #146: bounded schema diagnostics preserve the Rust-only validation, streaming, deterministic-contract, and Worker integration rules."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/crates/tidas-validation/src/batch.rs
+++ b/crates/tidas-validation/src/batch.rs
@@ -752,6 +752,51 @@ mod tests {
     }
 
     #[test]
+    fn oversized_schema_issue_stays_within_the_batch_frame_limit() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("batch");
+        fs::create_dir_all(root.join("sources")).unwrap();
+        let oversized = "x".repeat(2 * 1024 * 1024);
+        let document = serde_json::to_vec(&oversized).unwrap();
+        fs::write(root.join("sources/bad.json"), &document).unwrap();
+        let manifest = directory.path().join("manifest.jsonl");
+        fs::write(
+            &manifest,
+            format!(
+                "{{\"document_key\":\"source:oversized:01.00.000\",\"category\":\"sources\",\"relative_path\":\"sources/bad.json\",\"content_sha256\":\"{}\",\"identity\":{{\"dataset_type\":\"source\",\"dataset_id\":\"22222222-2222-2222-2222-222222222222\",\"dataset_version\":\"01.00.000\"}}}}\n",
+                hex_sha256(&document)
+            ),
+        )
+        .unwrap();
+        let events = directory.path().join("events.jsonl");
+
+        let first = run_document_validation_batch(&request(&root, &manifest, &events)).unwrap();
+        let first_bytes = fs::read(&events).unwrap();
+        let second = run_document_validation_batch(&request(&root, &manifest, &events)).unwrap();
+        let second_bytes = fs::read(&events).unwrap();
+
+        assert_eq!(first.final_event, second.final_event);
+        assert_eq!(first_bytes, second_bytes);
+        let lines: Vec<&[u8]> = first_bytes.split_inclusive(|byte| *byte == b'\n').collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].len() <= MAX_EVENT_BYTES);
+        let issue_event: Value = serde_json::from_slice(lines[0]).unwrap();
+        assert_eq!(issue_event["type"], "issue");
+        assert_eq!(issue_event["issue"]["context"]["schema_keyword"], "type");
+        assert_eq!(
+            issue_event["issue"]["context"]["instance_byte_length"],
+            Value::from(oversized.len() as u64)
+        );
+        assert_eq!(
+            first.final_event.logical_issue_stream_sha256,
+            hex_sha256(lines[0])
+        );
+        let final_event: Value = serde_json::from_slice(lines[1]).unwrap();
+        assert_eq!(final_event["type"], "final");
+        assert_eq!(first.final_event.summary.error_count, 1);
+    }
+
+    #[test]
     fn unsafe_paths_duplicates_and_hash_drift_fail_before_completion() {
         let directory = tempfile::tempdir().unwrap();
         let root = directory.path().join("batch");

--- a/crates/tidas-validation/src/schema.rs
+++ b/crates/tidas-validation/src/schema.rs
@@ -1,8 +1,11 @@
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
 
+use jsonschema::error::ValidationErrorKind;
 use jsonschema::{Resource, Validator};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 use tidas_assets::{AssetKind, bundled_assets};
 
@@ -10,6 +13,9 @@ use crate::contracts::ValidationIssueV1;
 
 const SCHEMA_ASSET_PREFIX: &str = "assets/tidas/schemas/";
 const SCHEMA_BASE_URI: &str = "https://tiangong.earth/assets/tidas/schemas/";
+const MAX_SCHEMA_MESSAGE_BYTES: usize = 16 * 1024;
+const MAX_INSTANCE_PREVIEW_BYTES: usize = 256;
+const MAX_LOCATION_BYTES: usize = 4 * 1024;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -147,15 +153,184 @@ impl TidasValidator {
             } else {
                 location
             };
-            ValidationIssueV1::error(
+            let bounded_location = bounded_text(&location, MAX_LOCATION_BYTES);
+            let schema_path = error.schema_path().to_string();
+            let detail = error.masked_with("<instance>").to_string();
+            let raw_message = format!(
+                "Schema error at {} (keyword: {}): {detail}",
+                bounded_location.value,
+                schema_keyword(error.kind())
+            );
+            let bounded_message = bounded_text(&raw_message, MAX_SCHEMA_MESSAGE_BYTES);
+            let message = bounded_message.value.clone();
+            let mut issue = ValidationIssueV1::error(
                 "schema_error",
                 self.category.as_str(),
                 file_path,
-                &location,
-                format!("Schema Error at {location}: {error}"),
-            )
+                &bounded_location.value,
+                message,
+            );
+            issue.context.insert(
+                "schema_keyword".to_owned(),
+                Value::String(schema_keyword(error.kind()).to_owned()),
+            );
+            issue
+                .context
+                .insert("schema_path".to_owned(), Value::String(schema_path));
+            add_instance_context(error.instance(), &mut issue.context);
+            add_truncation_context("location", &bounded_location, &mut issue.context);
+            add_truncation_context("diagnostic", &bounded_message, &mut issue.context);
+            issue
         })
     }
+}
+
+struct BoundedText {
+    value: String,
+    original_bytes: Option<usize>,
+    sha256: Option<String>,
+}
+
+fn bounded_text(value: &str, max_bytes: usize) -> BoundedText {
+    if value.len() <= max_bytes {
+        return BoundedText {
+            value: value.to_owned(),
+            original_bytes: None,
+            sha256: None,
+        };
+    }
+    let prefix = utf8_prefix(value, max_bytes);
+    BoundedText {
+        value: prefix.to_owned(),
+        original_bytes: Some(value.len()),
+        sha256: Some(sha256_hex(value.as_bytes())),
+    }
+}
+
+fn utf8_prefix(value: &str, max_bytes: usize) -> &str {
+    let mut end = value.len().min(max_bytes);
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    &value[..end]
+}
+
+fn add_truncation_context(
+    prefix: &str,
+    bounded: &BoundedText,
+    context: &mut BTreeMap<String, Value>,
+) {
+    let (Some(original_bytes), Some(sha256)) = (bounded.original_bytes, bounded.sha256.as_ref())
+    else {
+        return;
+    };
+    context.insert(format!("{prefix}_truncated"), Value::Bool(true));
+    context.insert(
+        format!("{prefix}_original_bytes"),
+        Value::from(original_bytes as u64),
+    );
+    context.insert(format!("{prefix}_sha256"), Value::String(sha256.clone()));
+}
+
+fn add_instance_context(instance: &Value, context: &mut BTreeMap<String, Value>) {
+    context.insert(
+        "instance_type".to_owned(),
+        Value::String(instance_type(instance).to_owned()),
+    );
+    match instance {
+        Value::Null => {}
+        Value::Bool(value) => {
+            context.insert("instance_preview".to_owned(), Value::Bool(*value));
+        }
+        Value::Number(value) => {
+            context.insert("instance_preview".to_owned(), Value::Number(value.clone()));
+        }
+        Value::String(value) => {
+            context.insert(
+                "instance_byte_length".to_owned(),
+                Value::from(value.len() as u64),
+            );
+            let preview = bounded_text(value, MAX_INSTANCE_PREVIEW_BYTES);
+            context.insert(
+                "instance_preview".to_owned(),
+                Value::String(preview.value.clone()),
+            );
+            add_truncation_context("instance_preview", &preview, context);
+        }
+        Value::Array(values) => {
+            context.insert(
+                "instance_item_count".to_owned(),
+                Value::from(values.len() as u64),
+            );
+        }
+        Value::Object(values) => {
+            context.insert(
+                "instance_property_count".to_owned(),
+                Value::from(values.len() as u64),
+            );
+        }
+    }
+}
+
+const fn instance_type(instance: &Value) -> &'static str {
+    match instance {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+const fn schema_keyword(kind: &ValidationErrorKind) -> &'static str {
+    match kind {
+        ValidationErrorKind::AdditionalItems { .. } => "additionalItems",
+        ValidationErrorKind::AdditionalProperties { .. } => "additionalProperties",
+        ValidationErrorKind::AnyOf { .. } => "anyOf",
+        ValidationErrorKind::BacktrackLimitExceeded { .. }
+        | ValidationErrorKind::Pattern { .. } => "pattern",
+        ValidationErrorKind::Constant { .. } => "const",
+        ValidationErrorKind::Contains => "contains",
+        ValidationErrorKind::ContentEncoding { .. } | ValidationErrorKind::FromUtf8 { .. } => {
+            "contentEncoding"
+        }
+        ValidationErrorKind::ContentMediaType { .. } => "contentMediaType",
+        ValidationErrorKind::Custom { .. } => "custom",
+        ValidationErrorKind::Enum { .. } => "enum",
+        ValidationErrorKind::ExclusiveMaximum { .. } => "exclusiveMaximum",
+        ValidationErrorKind::ExclusiveMinimum { .. } => "exclusiveMinimum",
+        ValidationErrorKind::FalseSchema => "falseSchema",
+        ValidationErrorKind::Format { .. } => "format",
+        ValidationErrorKind::MaxItems { .. } => "maxItems",
+        ValidationErrorKind::Maximum { .. } => "maximum",
+        ValidationErrorKind::MaxLength { .. } => "maxLength",
+        ValidationErrorKind::MaxProperties { .. } => "maxProperties",
+        ValidationErrorKind::MinItems { .. } => "minItems",
+        ValidationErrorKind::Minimum { .. } => "minimum",
+        ValidationErrorKind::MinLength { .. } => "minLength",
+        ValidationErrorKind::MinProperties { .. } => "minProperties",
+        ValidationErrorKind::MultipleOf { .. } => "multipleOf",
+        ValidationErrorKind::Not { .. } => "not",
+        ValidationErrorKind::OneOfMultipleValid { .. }
+        | ValidationErrorKind::OneOfNotValid { .. } => "oneOf",
+        ValidationErrorKind::PropertyNames { .. } => "propertyNames",
+        ValidationErrorKind::Required { .. } => "required",
+        ValidationErrorKind::Type { .. } => "type",
+        ValidationErrorKind::UnevaluatedItems { .. } => "unevaluatedItems",
+        ValidationErrorKind::UnevaluatedProperties { .. } => "unevaluatedProperties",
+        ValidationErrorKind::UniqueItems => "uniqueItems",
+        ValidationErrorKind::Referencing(_) => "$ref",
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut output, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    output
 }
 
 #[must_use]
@@ -224,6 +399,34 @@ mod tests {
         for category in SUPPORTED_TIDAS_CATEGORIES {
             catalog.validator(category).unwrap();
         }
+    }
+
+    #[test]
+    fn oversized_schema_instances_emit_bounded_diagnostics() {
+        let validator = SchemaCatalog::load()
+            .unwrap()
+            .validator(TidasCategory::Sources)
+            .unwrap();
+        let oversized = "数".repeat(1024 * 1024);
+        let document = Value::String(oversized.clone());
+        let issue = validator
+            .issues(&document, "sources/oversized.json")
+            .next()
+            .unwrap();
+
+        assert!(issue.message.len() <= MAX_SCHEMA_MESSAGE_BYTES);
+        assert!(!issue.message.contains(&oversized));
+        assert_eq!(issue.context["schema_keyword"], "type");
+        assert_eq!(issue.context["instance_type"], "string");
+        assert_eq!(
+            issue.context["instance_byte_length"],
+            Value::from(oversized.len() as u64)
+        );
+        assert_eq!(issue.context["instance_preview_truncated"], true);
+        assert_eq!(
+            issue.context["instance_preview_sha256"],
+            sha256_hex(oversized.as_bytes())
+        );
     }
 
     #[test]

--- a/docs/agents/cli-contract.md
+++ b/docs/agents/cli-contract.md
@@ -26,9 +26,9 @@ checkPaths:
   - contracts/**
   - README.md
   - README_CN.md
-lastReviewedAt: 2026-07-27
-lastReviewedCommit: f7a56243cfc6d38114dac396893889e748c68c88
-lastReviewedNote: "Reviewed for Issue #126: the Rust-only cutover preserves the seven-command, report, output-channel, configuration, and exit contract."
+lastReviewedAt: 2026-07-28
+lastReviewedCommit: 0d3170f3f4af0f25a63be49ff63585af1b53f76b
+lastReviewedNote: "Reviewed for Issue #146: schema diagnostics retain complete issue/final protocol semantics while bounding rejected-instance text below the Worker event ceiling."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -350,6 +350,14 @@ logical issue-stream hash, and validation fingerprints. Unsafe paths,
 symlinks, missing files, hash drift, or malformed protocol input fail without
 a final event. `tidas validate --describe --format json` returns the supported
 protocol/profile and engine/asset handshake.
+
+Schema issue diagnostics never serialize the complete rejected JSON instance.
+Their human message is capped at 16 KiB and uses an instance placeholder;
+structured context carries the schema keyword/path, instance type, bounded
+scalar preview or collection size, and SHA-256/original-byte metadata whenever
+text is truncated. This keeps each Worker-facing JSONL issue below the 1 MiB
+protocol frame ceiling without dropping the issue, changing its ordinal, or
+breaking the final logical issue-stream hash.
 
 `tidas ruleset --format json` validates and returns the packaged methodology
 catalog. `tidas ruleset --id <RULESET_ID> --format json` returns its ordered

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,9 +25,9 @@ checkPaths:
   - .github/workflows/**
   - .githooks/pre-push
   - scripts/**
-lastReviewedAt: 2026-07-27
-lastReviewedCommit: f7a56243cfc6d38114dac396893889e748c68c88
-lastReviewedNote: "Issue #126 establishes the Rust workspace, top-level assets, unified CLI, native release, and Rust-only gates as the complete active architecture."
+lastReviewedAt: 2026-07-28
+lastReviewedCommit: 0d3170f3f4af0f25a63be49ff63585af1b53f76b
+lastReviewedNote: "Issue #146 keeps validation streaming and deterministic by summarizing oversized rejected instances instead of embedding them in schema issue events."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -94,7 +94,9 @@ credentials.
 Validation resolves only embedded assets. Draft 7 schema resources and ILCD
 XSD contexts are compiled offline and reused. Issue details stream or are
 discarded; batch evidence preflights content hashes and publishes a final
-logical stream hash only after drift-free completion.
+logical stream hash only after drift-free completion. Schema diagnostics
+describe rejected instances through bounded summaries and content hashes
+rather than embedding arbitrarily large instance values in JSONL events.
 
 Release consumes finalized UUID/version decisions. It resolves exact
 standalone/full closure, derives schema-ordered ILCD, runs native validation and

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -26,9 +26,9 @@ checkPaths:
   - .github/workflows/**
   - .githooks/pre-push
   - scripts/**
-lastReviewedAt: 2026-07-27
-lastReviewedCommit: f7a56243cfc6d38114dac396893889e748c68c88
-lastReviewedNote: "Issue #126 replaces every active migration-oracle gate with Rust-only source, asset, package, artifact, and scale validation."
+lastReviewedAt: 2026-07-28
+lastReviewedCommit: 0d3170f3f4af0f25a63be49ff63585af1b53f76b
+lastReviewedNote: "Issue #146 adds an oversized rejected-instance regression proving bounded issue frames, deterministic final events, and logical stream hashes."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -67,7 +67,7 @@ Intel/Apple Silicon, and Windows x86_64. Windows ARM64 is intentionally absent.
 | import | all supported format fixtures; native target validation; deterministic package/mapping/bundle hashes; malformed/unsupported input, cancellation, budget, atomic publication | large exchange/issue-spool fixture with wall time/RSS and cross-root determinism |
 | export | focused crate/CLI tests; report schema; secret redaction; unsafe paths; cancellation/budget; version suffixes; deterministic ZIP; atomic replacement | disposable local PostgreSQL and S3-compatible fixtures twice, comparing archive bytes and membership |
 | release | closure/order/round-trip golden fixtures; missing/inexact reference failure; four deterministic ZIPs; native validation; cancellation/budget; atomic directory publication | run the local 237 MiB package twice, compare all four archives, and record wall time/RSS |
-| validation/batch/references | compile every bundled schema/XSD root offline; schema and semantic fixtures; bounded issue spool; batch preflight/drift/final-event hash; extraction schema/roles | local 237 MiB validation twice, recording schema time, total time, peak RSS, cancellation, and spool hash |
+| validation/batch/references | compile every bundled schema/XSD root offline; schema and semantic fixtures; oversized rejected-instance event below the 1 MiB frame ceiling; bounded issue spool; batch preflight/drift/final-event hash; extraction schema/roles | local 237 MiB validation twice, recording schema time, total time, peak RSS, cancellation, and spool hash |
 | assets | baseline asset check; representative `git check-attr eol`; schema-local-reference and translation-parity tests | regenerate locks only after reviewing every changed path/hash; compare fingerprints twice |
 | XML/XSD/XSLT | focused `tidas-xml` and validation tests; resolver/security tests; five-platform CI | representative production schemas/stylesheets and static-release dependency inspection |
 | native distribution | focused `tidas-dist`; package twice; archive/checksum equality; extract and run version/help/JSON/ruleset; installer syntax | five release jobs, clean-machine archive execution, runtime dependency inspection, SBOM and attestation |


### PR DESCRIPTION
Closes #146

## Summary
- Bound JSON Schema issue messages and locations before they enter the Worker-facing JSONL issue stream.
- Preserve actionable schema keyword/path/type/value summaries and deterministic truncation fingerprints without embedding rejected JSON instances.
- Add a 2 MiB rejected-instance regression proving bounded issue events, deterministic bytes, stable logical hashing, and a reachable final event.

## Key Decisions
- Schema diagnostics are an intentionally compact report contract: message <= 16 KiB, location <= 4 KiB, scalar preview <= 256 bytes, with SHA-256 metadata when truncated.
- The validator masks the jsonschema instance display instead of relying on downstream Worker parsing or transport-specific clipping.

## Validation
- Rust-only audit, asset lock verification, cargo fmt, clippy -D warnings, full workspace tests, package asset sync, and crates.io publish checks passed.
- Docpact strict validation/lint passed for all seven changed paths.
- Repository pre-push hook completed successfully before commit 34aae812 was pushed.

## Risks / Rollback
- This deliberately changes oversized schema issue text; consumers must treat structured context fields as the stable diagnostic surface. Revert this PR to restore the previous formatter.

## Follow-ups
- After merge, publish the next tidas crate/CLI patch release and update the Worker deployment before rerunning the production integrity check.

## Workspace Integration
- Workspace integration remains pending until the merged tidas-tools commit and the Worker deployment/version update are recorded in lca-workspace.