### PR TITLE
release: request tidas v0.1.2 publication

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,9 +1,9 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-28"
-lastReviewedCommit: "174cbaf530756261c358f877d0d963ccc3ebaea4"
-# Reviewed for Issue #148: the 0.1.2 version-set and native distribution paths
-# remain governed by the existing Rust release and validation contracts.
+lastReviewedCommit: "9837f4f99606e6571a1c02672a6a2998d2866ac4"
+# Reviewed for Issue #148 phase 2: the immutable v0.1.2 Release Request remains
+# governed by the existing merge-gated Rust release and validation contracts.
 
 catalog:
   repos:
@@ -329,6 +329,8 @@ rules:
     scope: repo
     repo: tidas-tools
     triggers:
+      - path: .github/releases/**
+        kind: release-authorization
       - path: scripts/**
         kind: automation
       - path: .github/workflows/**

--- a/.github/releases/v0.1.2.json
+++ b/.github/releases/v0.1.2.json
@@ -1,0 +1,5 @@
+{
+  "request_schema": "tidas.release-request.v1",
+  "version": "0.1.2",
+  "target": "9837f4f99606e6571a1c02672a6a2998d2866ac4"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/**
   - .githooks/pre-push
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 174cbaf530756261c358f877d0d963ccc3ebaea4
-lastReviewedNote: "Reviewed for Issue #148: the 0.1.2 version-set preparation preserves the unified Rust product, exact-version crate set, supported platform matrix, and merge-gated release architecture."
+lastReviewedCommit: 9837f4f99606e6571a1c02672a6a2998d2866ac4
+lastReviewedNote: "Reviewed for Issue #148 phase 2: the immutable v0.1.2 Release Request preserves the unified Rust product, exact-version crate set, supported platform matrix, and merge-gated release architecture."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/docs/agents/cli-contract.md
+++ b/docs/agents/cli-contract.md
@@ -27,8 +27,8 @@ checkPaths:
   - README.md
   - README_CN.md
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 174cbaf530756261c358f877d0d963ccc3ebaea4
-lastReviewedNote: "Reviewed for Issue #148: the 0.1.2 packaging update changes only the exact published version and installation examples, not the unified command or report contracts."
+lastReviewedCommit: 9837f4f99606e6571a1c02672a6a2998d2866ac4
+lastReviewedNote: "Reviewed for Issue #148 phase 2: the immutable v0.1.2 Release Request does not change the unified command, report, output-channel, or exit contracts."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/**
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 174cbaf530756261c358f877d0d963ccc3ebaea4
-lastReviewedNote: "Issue #148 reviews the 0.1.2 exact-version crate set and native release packaging without changing crate ownership or release architecture."
+lastReviewedCommit: 9837f4f99606e6571a1c02672a6a2998d2866ac4
+lastReviewedNote: "Issue #148 phase 2 binds the immutable v0.1.2 Release Request to the qualified version-set merge commit without changing crate ownership or release architecture."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/**
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 174cbaf530756261c358f877d0d963ccc3ebaea4
-lastReviewedNote: "Issue #148 retains the full Rust, package qualification, deterministic native distribution, release-request, Docpact, and five-platform proof for the 0.1.2 version set."
+lastReviewedCommit: 9837f4f99606e6571a1c02672a6a2998d2866ac4
+lastReviewedNote: "Issue #148 phase 2 retains release-request validation, Docpact gates, and tag-bound five-platform publication proof for the qualified v0.1.2 version set."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
## Summary

- add the immutable `v0.1.2` Release Request bound to exact qualified commit `9837f4f99606e6571a1c02672a6a2998d2866ac4`
- record Docpact review evidence for the unchanged release, architecture, validation, and CLI contracts
- connect `.github/releases/**` to the existing release/automation Docpact contract so future release requests are covered

Closes #148

Parent rollout: tiangong-lca/workspace#501

## Immutable preflight

- canonical `origin/main` was exactly `9837f4f99606e6571a1c02672a6a2998d2866ac4` before branch creation
- remote `v0.1.2` tag, GitHub Release, request file, and published 0.1.2 artifacts were absent
- the target Cargo workspace version is exactly `0.1.2`
- the request is append-only and authorizes only the merged Phase 1 version set

## Validation

- `scripts/validate-release-request.sh .github/releases/v0.1.2.json HEAD`
- `scripts/test-release-request.sh`
- strict Docpact config validation and base/head lint
- managed pre-push gate: Rust-only audit, asset lock, fmt, Clippy with warnings denied, and full workspace/all-target tests

## Scope and rollout

This PR does not create a tag or publish artifacts by itself. Merging it is the reviewed authorization that creates/verifies `v0.1.2` at the exact target and dispatches the tag-bound native release workflow. Production Worker deployment remains blocked until that workflow publishes and verifies the 0.1.2 crate/native artifacts.