### PR TITLE
release: prepare tidas v0.1.2 version set

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,9 +1,9 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-28"
-lastReviewedCommit: "0d3170f3f4af0f25a63be49ff63585af1b53f76b"
-# Reviewed for Issue #146: validation and Worker protocol changes remain routed
-# through the existing Rust product/runtime contracts and proof paths.
+lastReviewedCommit: "174cbaf530756261c358f877d0d963ccc3ebaea4"
+# Reviewed for Issue #148: the 0.1.2 version-set and native distribution paths
+# remain governed by the existing Rust release and validation contracts.
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/**
   - .githooks/pre-push
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 0d3170f3f4af0f25a63be49ff63585af1b53f76b
-lastReviewedNote: "Reviewed for Issue #146: bounded schema diagnostics preserve the Rust-only validation, streaming, deterministic-contract, and Worker integration rules."
+lastReviewedCommit: 174cbaf530756261c358f877d0d963ccc3ebaea4
+lastReviewedNote: "Reviewed for Issue #148: the 0.1.2 version-set preparation preserves the unified Rust product, exact-version crate set, supported platform matrix, and merge-gated release architecture."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,7 +2455,7 @@ dependencies = [
 
 [[package]]
 name = "tidas"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-assets"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "include_dir",
  "jsonschema",
@@ -2490,7 +2490,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-contracts"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-conversion"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "jsonschema",
  "quick-xml",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-dist"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "flate2",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-export"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "futures-util",
  "jsonschema",
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-import"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bigdecimal",
  "encoding_rs",
@@ -2577,7 +2577,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-references"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "jsonschema",
  "serde",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-release"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "jsonschema",
  "serde",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-rulesets"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "jsonschema",
  "noyalib",
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-runtime"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "crossbeam-channel",
  "serde",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-validation"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "jsonschema",
  "quick-xml",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-xml"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "libxml",
  "libxslt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ libxslt development dependencies can install the unified executable from
 source:
 
 ```bash
-cargo install tidas --version 0.1.1 --locked
+cargo install tidas --version 0.1.2 --locked
 ```
 
 All public workspace crates use the exact same version so Cargo cannot combine
@@ -171,11 +171,11 @@ After a native version is published, install an explicit immutable version:
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSLO \
   https://raw.githubusercontent.com/tiangong-lca/tidas-tools/main/scripts/install.sh
-sh install.sh --version 0.1.1 --prefix "$HOME/.local"
+sh install.sh --version 0.1.2 --prefix "$HOME/.local"
 ```
 
 ```powershell
-.\scripts\install.ps1 -Version 0.1.1
+.\scripts\install.ps1 -Version 0.1.2
 ```
 
 Every GitHub Release also carries generated Homebrew formula and Winget

--- a/README_CN.md
+++ b/README_CN.md
@@ -137,7 +137,7 @@ provenance/SBOM attestation。固定版本且静态链接的 libxml2/libxslt 使
 libxml2/libxslt 开发依赖的开发者，也可从源码安装唯一的统一 executable：
 
 ```bash
-cargo install tidas --version 0.1.1 --locked
+cargo install tidas --version 0.1.2 --locked
 ```
 
 全部公开 workspace crates 使用完全相同的精确版本，避免 Cargo 混用不兼容的领域
@@ -156,11 +156,11 @@ tag，再显式从该 tag dispatch 原生 release workflow，使 artifact proven
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSLO \
   https://raw.githubusercontent.com/tiangong-lca/tidas-tools/main/scripts/install.sh
-sh install.sh --version 0.1.1 --prefix "$HOME/.local"
+sh install.sh --version 0.1.2 --prefix "$HOME/.local"
 ```
 
 ```powershell
-.\scripts\install.ps1 -Version 0.1.1
+.\scripts\install.ps1 -Version 0.1.2
 ```
 
 每个 GitHub Release 同时携带由相同归档哈希生成的 Homebrew formula 与 Winget

--- a/crates/tidas-cli/Cargo.toml
+++ b/crates/tidas-cli/Cargo.toml
@@ -22,16 +22,16 @@ clap_complete.workspace = true
 ctrlc.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tidas-assets = { version = "=0.1.1", path = "../.." }
-tidas-conversion = { version = "=0.1.1", path = "../tidas-conversion" }
-tidas-contracts = { version = "=0.1.1", path = "../tidas-contracts" }
-tidas-export = { version = "=0.1.1", path = "../tidas-export" }
-tidas-import = { version = "=0.1.1", path = "../tidas-import" }
-tidas-release = { version = "=0.1.1", path = "../tidas-release" }
-tidas-runtime = { version = "=0.1.1", path = "../tidas-runtime" }
-tidas-rulesets = { version = "=0.1.1", path = "../tidas-rulesets" }
-tidas-validation = { version = "=0.1.1", path = "../tidas-validation" }
-tidas-xml = { version = "=0.1.1", path = "../tidas-xml" }
+tidas-assets = { version = "=0.1.2", path = "../.." }
+tidas-conversion = { version = "=0.1.2", path = "../tidas-conversion" }
+tidas-contracts = { version = "=0.1.2", path = "../tidas-contracts" }
+tidas-export = { version = "=0.1.2", path = "../tidas-export" }
+tidas-import = { version = "=0.1.2", path = "../tidas-import" }
+tidas-release = { version = "=0.1.2", path = "../tidas-release" }
+tidas-runtime = { version = "=0.1.2", path = "../tidas-runtime" }
+tidas-rulesets = { version = "=0.1.2", path = "../tidas-rulesets" }
+tidas-validation = { version = "=0.1.2", path = "../tidas-validation" }
+tidas-xml = { version = "=0.1.2", path = "../tidas-xml" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/tidas-conversion/Cargo.toml
+++ b/crates/tidas-conversion/Cargo.toml
@@ -19,8 +19,8 @@ serde_json = { workspace = true, features = ["arbitrary_precision"] }
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tidas-assets = { version = "=0.1.1", path = "../.." }
-tidas-runtime = { version = "=0.1.1", path = "../tidas-runtime" }
+tidas-assets = { version = "=0.1.2", path = "../.." }
+tidas-runtime = { version = "=0.1.2", path = "../tidas-runtime" }
 walkdir.workspace = true
 
 [dev-dependencies]

--- a/crates/tidas-export/Cargo.toml
+++ b/crates/tidas-export/Cargo.toml
@@ -21,8 +21,8 @@ serde_json = { workspace = true, features = ["preserve_order"] }
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tidas-conversion = { version = "=0.1.1", path = "../tidas-conversion" }
-tidas-runtime = { version = "=0.1.1", path = "../tidas-runtime" }
+tidas-conversion = { version = "=0.1.2", path = "../tidas-conversion" }
+tidas-runtime = { version = "=0.1.2", path = "../tidas-runtime" }
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-postgres-rustls.workspace = true

--- a/crates/tidas-import/Cargo.toml
+++ b/crates/tidas-import/Cargo.toml
@@ -22,10 +22,10 @@ serde_json = { workspace = true, features = ["arbitrary_precision", "preserve_or
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tidas-assets = { version = "=0.1.1", path = "../.." }
-tidas-conversion = { version = "=0.1.1", path = "../tidas-conversion" }
-tidas-runtime = { version = "=0.1.1", path = "../tidas-runtime" }
-tidas-validation = { version = "=0.1.1", path = "../tidas-validation" }
+tidas-assets = { version = "=0.1.2", path = "../.." }
+tidas-conversion = { version = "=0.1.2", path = "../tidas-conversion" }
+tidas-runtime = { version = "=0.1.2", path = "../tidas-runtime" }
+tidas-validation = { version = "=0.1.2", path = "../tidas-validation" }
 uuid.workspace = true
 walkdir.workspace = true
 zip.workspace = true

--- a/crates/tidas-release/Cargo.toml
+++ b/crates/tidas-release/Cargo.toml
@@ -18,16 +18,16 @@ serde_json = { workspace = true, features = ["preserve_order"] }
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tidas-assets = { version = "=0.1.1", path = "../.." }
-tidas-conversion = { version = "=0.1.1", path = "../tidas-conversion" }
-tidas-runtime = { version = "=0.1.1", path = "../tidas-runtime" }
-tidas-validation = { version = "=0.1.1", path = "../tidas-validation" }
+tidas-assets = { version = "=0.1.2", path = "../.." }
+tidas-conversion = { version = "=0.1.2", path = "../tidas-conversion" }
+tidas-runtime = { version = "=0.1.2", path = "../tidas-runtime" }
+tidas-validation = { version = "=0.1.2", path = "../tidas-validation" }
 walkdir.workspace = true
 zip.workspace = true
 
 [dev-dependencies]
 jsonschema.workspace = true
-tidas-import = { version = "=0.1.1", path = "../tidas-import" }
+tidas-import = { version = "=0.1.2", path = "../tidas-import" }
 
 [lints]
 workspace = true

--- a/crates/tidas-rulesets/Cargo.toml
+++ b/crates/tidas-rulesets/Cargo.toml
@@ -19,7 +19,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-tidas-assets = { version = "=0.1.1", path = "../.." }
+tidas-assets = { version = "=0.1.2", path = "../.." }
 
 [lints]
 workspace = true

--- a/crates/tidas-validation/Cargo.toml
+++ b/crates/tidas-validation/Cargo.toml
@@ -20,10 +20,10 @@ serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tidas-assets = { version = "=0.1.1", path = "../.." }
-tidas-runtime = { version = "=0.1.1", path = "../tidas-runtime" }
-tidas-rulesets = { version = "=0.1.1", path = "../tidas-rulesets" }
-tidas-xml = { version = "=0.1.1", path = "../tidas-xml" }
+tidas-assets = { version = "=0.1.2", path = "../.." }
+tidas-runtime = { version = "=0.1.2", path = "../tidas-runtime" }
+tidas-rulesets = { version = "=0.1.2", path = "../tidas-rulesets" }
+tidas-xml = { version = "=0.1.2", path = "../tidas-xml" }
 walkdir.workspace = true
 
 [lints]

--- a/docs/agents/cli-contract.md
+++ b/docs/agents/cli-contract.md
@@ -27,8 +27,8 @@ checkPaths:
   - README.md
   - README_CN.md
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 0d3170f3f4af0f25a63be49ff63585af1b53f76b
-lastReviewedNote: "Reviewed for Issue #146: schema diagnostics retain complete issue/final protocol semantics while bounding rejected-instance text below the Worker event ceiling."
+lastReviewedCommit: 174cbaf530756261c358f877d0d963ccc3ebaea4
+lastReviewedNote: "Reviewed for Issue #148: the 0.1.2 packaging update changes only the exact published version and installation examples, not the unified command or report contracts."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/**
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 0d3170f3f4af0f25a63be49ff63585af1b53f76b
-lastReviewedNote: "Issue #146 keeps validation streaming and deterministic by summarizing oversized rejected instances instead of embedding them in schema issue events."
+lastReviewedCommit: 174cbaf530756261c358f877d0d963ccc3ebaea4
+lastReviewedNote: "Issue #148 reviews the 0.1.2 exact-version crate set and native release packaging without changing crate ownership or release architecture."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/**
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 0d3170f3f4af0f25a63be49ff63585af1b53f76b
-lastReviewedNote: "Issue #146 adds an oversized rejected-instance regression proving bounded issue frames, deterministic final events, and logical stream hashes."
+lastReviewedCommit: 174cbaf530756261c358f877d0d963ccc3ebaea4
+lastReviewedNote: "Issue #148 retains the full Rust, package qualification, deterministic native distribution, release-request, Docpact, and five-platform proof for the 0.1.2 version set."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/packaging/vcpkg/vcpkg.json
+++ b/packaging/vcpkg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidas-native-release-dependencies",
-  "version-string": "0.1.1",
+  "version-string": "0.1.2",
   "builtin-baseline": "40f3c709db80acf154ac4b17a1f83c564ebd022e",
   "dependencies": [
     "libxslt"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@ VERSION=""
 
 usage() {
   echo "usage: install.sh --version <VERSION> [--prefix <DIR>]" >&2
-  echo "example: install.sh --version 0.1.1 --prefix \"\$HOME/.local\"" >&2
+  echo "example: install.sh --version 0.1.2 --prefix \"\$HOME/.local\"" >&2
 }
 
 while [ "$#" -gt 0 ]; do


### PR DESCRIPTION
## Summary

- move the Cargo workspace and all internal exact dependency pins from 0.1.1 to 0.1.2
- refresh the lockfile, active install examples, vcpkg metadata, and reviewed agent guidance
- keep historical v0.1.1 release records immutable and deliberately omit the v0.1.2 Release Request from this preparation phase

## Release decision

This is phase 1 of the two-phase release tracked by #148. After this PR merges, a separate immutable Release Request PR will bind v0.1.2 to the exact merged `main` commit and trigger the existing protected release workflow after review/merge.

The supported native matrix remains Linux x86_64/ARM64, macOS Intel/Apple Silicon, and Windows x86_64. Windows ARM64 is not a supported target.

## Validation

- `scripts/audit-rust-only.sh`
- `cargo run --locked -p tidas-assets --bin tidas-asset-lock -- check`
- `cargo fmt --all --check`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked --workspace --all-targets`
- `scripts/sync-rust-package-assets.sh check`
- `scripts/publish-crates.sh check` (all 12 public crates packaged, rebuilt through the temporary registry, and passed upload dry-run)
- two independent `aarch64-apple-darwin` native packages were byte-identical; archive SHA-256 `8f4dff1fa8d7b9abb576b1a89345449ca6fca1e469c509dc1c2d176f13e292c6`
- packaged archive verification and smoke probes passed
- `sh -n scripts/install.sh`
- staged and pre-push Docpact gates passed

PowerShell is unavailable on this macOS host; Windows script and native target coverage remains enforced by release CI.

Refs #148

Parent rollout: tiangong-lca/workspace#501