### PR TITLE
release: request tidas v0.1.3

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,9 +1,9 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-01"
-lastReviewedCommit: "9ffb6c51aa07c7719b3bd218b99d30a19676168c"
-# Reviewed for Issue #153: the v0.1.3 version set preserves the existing Rust
-# release ownership, exact-version crate graph, and native distribution route.
+lastReviewedCommit: "9f67345f4c6f791a01d21688b4f003a157a33d04"
+# Reviewed for Issue #153 phase 2: the immutable v0.1.3 Release Request remains
+# governed by the existing merge-gated Rust release and validation contracts.
 
 catalog:
   repos:

--- a/.github/releases/v0.1.3.json
+++ b/.github/releases/v0.1.3.json
@@ -1,0 +1,5 @@
+{
+  "request_schema": "tidas.release-request.v1",
+  "version": "0.1.3",
+  "target": "9f67345f4c6f791a01d21688b4f003a157a33d04"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/**
   - .githooks/pre-push
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: 9ffb6c51aa07c7719b3bd218b99d30a19676168c
-lastReviewedNote: "Reviewed for Issue #153 phase 1: the v0.1.3 version-set preparation preserves the unified Rust product, exact-version crate set, supported platform matrix, and merge-gated release architecture."
+lastReviewedCommit: 9f67345f4c6f791a01d21688b4f003a157a33d04
+lastReviewedNote: "Reviewed for Issue #153 phase 2: the immutable v0.1.3 Release Request preserves the unified Rust product, exact-version crate set, supported platform matrix, and merge-gated release architecture."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/docs/agents/cli-contract.md
+++ b/docs/agents/cli-contract.md
@@ -27,8 +27,8 @@ checkPaths:
   - README.md
   - README_CN.md
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: 9ffb6c51aa07c7719b3bd218b99d30a19676168c
-lastReviewedNote: "Reviewed for Issue #153 phase 1: the v0.1.3 packaging update changes only the exact published version and installation examples, not the unified command or report contracts."
+lastReviewedCommit: 9f67345f4c6f791a01d21688b4f003a157a33d04
+lastReviewedNote: "Reviewed for Issue #153 phase 2: the immutable v0.1.3 Release Request does not change the unified command, report, output-channel, or exit contracts."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/**
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: 9ffb6c51aa07c7719b3bd218b99d30a19676168c
-lastReviewedNote: "Issue #153 phase 1 reviews the v0.1.3 exact-version crate set and native release packaging without changing crate ownership or release architecture."
+lastReviewedCommit: 9f67345f4c6f791a01d21688b4f003a157a33d04
+lastReviewedNote: "Issue #153 phase 2 binds the immutable v0.1.3 Release Request to the qualified version-set merge commit without changing crate ownership or release architecture."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/**
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: 9ffb6c51aa07c7719b3bd218b99d30a19676168c
-lastReviewedNote: "Issue #153 phase 1 retains crate qualification, Docpact gates, and tag-bound five-platform publication proof for the v0.1.3 version set."
+lastReviewedCommit: 9f67345f4c6f791a01d21688b4f003a157a33d04
+lastReviewedNote: "Issue #153 phase 2 retains release-request validation, Docpact gates, and tag-bound five-platform publication proof for the qualified v0.1.3 version set."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes tiangong-lca/tidas-tools#153

## Summary
- Add the append-only v0.1.3 release authorization bound to the qualified version-preparation merge commit.

## Key Decisions
- Bind v0.1.3 to exact target 9f67345f4c6f791a01d21688b4f003a157a33d04; merging this request is the only action authorized to create the tag and dispatch tag-context publication.

## Validation
- scripts/test-release-request.sh
- scripts/validate-release-request.sh .github/releases/v0.1.3.json HEAD
- scripts/docpact validate-config --root . --strict
- scripts/docpact lint --root . --worktree
- git diff --check origin/main...HEAD

## Risks / Rollback
- Low and append-only: rollback is to close this PR without merging; after merge, the immutable tag/release workflow governs publication.

## Follow-ups
- After merge, verify v0.1.3 tag, all public crates on crates.io, five native archives/checksums/SBOM, and the immutable GitHub Release.

## Workspace Integration
- After publication succeeds, refresh workspace PR tiangong-lca/workspace#536 to the final v0.1.3 target commit.