### PR TITLE
release: prepare tidas v0.1.3 version set

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,9 +1,9 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-01"
-lastReviewedCommit: "076028949d0de8c35f4ef6a67563dc958d655707"
-# Reviewed for Issue #151: schema-ordered direct conversion remains inside the
-# existing Rust product ownership, conversion routing, and validation proof graph.
+lastReviewedCommit: "9ffb6c51aa07c7719b3bd218b99d30a19676168c"
+# Reviewed for Issue #153: the v0.1.3 version set preserves the existing Rust
+# release ownership, exact-version crate graph, and native distribution route.
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/**
   - .github/workflows/**
   - .githooks/pre-push
-lastReviewedAt: 2026-07-28
-lastReviewedCommit: 9837f4f99606e6571a1c02672a6a2998d2866ac4
-lastReviewedNote: "Reviewed for Issue #148 phase 2: the immutable v0.1.2 Release Request preserves the unified Rust product, exact-version crate set, supported platform matrix, and merge-gated release architecture."
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: 9ffb6c51aa07c7719b3bd218b99d30a19676168c
+lastReviewedNote: "Reviewed for Issue #153 phase 1: the v0.1.3 version-set preparation preserves the unified Rust product, exact-version crate set, supported platform matrix, and merge-gated release architecture."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,7 +2455,7 @@ dependencies = [
 
 [[package]]
 name = "tidas"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-assets"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "include_dir",
  "jsonschema",
@@ -2490,7 +2490,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-contracts"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-conversion"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "jsonschema",
  "quick-xml",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-dist"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "flate2",
@@ -2532,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-export"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "futures-util",
  "jsonschema",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-import"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bigdecimal",
  "encoding_rs",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-references"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "jsonschema",
  "serde",
@@ -2588,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-release"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "jsonschema",
  "serde",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-rulesets"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "jsonschema",
  "noyalib",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-runtime"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "crossbeam-channel",
  "serde",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-validation"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "jsonschema",
  "quick-xml",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "tidas-xml"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "libxml",
  "libxslt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ libxslt development dependencies can install the unified executable from
 source:
 
 ```bash
-cargo install tidas --version 0.1.2 --locked
+cargo install tidas --version 0.1.3 --locked
 ```
 
 All public workspace crates use the exact same version so Cargo cannot combine
@@ -171,11 +171,11 @@ After a native version is published, install an explicit immutable version:
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSLO \
   https://raw.githubusercontent.com/tiangong-lca/tidas-tools/main/scripts/install.sh
-sh install.sh --version 0.1.2 --prefix "$HOME/.local"
+sh install.sh --version 0.1.3 --prefix "$HOME/.local"
 ```
 
 ```powershell
-.\scripts\install.ps1 -Version 0.1.2
+.\scripts\install.ps1 -Version 0.1.3
 ```
 
 Every GitHub Release also carries generated Homebrew formula and Winget

--- a/README_CN.md
+++ b/README_CN.md
@@ -137,7 +137,7 @@ provenance/SBOM attestation。固定版本且静态链接的 libxml2/libxslt 使
 libxml2/libxslt 开发依赖的开发者，也可从源码安装唯一的统一 executable：
 
 ```bash
-cargo install tidas --version 0.1.2 --locked
+cargo install tidas --version 0.1.3 --locked
 ```
 
 全部公开 workspace crates 使用完全相同的精确版本，避免 Cargo 混用不兼容的领域
@@ -156,11 +156,11 @@ tag，再显式从该 tag dispatch 原生 release workflow，使 artifact proven
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSLO \
   https://raw.githubusercontent.com/tiangong-lca/tidas-tools/main/scripts/install.sh
-sh install.sh --version 0.1.2 --prefix "$HOME/.local"
+sh install.sh --version 0.1.3 --prefix "$HOME/.local"
 ```
 
 ```powershell
-.\scripts\install.ps1 -Version 0.1.2
+.\scripts\install.ps1 -Version 0.1.3
 ```
 
 每个 GitHub Release 同时携带由相同归档哈希生成的 Homebrew formula 与 Winget

--- a/crates/tidas-cli/Cargo.toml
+++ b/crates/tidas-cli/Cargo.toml
@@ -22,16 +22,16 @@ clap_complete.workspace = true
 ctrlc.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tidas-assets = { version = "=0.1.2", path = "../.." }
-tidas-conversion = { version = "=0.1.2", path = "../tidas-conversion" }
-tidas-contracts = { version = "=0.1.2", path = "../tidas-contracts" }
-tidas-export = { version = "=0.1.2", path = "../tidas-export" }
-tidas-import = { version = "=0.1.2", path = "../tidas-import" }
-tidas-release = { version = "=0.1.2", path = "../tidas-release" }
-tidas-runtime = { version = "=0.1.2", path = "../tidas-runtime" }
-tidas-rulesets = { version = "=0.1.2", path = "../tidas-rulesets" }
-tidas-validation = { version = "=0.1.2", path = "../tidas-validation" }
-tidas-xml = { version = "=0.1.2", path = "../tidas-xml" }
+tidas-assets = { version = "=0.1.3", path = "../.." }
+tidas-conversion = { version = "=0.1.3", path = "../tidas-conversion" }
+tidas-contracts = { version = "=0.1.3", path = "../tidas-contracts" }
+tidas-export = { version = "=0.1.3", path = "../tidas-export" }
+tidas-import = { version = "=0.1.3", path = "../tidas-import" }
+tidas-release = { version = "=0.1.3", path = "../tidas-release" }
+tidas-runtime = { version = "=0.1.3", path = "../tidas-runtime" }
+tidas-rulesets = { version = "=0.1.3", path = "../tidas-rulesets" }
+tidas-validation = { version = "=0.1.3", path = "../tidas-validation" }
+tidas-xml = { version = "=0.1.3", path = "../tidas-xml" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/tidas-conversion/Cargo.toml
+++ b/crates/tidas-conversion/Cargo.toml
@@ -19,13 +19,13 @@ serde_json = { workspace = true, features = ["arbitrary_precision", "preserve_or
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tidas-assets = { version = "=0.1.2", path = "../.." }
-tidas-runtime = { version = "=0.1.2", path = "../tidas-runtime" }
+tidas-assets = { version = "=0.1.3", path = "../.." }
+tidas-runtime = { version = "=0.1.3", path = "../tidas-runtime" }
 walkdir.workspace = true
 
 [dev-dependencies]
 jsonschema.workspace = true
-tidas-validation = { version = "=0.1.2", path = "../tidas-validation" }
+tidas-validation = { version = "=0.1.3", path = "../tidas-validation" }
 
 [lints]
 workspace = true

--- a/crates/tidas-export/Cargo.toml
+++ b/crates/tidas-export/Cargo.toml
@@ -21,8 +21,8 @@ serde_json = { workspace = true, features = ["preserve_order"] }
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tidas-conversion = { version = "=0.1.2", path = "../tidas-conversion" }
-tidas-runtime = { version = "=0.1.2", path = "../tidas-runtime" }
+tidas-conversion = { version = "=0.1.3", path = "../tidas-conversion" }
+tidas-runtime = { version = "=0.1.3", path = "../tidas-runtime" }
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-postgres-rustls.workspace = true

--- a/crates/tidas-import/Cargo.toml
+++ b/crates/tidas-import/Cargo.toml
@@ -22,10 +22,10 @@ serde_json = { workspace = true, features = ["arbitrary_precision", "preserve_or
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tidas-assets = { version = "=0.1.2", path = "../.." }
-tidas-conversion = { version = "=0.1.2", path = "../tidas-conversion" }
-tidas-runtime = { version = "=0.1.2", path = "../tidas-runtime" }
-tidas-validation = { version = "=0.1.2", path = "../tidas-validation" }
+tidas-assets = { version = "=0.1.3", path = "../.." }
+tidas-conversion = { version = "=0.1.3", path = "../tidas-conversion" }
+tidas-runtime = { version = "=0.1.3", path = "../tidas-runtime" }
+tidas-validation = { version = "=0.1.3", path = "../tidas-validation" }
 uuid.workspace = true
 walkdir.workspace = true
 zip.workspace = true

--- a/crates/tidas-release/Cargo.toml
+++ b/crates/tidas-release/Cargo.toml
@@ -18,16 +18,16 @@ serde_json = { workspace = true, features = ["preserve_order"] }
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tidas-assets = { version = "=0.1.2", path = "../.." }
-tidas-conversion = { version = "=0.1.2", path = "../tidas-conversion" }
-tidas-runtime = { version = "=0.1.2", path = "../tidas-runtime" }
-tidas-validation = { version = "=0.1.2", path = "../tidas-validation" }
+tidas-assets = { version = "=0.1.3", path = "../.." }
+tidas-conversion = { version = "=0.1.3", path = "../tidas-conversion" }
+tidas-runtime = { version = "=0.1.3", path = "../tidas-runtime" }
+tidas-validation = { version = "=0.1.3", path = "../tidas-validation" }
 walkdir.workspace = true
 zip.workspace = true
 
 [dev-dependencies]
 jsonschema.workspace = true
-tidas-import = { version = "=0.1.2", path = "../tidas-import" }
+tidas-import = { version = "=0.1.3", path = "../tidas-import" }
 
 [lints]
 workspace = true

--- a/crates/tidas-rulesets/Cargo.toml
+++ b/crates/tidas-rulesets/Cargo.toml
@@ -19,7 +19,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-tidas-assets = { version = "=0.1.2", path = "../.." }
+tidas-assets = { version = "=0.1.3", path = "../.." }
 
 [lints]
 workspace = true

--- a/crates/tidas-validation/Cargo.toml
+++ b/crates/tidas-validation/Cargo.toml
@@ -20,10 +20,10 @@ serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tidas-assets = { version = "=0.1.2", path = "../.." }
-tidas-runtime = { version = "=0.1.2", path = "../tidas-runtime" }
-tidas-rulesets = { version = "=0.1.2", path = "../tidas-rulesets" }
-tidas-xml = { version = "=0.1.2", path = "../tidas-xml" }
+tidas-assets = { version = "=0.1.3", path = "../.." }
+tidas-runtime = { version = "=0.1.3", path = "../tidas-runtime" }
+tidas-rulesets = { version = "=0.1.3", path = "../tidas-rulesets" }
+tidas-xml = { version = "=0.1.3", path = "../tidas-xml" }
 walkdir.workspace = true
 
 [lints]

--- a/docs/agents/cli-contract.md
+++ b/docs/agents/cli-contract.md
@@ -26,9 +26,9 @@ checkPaths:
   - contracts/**
   - README.md
   - README_CN.md
-lastReviewedAt: 2026-07-28
-lastReviewedCommit: 9837f4f99606e6571a1c02672a6a2998d2866ac4
-lastReviewedNote: "Reviewed for Issue #148 phase 2: the immutable v0.1.2 Release Request does not change the unified command, report, output-channel, or exit contracts."
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: 9ffb6c51aa07c7719b3bd218b99d30a19676168c
+lastReviewedNote: "Reviewed for Issue #153 phase 1: the v0.1.3 packaging update changes only the exact published version and installation examples, not the unified command or report contracts."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,9 +25,9 @@ checkPaths:
   - .github/workflows/**
   - .githooks/pre-push
   - scripts/**
-lastReviewedAt: 2026-07-28
-lastReviewedCommit: 9837f4f99606e6571a1c02672a6a2998d2866ac4
-lastReviewedNote: "Issue #148 phase 2 binds the immutable v0.1.2 Release Request to the qualified version-set merge commit without changing crate ownership or release architecture."
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: 9ffb6c51aa07c7719b3bd218b99d30a19676168c
+lastReviewedNote: "Issue #153 phase 1 reviews the v0.1.3 exact-version crate set and native release packaging without changing crate ownership or release architecture."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -26,9 +26,9 @@ checkPaths:
   - .github/workflows/**
   - .githooks/pre-push
   - scripts/**
-lastReviewedAt: 2026-07-28
-lastReviewedCommit: 9837f4f99606e6571a1c02672a6a2998d2866ac4
-lastReviewedNote: "Issue #148 phase 2 retains release-request validation, Docpact gates, and tag-bound five-platform publication proof for the qualified v0.1.2 version set."
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: 9ffb6c51aa07c7719b3bd218b99d30a19676168c
+lastReviewedNote: "Issue #153 phase 1 retains crate qualification, Docpact gates, and tag-bound five-platform publication proof for the v0.1.3 version set."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/packaging/vcpkg/vcpkg.json
+++ b/packaging/vcpkg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tidas-native-release-dependencies",
-  "version-string": "0.1.2",
+  "version-string": "0.1.3",
   "builtin-baseline": "40f3c709db80acf154ac4b17a1f83c564ebd022e",
   "dependencies": [
     "libxslt"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@ VERSION=""
 
 usage() {
   echo "usage: install.sh --version <VERSION> [--prefix <DIR>]" >&2
-  echo "example: install.sh --version 0.1.2 --prefix \"\$HOME/.local\"" >&2
+  echo "example: install.sh --version 0.1.3 --prefix \"\$HOME/.local\"" >&2
 }
 
 while [ "$#" -gt 0 ]; do


### PR DESCRIPTION
Closes #153

## Summary
- Advance all public workspace crates and native distribution metadata to 0.1.3.
- Update English and Chinese installation examples to the new immutable patch version.

## Key Decisions
- Keep the release split into a qualification PR and a later append-only exact-SHA release request.

## Validation
- Rust-only audit, asset locks, cargo fmt, full workspace clippy, and full workspace tests passed.
- Docpact strict validation/lint and shell syntax checks passed.
- scripts/publish-crates.sh check qualified the complete self-contained 0.1.3 crates.io set.

## Risks / Rollback
- No runtime behavior changes beyond the already-merged #151 fix; rollback is to avoid merging the later release request.

## Follow-ups
- After this PR merges, add .github/releases/v0.1.3.json targeting its exact merge commit.

## Workspace Integration
- No tidas-sdk refresh is required because executable schemas and methodologies are unchanged; workspace PR #536 will be refreshed to the final release target.